### PR TITLE
fix sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nrel.routee.compass"
-version = "0.2.0"
+version = "0.2.0.post1"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"
 documentation = "nrel.github.io/routee-compass"
@@ -41,6 +41,12 @@ Homepage = "https://github.nrel.gov/MBAP/routee-compass"
 [tool.maturin]
 python-source = "python"
 features = ["pyo3/extension-module"]
-module-name = "nrel.routee.compass.compass_app_py"
+module-name = "nrel.routee.compass.routee_compass_py"
 manifest-path = "rust/routee-compass-py/Cargo.toml"
-include = ["python/nrel/routee/compass/resources/models/*.bin"]
+include = [
+    "python/nrel/routee/compass/resources/models/*.bin",
+    "python/nrel/routee/compass/resources/*.toml",
+]
+exclude = [
+    "rust/routee-compass-powertrain/onnx-runtime/v1.15.1/**/*"
+]

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -4,7 +4,7 @@ import json
 
 from pathlib import Path
 from typing import Any, Dict, List, Union
-from nrel.routee.compass.compass_app_py import (
+from nrel.routee.compass.routee_compass_py import (
     CompassAppWrapper,
 )
 


### PR DESCRIPTION
Applies some small changes to fix the source distribution. 

Building the source distribution with this fix: https://github.com/PyO3/maturin/pull/1828 correctly includes the routee-compass-py member in the resulting `Cargo.toml` file that gets placed in the sdist, allowing someone to install the package from distribution. For now, we can manually upload our source distributions and hopefully just point to an updated version of maturin with the fix applied for future builds. 

I've also updated the `pyproject.toml` file to include the default config files for OSM and exclude the onnx runtime files. 

I tagged this version as release v0.2.0.post1 since the code hasn't changed, we're just correcting the source distribution. ([see here](https://peps.python.org/pep-0440/#post-releases))

@robfitzgerald if this looks okay to you I'll proceed with the manual PyPI release after we merge this.

Closes #7 