### PR TITLE
skip chunking if empty

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -237,7 +237,6 @@ impl CompassApp {
 
         // run parallel searches using a rayon thread pool
         let chunk_size = (input_queries.len() as f64 / self.parallelism as f64).ceil() as usize;
-
         log::info!(
             "creating {} parallel batches across {} threads to run queries with chunk size {}",
             self.parallelism,

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -231,9 +231,13 @@ impl CompassApp {
                 Err(error_response) => Either::Right(error_response),
             });
         let input_queries: Vec<serde_json::Value> = input_bundles.into_iter().flatten().collect();
+        if input_queries.len() == 0 {
+            return Ok(input_error_responses);
+        }
 
         // run parallel searches using a rayon thread pool
         let chunk_size = (input_queries.len() as f64 / self.parallelism as f64).ceil() as usize;
+
         log::info!(
             "creating {} parallel batches across {} threads to run queries with chunk size {}",
             self.parallelism,


### PR DESCRIPTION
this PR checks if input plugin processing resulted in 0 queries and returns any error responses if this is the case.

Closes #12.