### PR TITLE
trigger build on release tag prefix "py-"

### DIFF
--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: startsWith(github.ref, 'refs/tags/py-') # 
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
this PR sets the python build operation to only happen when the release's tag begins with the string `py-`. this was tested by creating two releases from two "valid" tags. the build process correctly activated from the `py-` tag and didn't run from the `rs-` tag.

![Screen Shot 2023-11-08 at 2 00 58 PM](https://github.com/NREL/routee-compass/assets/7003022/58a26ee6-bf7f-45b0-b2a7-ad0873425ec1)

publishing to pypi and crates is done manually; we only use CI to build python wheels for different OSs and python versions, so for this issue, we really only needed to make sure that the python build didn't happen for rust releases.

Closes #6.