### PR TITLE
Improve energy model error

### DIFF
--- a/docs/notebooks/open_street_maps_example.ipynb
+++ b/docs/notebooks/open_street_maps_example.ipynb
@@ -154,7 +154,7 @@
     "\n",
     "The energy cost coefficient indicates how much we should factor energy into our route search, 0.0 indicating that we should not factor in energy at all (shortest time route) and 1.0 indicating that we should only factor energy in (least energy route)\n",
     "\n",
-    "The `model_name` parameter specifies which energy model to use. This can anything that was included in the config as a ``[traveral.energy_models]]` section. We'll use the 2016 Toyota Camry."
+    "The `model_name` parameter specifies which energy model to use. This can anything that was included in the config as a `[[traveral.energy_models]]` section. We'll use the 2016 Toyota Camry."
    ]
   },
   {
@@ -807,7 +807,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/rust/routee-compass-powertrain/src/routee/speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/speed_grade_model.rs
@@ -144,8 +144,6 @@ impl TryFrom<(Arc<SpeedGradeModelService>, &serde_json::Value)> for SpeedGradeMo
     ) -> Result<Self, Self::Error> {
         let (service, conf) = input;
 
-        let model_names: Vec<&String> = service.energy_model_library.keys().collect();
-
         let energy_cost_coefficient = match conf.get(String::from("energy_cost_coefficient")) {
             None => {
                 log::debug!("no energy_cost_coefficient provided");
@@ -178,10 +176,11 @@ impl TryFrom<(Arc<SpeedGradeModelService>, &serde_json::Value)> for SpeedGradeMo
 
         let model_record = match service.energy_model_library.get(&prediction_model_name) {
             None => {
+                let model_names: Vec<&String> = service.energy_model_library.keys().collect();
                 return Err(TraversalModelError::BuildError(format!(
-                    "No energy model found with name '{}', try one of: {:?}",
+                    "No energy model found with model_name = '{}', try one of: {:?}",
                     prediction_model_name, model_names
-                )))
+                )));
             }
             Some(mr) => mr.clone(),
         };


### PR DESCRIPTION
Improves the error for the speed grade model when the energy model provided under the `model_name` parameter cannot be found in the library. When providing the key `"model_name": "flying_car"` for the default OSM energy config produces the error:


> failure building traversal model: No energy model found with name \'flying_car\', try one of: ["2022_Volvo_XC40_Recharge_twin", "2012_Ford_Focus", "2016_TOYOTA_Corolla_4cyl_2WD", "2016_TOYOTA_Highlander_Hybrid", "2016_TESLA_Model_S60_2WD", "2016_AUDI_A3_4cyl_2WD", "2016_CHEVROLET_Spark_EV", "2017_Maruti_Dzire_VDI", "2020_Chevrolet_Colorado_2WD_Diesel", "2016_Toyota_Prius_Two_FWD", "2022_Tesla_Model_3_RWD", "2017_CHEVROLET_Bolt", "2012_Ford_Fusion", "2016_TOYOTA_Camry_4cyl_2WD", "2020_VW_Golf_2.0TDI", "2022_Ford_F-150_Lightning_4WD", "2022_Tesla_Model_Y_RWD", "2016_FORD_C-MAX_HEV", "2016_FORD_Escape_4cyl_2WD", "2016_KIA_Optima_Hybrid", "2022_Renault_Zoe_ZE50_R135", "2016_BMW_328d_4cyl_2WD", "2016_HYUNDAI_Elantra_4cyl_2WD", "2017_Toyota_Highlander_3.5_L", "2023_Mitsubishi_Pajero_Sport", "2022_Toyota_Yaris_Hybrid_Mid", "2016_CHEVROLET_Malibu_4cyl_2WD", "2021_Peugot_3008", "2021_Fiat_Panda_Mild_Hybrid", "2016_Nissan_Leaf_30_kWh", "2020_VW_Golf_1.5TSI", "2016_MITSUBISHI_i-MiEV", "2016_FORD_Explorer_4cyl_2WD", "2016_Leaf_24_kWh"]

closes #23 