### PR TITLE
optional distance tolerance paramter for rtree plugin

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_distance.toml
+++ b/python/nrel/routee/compass/resources/osm_default_distance.toml
@@ -12,7 +12,7 @@ distance_unit = "miles"
 [plugin]
 input_plugins = [
     { type = "grid_search" },
-    { type = "vertex_rtree", vertices_input_file = "vertices-compass.csv.gz" },
+    { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },
 ]
 output_plugins = [
     { type = "summary" },

--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -8,7 +8,7 @@ verbose = true
 [plugin]
 input_plugins = [
     { type = "grid_search" },
-    { type = "vertex_rtree", vertices_input_file = "vertices-compass.csv.gz" },
+    { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },
 ]
 output_plugins = [
     { type = "summary" },

--- a/python/nrel/routee/compass/resources/osm_default_speed.toml
+++ b/python/nrel/routee/compass/resources/osm_default_speed.toml
@@ -15,7 +15,7 @@ output_time_unit = "minutes"
 [plugin]
 input_plugins = [
     { type = "grid_search" },
-    { type = "vertex_rtree", vertices_input_file = "vertices-compass.csv.gz" },
+    { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },
 ]
 output_plugins = [
     { type = "summary" },

--- a/rust/routee-compass-core/src/util/unit/distance_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/distance_unit.rs
@@ -28,7 +28,9 @@ impl DistanceUnit {
 
 impl std::fmt::Display for DistanceUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
+        let s = serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)?
+            .replace("\"", "");
         write!(f, "{}", s)
     }
 }

--- a/rust/routee-compass-core/src/util/unit/energy_rate_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/energy_rate_unit.rs
@@ -38,7 +38,9 @@ impl EnergyRateUnit {
 
 impl std::fmt::Display for EnergyRateUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
+        let s = serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)?
+            .replace("\"", "");
         write!(f, "{}", s)
     }
 }

--- a/rust/routee-compass-core/src/util/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/energy_unit.rs
@@ -11,7 +11,9 @@ impl EnergyUnit {}
 
 impl std::fmt::Display for EnergyUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
+        let s = serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)?
+            .replace("\"", "");
         write!(f, "{}", s)
     }
 }

--- a/rust/routee-compass-core/src/util/unit/grade_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/grade_unit.rs
@@ -28,7 +28,9 @@ impl GradeUnit {
 
 impl std::fmt::Display for GradeUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
+        let s = serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)?
+            .replace("\"", "");
         write!(f, "{}", s)
     }
 }

--- a/rust/routee-compass-core/src/util/unit/speed_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/speed_unit.rs
@@ -12,7 +12,9 @@ pub enum SpeedUnit {
 
 impl std::fmt::Display for SpeedUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
+        let s = serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)?
+            .replace("\"", "");
         write!(f, "{}", s)
     }
 }

--- a/rust/routee-compass-core/src/util/unit/time_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/time_unit.rs
@@ -36,7 +36,9 @@ impl TimeUnit {
 
 impl std::fmt::Display for TimeUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
+        let s = serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)?
+            .replace("\"", "");
         write!(f, "{}", s)
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/rtree/builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/rtree/builder.rs
@@ -1,3 +1,5 @@
+use routee_compass_core::util::unit::{Distance, DistanceUnit};
+
 use crate::{
     app::compass::config::{
         builders::InputPluginBuilder, compass_configuration_error::CompassConfigurationError,
@@ -15,13 +17,19 @@ impl InputPluginBuilder for VertexRTreeBuilder {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
+        let parent_key = String::from("Vertex RTree Input Plugin");
         let vertex_filename_key = String::from("vertices_input_file");
-        let vertex_path = parameters.get_config_path(
-            vertex_filename_key,
-            String::from("Vertex RTree Input Plugin"),
+        let vertex_path = parameters.get_config_path(vertex_filename_key, parent_key.clone())?;
+        let tolerance_distance = parameters.get_config_serde_optional::<Distance>(
+            String::from("distance_tolerance"),
+            parent_key.clone(),
         )?;
-        let rtree =
-            RTreePlugin::from_file(&vertex_path).map_err(CompassConfigurationError::PluginError)?;
+        let distance_unit = parameters.get_config_serde_optional::<DistanceUnit>(
+            String::from("distance_unit"),
+            parent_key.clone(),
+        )?;
+        let rtree = RTreePlugin::new(&vertex_path, tolerance_distance, distance_unit)
+            .map_err(CompassConfigurationError::PluginError)?;
         let m: Box<dyn InputPlugin> = Box::new(rtree);
         return Ok(m);
     }

--- a/rust/routee-compass/src/plugin/input/default/rtree/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/rtree/plugin.rs
@@ -197,7 +197,7 @@ fn validate_tolerance(
         Some((tolerance_distance, tolerance_distance_unit)) => {
             let distance_meters = haversine::coord_distance_meters(src, dst)
                 .map_err(|s| PluginError::PluginFailed(s))?;
-            let distance = BASE_DISTANCE_UNIT.convert(distance_meters, *tolerance_distance_unit);
+            let distance = DistanceUnit::Meters.convert(distance_meters, *tolerance_distance_unit);
             if &distance >= tolerance_distance {
                 Err(PluginError::PluginFailed(
                     format!(

--- a/rust/routee-compass/src/plugin/plugin_error.rs
+++ b/rust/routee-compass/src/plugin/plugin_error.rs
@@ -15,8 +15,8 @@ pub enum PluginError {
     InputError(String),
     #[error("error with building plugin")]
     BuildError,
-    #[error("nearest vertex not found for coord {0:?}")]
-    NearestVertexNotFound(Coord),
+    #[error("{0}")]
+    PluginFailed(String),
     #[error("unable to read file {0} due to {1}")]
     FileReadError(PathBuf, String),
     #[error(transparent)]


### PR DESCRIPTION
this PR adds optional "distance_tolerance" and "distance_unit" parameters for the rtree plugin. there is no associated issue so i'll describe the problem here.

### problem

currently, if the user loads a road network and then submits a query that is well outside of the road network region, the rtree plugin will still find the nearest vertex. this leads to unexpected behavior where matched origins and destinations may be miles from the user-requested locations.

### solution

when the nearest vertex is found, if the optional tolerance is provided, the plugin checks that the vertex found does not exceed the distance tolerance from the query coordinate. if the tolerance is exceeded, the query fails. if no tolerance is provided, then we get the original behavior (tolerance is _infinite_).

i have updated the osm_default_*.toml files to use a tolerance of 200 meters (0.2km). along the way i also fixed the display implementation for Unit types so that they are not enquoted by double-quotes in their string representation.

### example

i have run a national query on a denver road network, where the destination coordinate is in Massachusetts which is 2000+ km outside of the nearest vertex:

```
$ RUST_BACKTRACE=1 RUST_LOG=debug target/release/routee-compass -c ~/dev/nrel/routee/routee-compass-tomtom/compass_tomtom_denver_energy_smartcore.toml /Users/rfitzger/dev/nrel/routee/routee-compass-tomtom/queries/test_national.json 
...
[2023-11-10T19:30:03Z INFO  routee_compass] Query: Object {"destination_name": String("Jack's Abby Craft Lagers"), "destination_x": Number(-71.4133386), "destination_y": Number(42.2803461), "grid_search": Object {"energy_cost_coefficient": Array [Number(0.0), Number(0.25), Number(0.5), Number(0.75), Number(1.0)]}, "model_name": String("2016_TOYOTA_Camry_4cyl_2WD"), "origin_name": String("NREL"), "origin_x": Number(-105.1710052), "origin_y": Number(39.7402804)}
...
[2023-11-10T19:35:06Z ERROR routee_compass] Error: "coord Coord { x: -71.4133386, y: 42.2803461 } nearest vertex coord is Coord { x: -104.541352, y: 40.044087 } which is 2766.833749832952 kilometers away, exceeding the distance tolerance of 0.2 kilometers"