### PR TITLE
Rjf/easier compass app interactions

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app_ops.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_ops.rs
@@ -1,0 +1,41 @@
+use super::{compass_app_error::CompassAppError, compass_input_field::CompassInputField};
+use config::Config;
+use std::path::Path;
+
+/// reads the compass configuration TOML file from a path
+/// combines it with a configuration file that provides library defaults
+///
+/// # Arguments
+///
+/// * `config` - path to the config file
+///
+/// # Returns
+///
+/// A config object read from file, or an error
+pub fn read_config(config: &Path) -> Result<Config, CompassAppError> {
+    let default_config = config::File::from_str(
+        include_str!("config.default.toml"),
+        config::FileFormat::Toml,
+    );
+
+    // We want to store the location of where the config file
+    // was found so we can use it later to resolve relative paths
+    let conf_file_string = config
+        .to_str()
+        .ok_or(CompassAppError::InternalError(
+            "Could not parse incoming config file path".to_string(),
+        ))?
+        .to_string();
+
+    let config = Config::builder()
+        .add_source(default_config)
+        .add_source(config::File::from(config))
+        .set_override(
+            CompassInputField::ConfigInputFile.to_string(),
+            conf_file_string,
+        )?
+        .build()
+        .map_err(CompassAppError::ConfigError)?;
+
+    Ok(config)
+}

--- a/rust/routee-compass/src/app/compass/compass_input_field.rs
+++ b/rust/routee-compass/src/app/compass/compass_input_field.rs
@@ -3,12 +3,14 @@ use std::fmt::Display;
 #[derive(Debug)]
 pub enum CompassInputField {
     Queries,
+    ConfigInputFile,
 }
 
 impl CompassInputField {
     pub fn to_str(&self) -> &'static str {
         match self {
             CompassInputField::Queries => "queries",
+            CompassInputField::ConfigInputFile => "config_input_file",
         }
     }
     pub fn to_string(&self) -> String {

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -56,7 +56,7 @@ use std::{collections::HashMap, sync::Arc};
 /// * `output_plugin_builders` - a mapping of OutputPlugin `type` names to builders
 ///
 pub struct CompassAppBuilder {
-    pub tm_builders: HashMap<String, Box<dyn TraversalModelBuilder>>,
+    pub traversal_model_builders: HashMap<String, Box<dyn TraversalModelBuilder>>,
     pub frontier_builders: HashMap<String, Box<dyn FrontierModelBuilder>>,
     pub input_plugin_builders: HashMap<String, Box<dyn InputPluginBuilder>>,
     pub output_plugin_builders: HashMap<String, Box<dyn OutputPluginBuilder>>,
@@ -75,11 +75,27 @@ impl CompassAppBuilder {
     /// * an instance of a CompassAppBuilder that can be used to build a CompassApp
     pub fn new() -> CompassAppBuilder {
         CompassAppBuilder {
-            tm_builders: HashMap::new(),
+            traversal_model_builders: HashMap::new(),
             frontier_builders: HashMap::new(),
             input_plugin_builders: HashMap::new(),
             output_plugin_builders: HashMap::new(),
         }
+    }
+
+    pub fn add_traversal_model(&mut self, name: String, builder: Box<dyn TraversalModelBuilder>) {
+        let _ = self.traversal_model_builders.insert(name, builder);
+    }
+
+    pub fn add_frontier_model(&mut self, name: String, builder: Box<dyn FrontierModelBuilder>) {
+        let _ = self.frontier_builders.insert(name, builder);
+    }
+
+    pub fn add_input_plugin(&mut self, name: String, builder: Box<dyn InputPluginBuilder>) {
+        let _ = self.input_plugin_builders.insert(name, builder);
+    }
+
+    pub fn add_output_plugin(&mut self, name: String, builder: Box<dyn OutputPluginBuilder>) {
+        let _ = self.output_plugin_builders.insert(name, builder);
     }
 
     /// Builds the default builder.
@@ -131,7 +147,7 @@ impl CompassAppBuilder {
         ]);
 
         CompassAppBuilder {
-            tm_builders,
+            traversal_model_builders: tm_builders,
             frontier_builders,
             input_plugin_builders,
             output_plugin_builders,
@@ -158,7 +174,7 @@ impl CompassAppBuilder {
                 String::from("String"),
             ))?
             .into();
-        self.tm_builders
+        self.traversal_model_builders
             .get(&tm_type)
             .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
                 tm_type.clone(),

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -1,6 +1,7 @@
 pub mod compass_app;
 pub mod compass_app_args;
 pub mod compass_app_error;
+pub mod compass_app_ops;
 pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod config;


### PR DESCRIPTION
this PR makes it easier to work with CompassApp outside of routee-compass for when users want to append new builders to a CompassAppBuilder instance and then use the `fn try_from(pair: (&Config, &CompassAppBuilder))` method on `CompassApp`. to previously do this, i had to duplicate the config reading code and also manually take mutable builder collections, modify them, and build a new CompassAppBuilder to inject builders.