### PR TITLE
fix error message

### DIFF
--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -228,12 +228,8 @@ impl ConfigJsonExtensions for serde_json::Value {
             ))?
             .to_owned();
 
-        let result: T = serde_json::from_value(value).map_err(|_| {
-            CompassConfigurationError::ExpectedFieldWithType(
-                key.clone(),
-                String::from("string-parseable"),
-            )
-        })?;
+        let result: T = serde_json::from_value(value)
+            .map_err(CompassConfigurationError::SerdeDeserializationError)?;
         Ok(result)
     }
     fn get_config_serde_optional<T: de::DeserializeOwned>(


### PR DESCRIPTION
quick fix that changes the error message for `get_config_serde`. the current error message seems like a copy and paste typo, it implies the type is supposed to be _string-parseable_, but it really should be _deserializable_.