### PR TITLE
list valid module names with unknown module error

### DIFF
--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -30,6 +30,7 @@ use crate::plugin::{
         output_plugin::OutputPlugin,
     },
 };
+use itertools::Itertools;
 use routee_compass_core::model::frontier::frontier_model::FrontierModel;
 use std::{collections::HashMap, sync::Arc};
 
@@ -179,6 +180,7 @@ impl CompassAppBuilder {
             .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
                 tm_type.clone(),
                 String::from("traversal"),
+                self.traversal_model_builders.keys().join(","),
             ))
             .and_then(|b| b.build(config))
     }
@@ -208,6 +210,7 @@ impl CompassAppBuilder {
             .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
                 fm_type.clone(),
                 String::from("frontier"),
+                self.frontier_builders.keys().join(","),
             ))
             .and_then(|b| b.build(&config))
     }
@@ -246,6 +249,7 @@ impl CompassAppBuilder {
                 CompassConfigurationError::UnknownModelNameForComponent(
                     plugin_type.clone(),
                     String::from("Input Plugin"),
+                    self.input_plugin_builders.keys().join(","),
                 ),
             )?;
             let input_plugin = builder.build(&plugin_json)?;
@@ -288,6 +292,7 @@ impl CompassAppBuilder {
                 CompassConfigurationError::UnknownModelNameForComponent(
                     plugin_type.clone(),
                     String::from("Output Plugin"),
+                    self.output_plugin_builders.keys().join(","),
                 ),
             )?;
             let output_plugin = builder.build(&plugin_json)?;

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -180,7 +180,7 @@ impl CompassAppBuilder {
             .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
                 tm_type.clone(),
                 String::from("traversal"),
-                self.traversal_model_builders.keys().join(","),
+                self.traversal_model_builders.keys().join(", "),
             ))
             .and_then(|b| b.build(config))
     }
@@ -210,7 +210,7 @@ impl CompassAppBuilder {
             .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
                 fm_type.clone(),
                 String::from("frontier"),
-                self.frontier_builders.keys().join(","),
+                self.frontier_builders.keys().join(", "),
             ))
             .and_then(|b| b.build(&config))
     }
@@ -249,7 +249,7 @@ impl CompassAppBuilder {
                 CompassConfigurationError::UnknownModelNameForComponent(
                     plugin_type.clone(),
                     String::from("Input Plugin"),
-                    self.input_plugin_builders.keys().join(","),
+                    self.input_plugin_builders.keys().join(", "),
                 ),
             )?;
             let input_plugin = builder.build(&plugin_json)?;
@@ -292,7 +292,7 @@ impl CompassAppBuilder {
                 CompassConfigurationError::UnknownModelNameForComponent(
                     plugin_type.clone(),
                     String::from("Output Plugin"),
-                    self.output_plugin_builders.keys().join(","),
+                    self.output_plugin_builders.keys().join(", "),
                 ),
             )?;
             let output_plugin = builder.build(&plugin_json)?;

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
@@ -17,8 +17,8 @@ pub enum CompassConfigurationError {
     ExpectedFieldWithType(String, String),
     #[error("expected field {0} for component {1} had unrecognized value {2}")]
     ExpectedFieldWithTypeUnrecognized(String, String, String),
-    #[error("unknown module {0} for component {1} provided by configuration")]
-    UnknownModelNameForComponent(String, String),
+    #[error("unknown module {0} for component {1} provided by configuration, must be one of {2}")]
+    UnknownModelNameForComponent(String, String, String),
     #[error(
         r#"
         File '{0}' was not found.

--- a/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
@@ -109,6 +109,7 @@ impl TerminationModelBuilder {
                 _ => Err(CompassConfigurationError::UnknownModelNameForComponent(
                     term_type,
                     CompassConfigurationField::Termination.to_string(),
+                    String::from("query_runtime, iterations, solution_size, combined"),
                 )),
             }?;
 


### PR DESCRIPTION
more small fries fallout from mep-routee work, this time to list the valid module names when reporting an unknown module name error