### PR TITLE
Update output file location

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-exclude = (?x)(
-    docs/    
-    | build/  
-    | dist/   
-  )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,9 @@ include = [
 exclude = [
     "rust/routee-compass-powertrain/onnx-runtime/v1.15.1/**/*"
 ]
+
+[tool.mypy]
+ignore_missing_imports = true
+namespace_packages = true
+explicit_package_bases = true
+exclude = ["docs/", "build/", "dist/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 keywords = ["eco routing"]
-dependencies = []
+dependencies = ["toml"]
 [project.optional-dependencies]
 dev = [
     "black",

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -8,8 +9,14 @@ from nrel.routee.compass.routee_compass_py import (
     CompassAppWrapper,
 )
 
+import toml
+
+
 Query = Dict[str, Any]
 Result = List[Dict[str, Any]]
+
+
+log = logging.getLogger(__name__)
 
 
 class CompassApp:
@@ -23,12 +30,15 @@ class CompassApp:
         self._app = app
 
     @classmethod
-    def from_config_file(cls, config_file: Union[str, Path]) -> CompassApp:
+    def from_config_file(
+        cls, config_file: Union[str, Path], output_file: Optional[str] = None
+    ) -> CompassApp:
         """
         Build a CompassApp from a config file
 
         Args:
             config_file (Union[str, Path]): Path to the config file
+            output_file (Optional[str]): Path to the output file. This overrides whatever is in the config file
 
         Returns:
             CompassApp: A CompassApp object
@@ -40,7 +50,32 @@ class CompassApp:
         config_path = Path(config_file)
         if not config_path.is_file():
             raise ValueError(f"Config file {str(config_path)} does not exist")
-        app = CompassAppWrapper._from_config_file(str(config_path.absolute()))
+        with open(config_path) as f:
+            toml_config = toml.load(f)
+
+        # inject the output file override into the to_disk plugin config
+        if output_file is not None:
+            override = False
+            plugins = toml_config.get("plugin")
+            if plugins is not None:
+                output_plugins = plugins.get("output_plugins")
+                if output_plugins is not None:
+                    for plugin in output_plugins:
+                        if plugin.get("type") == "to_disk":
+                            override = True
+                            plugin["output_file"] = output_file
+            if not override:
+                log.warning(
+                    f"Output file override {output_file} was provided but "
+                    "to_disk plugin was not found in config file"
+                )
+
+        toml_string = toml.dumps(toml_config)
+        config_path_string = str(config_path.absolute())
+
+        app = CompassAppWrapper._from_config_toml_string(
+            toml_string, config_path_string
+        )
         return cls(app)
 
     def run(self, query: Union[Query, List[Query]]) -> Result:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,3 +23,4 @@ csv = { version = "1.2.2" }
 itertools = { version = "0.11.0" }
 chrono = "0.4.26"
 regex = "1.9.5"
+config = "0.13.3"

--- a/rust/routee-compass-py/Cargo.toml
+++ b/rust/routee-compass-py/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/routee-compass"
 routee-compass = { path = "../routee-compass", version = "0.3.0" }
 pyo3 = { version = "0.19", features = ["extension-module"] }
 serde_json = { workspace = true }
+config = {workspace = true }
 
 [lib]
 name = "routee_compass_py"

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -36,6 +36,6 @@ rayon = { workspace = true }
 serde_repr = "0.1"
 rand = "0.8.5"
 chrono = { workspace = true }
-config = "0.13.3"
+config = { workspace = true } 
 clap = { version = "4.3.19", features = ["derive"] }
 itertools = { workspace = true }

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -45,7 +45,7 @@ pub struct CompassApp {
 impl TryFrom<&Path> for CompassApp {
     type Error = CompassAppError;
 
-    /// Builds a CompassApp from a configuration filepath, using the default CompassAppBuilder.
+    /// Builds a CompassApp from a configuration filepath, using the default CompasksAppBuilder.
     /// Builds all components such as the DirectedGraph, TraversalModel, and SearchAlgorithm.
     /// Also builds the input and output plugins.
     /// Returns a persistent application that can run user queries in parallel.
@@ -58,7 +58,7 @@ impl TryFrom<&Path> for CompassApp {
     ///
     /// * an instance of [`CompassApp`], or an error if load failed.
     fn try_from(conf_file: &Path) -> Result<Self, Self::Error> {
-        let config = ops::read_config(conf_file)?;
+        let config = ops::read_config_from_file(conf_file)?;
         let builder = CompassAppBuilder::default();
         let compass_app = CompassApp::try_from((&config, &builder))?;
         Ok(compass_app)

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -45,7 +45,7 @@ pub struct CompassApp {
 impl TryFrom<&Path> for CompassApp {
     type Error = CompassAppError;
 
-    /// Builds a CompassApp from a configuration filepath, using the default CompasksAppBuilder.
+    /// Builds a CompassApp from a configuration filepath, using the default CompassAppBuilder.
     /// Builds all components such as the DirectedGraph, TraversalModel, and SearchAlgorithm.
     /// Also builds the input and output plugins.
     /// Returns a persistent application that can run user queries in parallel.


### PR DESCRIPTION
Takes a pass at #32 by adding a new optional argument `output_file_override` to the `from_config_file` method on the python compass application. This would allow the user to load the application as:

```python
app = CompassApp.from_config_file("my_config.toml:, output_file_override="my_output.json")
```

I also played around with changing the output file after the application has been loaded (see the rust `CompassApp.with_output_directory()` method) but we can roll that back if seems too weird.

Going through this it still feels a bit awkward but I had a hard time finding an elegant way to give a custom config parameter outside of the context of the config file. I'm open to alternatives if you have any ideas.