### PR TITLE
only recurse when array element is array or object

### DIFF
--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -317,7 +317,15 @@ impl ConfigJsonExtensions for serde_json::Value {
             serde_json::Value::Array(arr) => {
                 let mut new_arr = Vec::new();
                 for value in arr.iter() {
-                    new_arr.push(value.normalize_file_paths(root_config_path)?);
+                    match value {
+                        serde_json::Value::Array(_) => {
+                            new_arr.push(value.normalize_file_paths(root_config_path)?)
+                        }
+                        serde_json::Value::Object(_) => {
+                            new_arr.push(value.normalize_file_paths(root_config_path)?)
+                        }
+                        _ => {}
+                    }
                 }
                 Ok(serde_json::Value::Array(new_arr))
             }


### PR DESCRIPTION
This PR makes a slight modification to the recursive call when normalizing paths on a configuration file. If an array is encountered, the function only recurses if the element within the array is either a JSON object or JSON array.

Closes #39.