### PR TITLE
Rjf/traversal abstractions clone issue

### DIFF
--- a/rust/routee-compass-core/src/model/traversal/mod.rs
+++ b/rust/routee-compass-core/src/model/traversal/mod.rs
@@ -2,5 +2,7 @@ pub mod access_result;
 pub mod default;
 pub mod state;
 pub mod traversal_model;
+pub mod traversal_model_builder;
 pub mod traversal_model_error;
+pub mod traversal_model_service;
 pub mod traversal_result;

--- a/rust/routee-compass-core/src/model/traversal/traversal_model_builder.rs
+++ b/rust/routee-compass-core/src/model/traversal/traversal_model_builder.rs
@@ -1,0 +1,25 @@
+use super::{
+    traversal_model_error::TraversalModelError, traversal_model_service::TraversalModelService,
+};
+use std::sync::Arc;
+
+/// A [`TraversalModelBuilder`] takes a JSON object describing the configuration of a
+/// traversal model and builds a [`TraversalModelService`].
+///
+/// A [`TraversalModelBuilder`] instance should be an empty struct that implements
+/// this trait.
+pub trait TraversalModelBuilder {
+    /// Builds a [`TraversalModelService`] from configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `parameters` - the contents of the "traversal" TOML config section
+    ///
+    /// # Returns
+    ///
+    /// A [`TraversalModelService`] designed to persist the duration of the CompassApp.
+    fn build(
+        &self,
+        parameters: &serde_json::Value,
+    ) -> Result<Arc<dyn TraversalModelService>, TraversalModelError>;
+}

--- a/rust/routee-compass-core/src/model/traversal/traversal_model_service.rs
+++ b/rust/routee-compass-core/src/model/traversal/traversal_model_service.rs
@@ -1,0 +1,32 @@
+use super::{traversal_model::TraversalModel, traversal_model_error::TraversalModelError};
+use std::sync::Arc;
+
+/// A [`TraversalModelService`] is a persistent builder of [TraversalModel] instances.
+/// Building a [`TraversalModelService`] may be an expensive operation and often includes
+/// file IO on the order of the size of the road network edge list.
+/// The service then builds a [TraversalModel] instance for each route query.
+/// [`TraversalModelService`] must be read across the thread pool and so it implements
+/// Send and Sync.
+///
+/// [TraversalModel]: compass_core::model::traversal::traversal_model::TraversalModel
+pub trait TraversalModelService: Send + Sync {
+    /// Builds a [TraversalModel] for the incoming query, used as parameters for this
+    /// build operation.
+    ///
+    /// The query is passed as parameters to this operation so that any query-time
+    /// coefficients may be applied to the [TraversalModel].
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - the incoming query which may contain parameters for building the [TraversalModel]
+    ///
+    /// # Returns
+    ///
+    /// The [TraversalModel] instance for this query, or an error
+    ///
+    /// [TraversalModel]: compass_core::model::traversal::traversal_model::TraversalModel
+    fn build(
+        &self,
+        query: &serde_json::Value,
+    ) -> Result<Arc<dyn TraversalModel>, TraversalModelError>;
+}

--- a/rust/routee-compass-powertrain/src/routee/mod.rs
+++ b/rust/routee-compass-powertrain/src/routee/mod.rs
@@ -1,8 +1,8 @@
 pub mod model_type;
 pub mod prediction_model;
 pub mod smartcore;
-pub mod speed_grade_model;
-pub mod speed_grade_model_service;
+pub mod speed_grade_energy_model;
+pub mod speed_grade_energy_model_service;
 
 #[cfg(feature = "onnx")]
 pub mod onnx;

--- a/rust/routee-compass-powertrain/src/routee/speed_grade_energy_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/speed_grade_energy_model.rs
@@ -1,5 +1,5 @@
 use super::prediction_model::SpeedGradePredictionModelRecord;
-use super::speed_grade_model_service::SpeedGradeModelService;
+use super::speed_grade_energy_model_service::SpeedGradeEnergyModelService;
 use routee_compass_core::model::cost::Cost;
 use routee_compass_core::model::property::edge::Edge;
 use routee_compass_core::model::property::vertex::Vertex;
@@ -17,13 +17,13 @@ use std::sync::Arc;
 
 const ZERO_ENERGY: f64 = 1e-9;
 
-pub struct SpeedGradeModel {
-    pub service: Arc<SpeedGradeModelService>,
+pub struct SpeedGradeEnergyModel {
+    pub service: Arc<SpeedGradeEnergyModelService>,
     pub model_record: Arc<SpeedGradePredictionModelRecord>,
     pub energy_cost_coefficient: f64,
 }
 
-impl TraversalModel for SpeedGradeModel {
+impl TraversalModel for SpeedGradeEnergyModel {
     fn initial_state(&self) -> TraversalState {
         // distance, time, energy
         vec![StateVar(0.0), StateVar(0.0), StateVar(0.0)]
@@ -136,11 +136,11 @@ impl TraversalModel for SpeedGradeModel {
     }
 }
 
-impl TryFrom<(Arc<SpeedGradeModelService>, &serde_json::Value)> for SpeedGradeModel {
+impl TryFrom<(Arc<SpeedGradeEnergyModelService>, &serde_json::Value)> for SpeedGradeEnergyModel {
     type Error = TraversalModelError;
 
     fn try_from(
-        input: (Arc<SpeedGradeModelService>, &serde_json::Value),
+        input: (Arc<SpeedGradeEnergyModelService>, &serde_json::Value),
     ) -> Result<Self, Self::Error> {
         let (service, conf) = input;
 
@@ -185,7 +185,7 @@ impl TryFrom<(Arc<SpeedGradeModelService>, &serde_json::Value)> for SpeedGradeMo
             Some(mr) => mr.clone(),
         };
 
-        Ok(SpeedGradeModel {
+        Ok(SpeedGradeEnergyModel {
             service,
             model_record,
             energy_cost_coefficient,
@@ -302,7 +302,7 @@ mod tests {
         let mut model_library = HashMap::new();
         model_library.insert("Toyota_Camry".to_string(), Arc::new(model_record));
 
-        let service = SpeedGradeModelService::new(
+        let service = SpeedGradeEnergyModelService::new(
             &speed_file_path,
             SpeedUnit::KilometersPerHour,
             &Some(grade_file_path),
@@ -317,7 +317,7 @@ mod tests {
             "model_name": "Toyota_Camry",
             "energy_cost_coefficient": 0.5,
         });
-        let model = SpeedGradeModel::try_from((arc_service, &conf)).unwrap();
+        let model = SpeedGradeEnergyModel::try_from((arc_service, &conf)).unwrap();
         let initial = model.initial_state();
         let e1 = mock_edge(0);
         // 100 meters @ 10kph should take 36 seconds ((0.1/10) * 3600)

--- a/rust/routee-compass/src/app/compass/config/builders.rs
+++ b/rust/routee-compass/src/app/compass/config/builders.rs
@@ -1,7 +1,6 @@
 use super::compass_configuration_error::CompassConfigurationError;
 use crate::plugin::{input::input_plugin::InputPlugin, output::output_plugin::OutputPlugin};
 use routee_compass_core::model::frontier::frontier_model::FrontierModel;
-use std::sync::Arc;
 
 /// A [`FrontierModelBuilder`] takes a JSON object describing the configuration of a
 /// frontier model and builds a [FrontierModel].

--- a/rust/routee-compass/src/app/compass/config/builders.rs
+++ b/rust/routee-compass/src/app/compass/config/builders.rs
@@ -1,60 +1,7 @@
 use super::compass_configuration_error::CompassConfigurationError;
 use crate::plugin::{input::input_plugin::InputPlugin, output::output_plugin::OutputPlugin};
-use routee_compass_core::model::{
-    frontier::frontier_model::FrontierModel, traversal::traversal_model::TraversalModel,
-};
+use routee_compass_core::model::frontier::frontier_model::FrontierModel;
 use std::sync::Arc;
-
-/// A [`TraversalModelBuilder`] takes a JSON object describing the configuration of a
-/// traversal model and builds a [`TraversalModelService`].
-///
-/// A [`TraversalModelBuilder`] instance should be an empty struct that implements
-/// this trait.
-pub trait TraversalModelBuilder {
-    /// Builds a [`TraversalModelService`] from configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - the contents of the "traversal" TOML config section
-    ///
-    /// # Returns
-    ///
-    /// A [`TraversalModelService`] designed to persist the duration of the CompassApp.
-    fn build(
-        &self,
-        parameters: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModelService>, CompassConfigurationError>;
-}
-
-/// A [`TraversalModelService`] is a persistent builder of [TraversalModel] instances.
-/// Building a [`TraversalModelService`] may be an expensive operation and often includes
-/// file IO on the order of the size of the road network edge list.
-/// The service then builds a [TraversalModel] instance for each route query.
-/// [`TraversalModelService`] must be read across the thread pool and so it implements
-/// Send and Sync.
-///
-/// [TraversalModel]: compass_core::model::traversal::traversal_model::TraversalModel
-pub trait TraversalModelService: Send + Sync {
-    /// Builds a [TraversalModel] for the incoming query, used as parameters for this
-    /// build operation.
-    ///
-    /// The query is passed as parameters to this operation so that any query-time
-    /// coefficients may be applied to the [TraversalModel].
-    ///
-    /// # Arguments
-    ///
-    /// * `query` - the incoming query which may contain parameters for building the [TraversalModel]
-    ///
-    /// # Returns
-    ///
-    /// The [TraversalModel] instance for this query, or an error
-    ///
-    /// [TraversalModel]: compass_core::model::traversal::traversal_model::TraversalModel
-    fn build(
-        &self,
-        query: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModel>, CompassConfigurationError>;
-}
 
 /// A [`FrontierModelBuilder`] takes a JSON object describing the configuration of a
 /// frontier model and builds a [FrontierModel].

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -1,8 +1,5 @@
 use super::{
-    builders::{
-        FrontierModelBuilder, InputPluginBuilder, OutputPluginBuilder, TraversalModelBuilder,
-        TraversalModelService,
-    },
+    builders::{FrontierModelBuilder, InputPluginBuilder, OutputPluginBuilder},
     compass_configuration_error::CompassConfigurationError,
     compass_configuration_field::CompassConfigurationField,
     config_json_extension::ConfigJsonExtensions,
@@ -31,7 +28,13 @@ use crate::plugin::{
     },
 };
 use itertools::Itertools;
-use routee_compass_core::model::frontier::frontier_model::FrontierModel;
+use routee_compass_core::model::{
+    frontier::frontier_model::FrontierModel,
+    traversal::{
+        traversal_model_builder::TraversalModelBuilder,
+        traversal_model_service::TraversalModelService,
+    },
+};
 use std::{collections::HashMap, sync::Arc};
 
 /// Upstream component factory of [`crate::app::compass::compass_app::CompassApp`]
@@ -175,14 +178,19 @@ impl CompassAppBuilder {
                 String::from("String"),
             ))?
             .into();
-        self.traversal_model_builders
+        let result = self
+            .traversal_model_builders
             .get(&tm_type)
             .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
                 tm_type.clone(),
                 String::from("traversal"),
                 self.traversal_model_builders.keys().join(", "),
             ))
-            .and_then(|b| b.build(config))
+            .and_then(|b| {
+                b.build(config)
+                    .map_err(CompassConfigurationError::TraversalModelError)
+            });
+        result
     }
 
     /// builds a frontier model with the specified type name with the provided

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
@@ -1,3 +1,4 @@
+use crate::plugin::plugin_error::PluginError;
 use config::ConfigError;
 use routee_compass_core::{
     model::{
@@ -6,8 +7,6 @@ use routee_compass_core::{
     },
     util::conversion::conversion_error::ConversionError,
 };
-
-use crate::plugin::plugin_error::PluginError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum CompassConfigurationError {

--- a/rust/routee-compass/src/app/compass/config/traversal_model/distance_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/distance_builder.rs
@@ -1,10 +1,9 @@
+use crate::app::compass::config::compass_configuration_field::CompassConfigurationField;
 use crate::app::compass::config::config_json_extension::ConfigJsonExtensions;
-use crate::app::compass::config::{
-    builders::{TraversalModelBuilder, TraversalModelService},
-    compass_configuration_error::CompassConfigurationError,
-    compass_configuration_field::CompassConfigurationField,
-};
 use routee_compass_core::model::traversal::traversal_model::TraversalModel;
+use routee_compass_core::model::traversal::traversal_model_builder::TraversalModelBuilder;
+use routee_compass_core::model::traversal::traversal_model_error::TraversalModelError;
+use routee_compass_core::model::traversal::traversal_model_service::TraversalModelService;
 use routee_compass_core::util::unit::BASE_DISTANCE_UNIT;
 use routee_compass_core::{
     model::traversal::default::distance::DistanceModel, util::unit::DistanceUnit,
@@ -21,12 +20,14 @@ impl TraversalModelBuilder for DistanceBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModelService>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn TraversalModelService>, TraversalModelError> {
         let traversal_key = CompassConfigurationField::Traversal.to_string();
-        let distance_unit_option = parameters.get_config_serde_optional::<DistanceUnit>(
-            String::from("distance_unit"),
-            traversal_key.clone(),
-        )?;
+        let distance_unit_option = parameters
+            .get_config_serde_optional::<DistanceUnit>(
+                String::from("distance_unit"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let distance_unit = distance_unit_option.unwrap_or(BASE_DISTANCE_UNIT);
         let m: Arc<dyn TraversalModelService> = Arc::new(DistanceService { distance_unit });
         Ok(m)
@@ -37,7 +38,7 @@ impl TraversalModelService for DistanceService {
     fn build(
         &self,
         _parameters: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModel>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn TraversalModel>, TraversalModelError> {
         let m: Arc<dyn TraversalModel> = Arc::new(DistanceModel::new(self.distance_unit));
         Ok(m)
     }

--- a/rust/routee-compass/src/app/compass/config/traversal_model/speed_grade_energy_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/speed_grade_energy_model_builder.rs
@@ -1,82 +1,99 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::app::compass::config::builders::TraversalModelService;
+use crate::app::compass::config::compass_configuration_error::CompassConfigurationError;
 use crate::app::compass::config::compass_configuration_field::CompassConfigurationField;
 use crate::app::compass::config::config_json_extension::ConfigJsonExtensions;
-use crate::app::compass::config::{
-    builders::TraversalModelBuilder, compass_configuration_error::CompassConfigurationError,
-};
-use routee_compass_core::model::traversal::traversal_model::TraversalModel;
+use routee_compass_core::model::traversal::traversal_model_builder::TraversalModelBuilder;
+use routee_compass_core::model::traversal::traversal_model_error::TraversalModelError;
+use routee_compass_core::model::traversal::traversal_model_service::TraversalModelService;
 use routee_compass_core::util::unit::{
     DistanceUnit, EnergyRate, EnergyRateUnit, GradeUnit, SpeedUnit, TimeUnit,
 };
 use routee_compass_powertrain::routee::model_type::ModelType;
 use routee_compass_powertrain::routee::prediction_model::SpeedGradePredictionModelRecord;
-use routee_compass_powertrain::routee::speed_grade_model::SpeedGradeModel;
-use routee_compass_powertrain::routee::speed_grade_model_service::SpeedGradeModelService;
+use routee_compass_powertrain::routee::speed_grade_energy_model_service::SpeedGradeEnergyModelService;
 
 pub struct SpeedGradeEnergyModelBuilder {}
 
-pub struct SpeedGradeEnergyModelService {
-    service: SpeedGradeModelService,
-}
+// pub struct SpeedGradeEnergyModelService {
+//     service: SpeedGradeModelService,
+// }
 
 impl TraversalModelBuilder for SpeedGradeEnergyModelBuilder {
     fn build(
         &self,
         params: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModelService>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn TraversalModelService>, TraversalModelError> {
         let traversal_key = CompassConfigurationField::Traversal.to_string();
 
-        let speed_table_path = params.get_config_path(
-            String::from("speed_table_input_file"),
-            traversal_key.clone(),
-        )?;
-        let speed_table_speed_unit = params.get_config_serde::<SpeedUnit>(
-            String::from("speed_table_speed_unit"),
-            traversal_key.clone(),
-        )?;
+        let speed_table_path = params
+            .get_config_path(
+                String::from("speed_table_input_file"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+        let speed_table_speed_unit = params
+            .get_config_serde::<SpeedUnit>(
+                String::from("speed_table_speed_unit"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
-        let grade_table_path = params.get_config_path_optional(
-            String::from("grade_table_input_file"),
-            traversal_key.clone(),
-        )?;
-        let grade_table_grade_unit = params.get_config_serde_optional::<GradeUnit>(
-            String::from("graph_grade_unit"),
-            traversal_key.clone(),
-        )?;
+        let grade_table_path = params
+            .get_config_path_optional(
+                String::from("grade_table_input_file"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+        let grade_table_grade_unit = params
+            .get_config_serde_optional::<GradeUnit>(
+                String::from("graph_grade_unit"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
-        let energy_model_configs =
-            params.get_config_array("energy_models".to_string(), traversal_key.clone())?;
+        let energy_model_configs = params
+            .get_config_array("energy_models".to_string(), traversal_key.clone())
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let mut energy_model_library = HashMap::new();
 
         for energy_model_config in energy_model_configs {
             let name = energy_model_config
-                .get_config_string(String::from("name"), traversal_key.clone())?;
+                .get_config_string(String::from("name"), traversal_key.clone())
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
             let model_path = energy_model_config
-                .get_config_path(String::from("model_input_file"), traversal_key.clone())?;
+                .get_config_path(String::from("model_input_file"), traversal_key.clone())
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
             let model_type = energy_model_config
-                .get_config_serde::<ModelType>(String::from("model_type"), traversal_key.clone())?;
+                .get_config_serde::<ModelType>(String::from("model_type"), traversal_key.clone())
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
             let speed_unit = energy_model_config
-                .get_config_serde::<SpeedUnit>(String::from("speed_unit"), traversal_key.clone())?;
+                .get_config_serde::<SpeedUnit>(String::from("speed_unit"), traversal_key.clone())
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
             let ideal_energy_rate_option = energy_model_config
                 .get_config_serde_optional::<EnergyRate>(
                     String::from("ideal_energy_rate"),
                     traversal_key.clone(),
-                )?;
+                )
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
             let grade_unit = energy_model_config
-                .get_config_serde::<GradeUnit>(String::from("grade_unit"), traversal_key.clone())?;
+                .get_config_serde::<GradeUnit>(String::from("grade_unit"), traversal_key.clone())
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
-            let energy_rate_unit = energy_model_config.get_config_serde::<EnergyRateUnit>(
-                String::from("energy_rate_unit"),
-                traversal_key.clone(),
-            )?;
-            let real_world_energy_adjustment_option = params.get_config_serde_optional::<f64>(
-                String::from("real_world_energy_adjustment"),
-                traversal_key.clone(),
-            )?;
+            let energy_rate_unit = energy_model_config
+                .get_config_serde::<EnergyRateUnit>(
+                    String::from("energy_rate_unit"),
+                    traversal_key.clone(),
+                )
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+            let real_world_energy_adjustment_option = params
+                .get_config_serde_optional::<f64>(
+                    String::from("real_world_energy_adjustment"),
+                    traversal_key.clone(),
+                )
+                .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
             let model_record = SpeedGradePredictionModelRecord::new(
                 name.clone(),
@@ -87,20 +104,25 @@ impl TraversalModelBuilder for SpeedGradeEnergyModelBuilder {
                 energy_rate_unit,
                 ideal_energy_rate_option,
                 real_world_energy_adjustment_option,
-            )?;
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
             energy_model_library.insert(name, Arc::new(model_record));
         }
 
-        let output_time_unit_option = params.get_config_serde_optional::<TimeUnit>(
-            String::from("output_time_unit"),
-            traversal_key.clone(),
-        )?;
-        let output_distance_unit_option = params.get_config_serde_optional::<DistanceUnit>(
-            String::from("output_distance_unit"),
-            traversal_key.clone(),
-        )?;
+        let output_time_unit_option = params
+            .get_config_serde_optional::<TimeUnit>(
+                String::from("output_time_unit"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+        let output_distance_unit_option = params
+            .get_config_serde_optional::<DistanceUnit>(
+                String::from("output_distance_unit"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
-        let inner_service = SpeedGradeModelService::new(
+        let service = SpeedGradeEnergyModelService::new(
             &speed_table_path,
             speed_table_speed_unit,
             &grade_table_path,
@@ -109,22 +131,23 @@ impl TraversalModelBuilder for SpeedGradeEnergyModelBuilder {
             output_distance_unit_option,
             energy_model_library,
         )
-        .map_err(CompassConfigurationError::TraversalModelError)?;
-        let service = SpeedGradeEnergyModelService {
-            service: inner_service,
-        };
-
-        Ok(Arc::new(service))
+        .map_err(CompassConfigurationError::TraversalModelError)
+        .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+        // let service = SpeedGradeEnergyModelService {
+        //     service: inner_service,
+        // };
+        let result: Arc<dyn TraversalModelService> = Arc::new(service);
+        Ok(result)
     }
 }
 
-impl TraversalModelService for SpeedGradeEnergyModelService {
-    fn build(
-        &self,
-        parameters: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModel>, CompassConfigurationError> {
-        let arc_self = Arc::new(self.service.clone());
-        let m = SpeedGradeModel::try_from((arc_self, parameters))?;
-        Ok(Arc::new(m))
-    }
-}
+// impl TraversalModelService for SpeedGradeEnergyModelService {
+//     fn build(
+//         &self,
+//         parameters: &serde_json::Value,
+//     ) -> Result<Arc<dyn TraversalModel>, CompassConfigurationError> {
+//         let arc_self = Arc::new(self.service.clone());
+//         let m = SpeedGradeModel::try_from((arc_self, parameters)).map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+//         Ok(Arc::new(m))
+//     }
+// }

--- a/rust/routee-compass/src/app/compass/config/traversal_model/speed_grade_energy_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/speed_grade_energy_model_builder.rs
@@ -16,10 +16,6 @@ use routee_compass_powertrain::routee::speed_grade_energy_model_service::SpeedGr
 
 pub struct SpeedGradeEnergyModelBuilder {}
 
-// pub struct SpeedGradeEnergyModelService {
-//     service: SpeedGradeModelService,
-// }
-
 impl TraversalModelBuilder for SpeedGradeEnergyModelBuilder {
     fn build(
         &self,
@@ -140,14 +136,3 @@ impl TraversalModelBuilder for SpeedGradeEnergyModelBuilder {
         Ok(result)
     }
 }
-
-// impl TraversalModelService for SpeedGradeEnergyModelService {
-//     fn build(
-//         &self,
-//         parameters: &serde_json::Value,
-//     ) -> Result<Arc<dyn TraversalModel>, CompassConfigurationError> {
-//         let arc_self = Arc::new(self.service.clone());
-//         let m = SpeedGradeModel::try_from((arc_self, parameters)).map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
-//         Ok(Arc::new(m))
-//     }
-// }

--- a/rust/routee-compass/src/app/compass/config/traversal_model/speed_lookup_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/speed_lookup_builder.rs
@@ -1,11 +1,10 @@
-use crate::app::compass::config::builders::TraversalModelService;
 use crate::app::compass::config::compass_configuration_field::CompassConfigurationField;
 use crate::app::compass::config::config_json_extension::ConfigJsonExtensions;
-use crate::app::compass::config::{
-    builders::TraversalModelBuilder, compass_configuration_error::CompassConfigurationError,
-};
 use routee_compass_core::model::traversal::default::speed_lookup_model::SpeedLookupModel;
 use routee_compass_core::model::traversal::traversal_model::TraversalModel;
+use routee_compass_core::model::traversal::traversal_model_builder::TraversalModelBuilder;
+use routee_compass_core::model::traversal::traversal_model_error::TraversalModelError;
+use routee_compass_core::model::traversal::traversal_model_service::TraversalModelService;
 use routee_compass_core::util::unit::{DistanceUnit, SpeedUnit, TimeUnit};
 use std::sync::Arc;
 
@@ -19,26 +18,32 @@ impl TraversalModelBuilder for SpeedLookupBuilder {
     fn build(
         &self,
         params: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModelService>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn TraversalModelService>, TraversalModelError> {
         let traversal_key = CompassConfigurationField::Traversal.to_string();
         // todo: optional output time unit
-        let filename = params.get_config_path(
-            String::from("speed_table_input_file"),
-            traversal_key.clone(),
-        )?;
+        let filename = params
+            .get_config_path(
+                String::from("speed_table_input_file"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let speed_unit = params
-            .get_config_serde::<SpeedUnit>(String::from("speed_unit"), traversal_key.clone())?;
-        let distance_unit = params.get_config_serde_optional::<DistanceUnit>(
-            String::from("output_distance_unit"),
-            traversal_key.clone(),
-        )?;
-        let time_unit = params.get_config_serde_optional::<TimeUnit>(
-            String::from("output_time_unit"),
-            traversal_key.clone(),
-        )?;
+            .get_config_serde::<SpeedUnit>(String::from("speed_unit"), traversal_key.clone())
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+        let distance_unit = params
+            .get_config_serde_optional::<DistanceUnit>(
+                String::from("output_distance_unit"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
+        let time_unit = params
+            .get_config_serde_optional::<TimeUnit>(
+                String::from("output_time_unit"),
+                traversal_key.clone(),
+            )
+            .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
-        let m = SpeedLookupModel::new(&filename, speed_unit, distance_unit, time_unit)
-            .map_err(CompassConfigurationError::TraversalModelError)?;
+        let m = SpeedLookupModel::new(&filename, speed_unit, distance_unit, time_unit)?;
         let service = Arc::new(SpeedLookupService { m: Arc::new(m) });
         Ok(service)
     }
@@ -48,7 +53,7 @@ impl TraversalModelService for SpeedLookupService {
     fn build(
         &self,
         _parameters: &serde_json::Value,
-    ) -> Result<Arc<dyn TraversalModel>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn TraversalModel>, TraversalModelError> {
         Ok(self.m.clone())
     }
 }

--- a/rust/routee-compass/src/app/search/search_app.rs
+++ b/rust/routee-compass/src/app/search/search_app.rs
@@ -1,18 +1,18 @@
 use super::search_app_result::SearchAppResult;
 use crate::{
-    app::{
-        compass::compass_app_error::CompassAppError,
-        compass::config::builders::TraversalModelService,
-    },
+    app::compass::compass_app_error::CompassAppError,
     plugin::input::input_json_extensions::InputJsonExtensions,
 };
 use chrono::Local;
 use routee_compass_core::{
     algorithm::search::{backtrack, search_algorithm::SearchAlgorithm},
     model::{
-        frontier::frontier_model::FrontierModel, road_network::graph::Graph,
+        frontier::frontier_model::FrontierModel,
+        road_network::graph::Graph,
         termination::termination_model::TerminationModel,
-        traversal::traversal_model::TraversalModel,
+        traversal::{
+            traversal_model::TraversalModel, traversal_model_service::TraversalModelService,
+        },
     },
     util::read_only_lock::{DriverReadOnlyLock, ExecutorReadOnlyLock},
 };

--- a/rust/routee-compass/src/doc.md
+++ b/rust/routee-compass/src/doc.md
@@ -48,7 +48,7 @@ Any custom builders will need to be added to a [CompassAppBuilder] instance that
 
 [CompassApp]: crate::app::compass::routee_compass::CompassApp
 [CompassAppBuilder]: crate::app::compass::config::routee_compass_builder::CompassAppBuilder
-[TraversalModelBuilder]: crate::app::compass::config::builders::TraversalModelBuilder
+[TraversalModelBuilder]: routee_compass_core::app::compass::config::builders::TraversalModelBuilder
 [FrontierModelBuilder]: crate::app::compass::config::builders::FrontierModelBuilder
 [InputPluginBuilder]: crate::app::compass::config::builders::InputPluginBuilder
 [OutputPluginBuilder]: crate::app::compass::config::builders::OutputPluginBuilder


### PR DESCRIPTION
This PR refactors the energy model build process so that all objects in the energy `TraversalModelService` are wrapped in `Arc` references if they are large heap objects, so cloning is not expensive. it cleans up the build removing one layer of indirection along the way. 

`TraversalModelService` (and builder) traits were defined in routee-compass but have been moved to routee-compass-core so that they are available from the routee-compass-powertrain crate. build methods now return a TraversalModelError on failure, since CompassConfigurationError is no longer in scope.

It's probably a good low-hanging fruit task to move the rest of the builder traits to the core crate too.

i attempted to update the doc reference from the routee-compass crate that references TraversalModelBuilder, but i'm worried it won't take, that we can't make cross-crate references like that. we may need to replace those builder links with a direct hyperlink to the routee-compass-core docs at docs.rs.

Closes #34.