### PR TITLE
Rjf/termination error

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -130,7 +130,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
         // build termination model
         let termination_model_json =
             config_json.get_config_section(CompassConfigurationField::Termination)?;
-        let termination_model = TerminationModelBuilder::build(&termination_model_json)?;
+        let termination_model = TerminationModelBuilder::build(&termination_model_json, None)?;
 
         // build graph
         let graph_start = Local::now();

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
@@ -16,7 +16,9 @@ pub enum CompassConfigurationError {
     ExpectedFieldWithType(String, String),
     #[error("expected field {0} for component {1} had unrecognized value {2}")]
     ExpectedFieldWithTypeUnrecognized(String, String, String),
-    #[error("unknown module {0} for component {1} provided by configuration, must be one of {2}")]
+    #[error(
+        "unknown module '{0}' for component '{1}' provided by configuration, must be one of {2}"
+    )]
     UnknownModelNameForComponent(String, String, String),
     #[error(
         r#"

--- a/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
@@ -53,9 +53,9 @@ impl TerminationModelBuilder {
 
                 let models = models_val
                     .iter()
-                    .map(|c| {
-                        let next_scope =
-                            format!("{}.{}", local_scope.clone(), String::from("combined"));
+                    .enumerate()
+                    .map(|(idx, c)| {
+                        let next_scope = format!("{}.combined[{}]", local_scope.clone(), idx);
                         TerminationModelBuilder::build(c, Some(next_scope))
                     })
                     .collect::<Result<Vec<_>, _>>()?;

--- a/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
@@ -1,5 +1,6 @@
 use super::compass_configuration_error::CompassConfigurationError;
 use crate::app::compass::config::compass_configuration_field::CompassConfigurationField;
+use crate::app::compass::config::config_json_extension::ConfigJsonExtensions;
 use log;
 use routee_compass_core::model::termination::termination_model::TerminationModel;
 use routee_compass_core::util::conversion::duration_extension::DurationExtension;
@@ -12,106 +13,60 @@ impl TerminationModelBuilder {
     /// consistency with our user interfaces.
     pub fn build(
         config: &serde_json::Value,
+        scope: Option<String>,
     ) -> Result<TerminationModel, CompassConfigurationError> {
         use routee_compass_core::model::termination::termination_model::TerminationModel as T;
-        let term_type_obj =
-            config
-                .get("type")
-                .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::Termination.to_string(),
-                    String::from("type"),
-                ))?;
-        let term_type: String = term_type_obj
-            .as_str()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from("type"),
-                String::from("String"),
-            ))?
-            .into();
+        let local_scope = scope.unwrap_or(CompassConfigurationField::Termination.to_string());
+        let term_type = config.get_config_string(String::from("type"), local_scope.clone())?;
 
-        let result =
-            match term_type.to_lowercase().as_str() {
-                "query_runtime" => {
-                    let dur_val = config.get("limit").ok_or(
-                        CompassConfigurationError::ExpectedFieldForComponent(
-                            CompassConfigurationField::Termination.to_string(),
-                            String::from("limit"),
-                        ),
-                    )?;
-                    let dur = dur_val.as_duration()?;
-                    let freq_val = config.get("frequency").ok_or(
-                        CompassConfigurationError::ExpectedFieldForComponent(
-                            CompassConfigurationField::Termination.to_string(),
-                            String::from("frequency"),
-                        ),
-                    )?;
-                    let freq = freq_val.as_u64().ok_or(
-                        CompassConfigurationError::ExpectedFieldWithType(
-                            String::from("frequency"),
-                            String::from("integer"),
-                        ),
-                    )?;
-                    Ok(T::QueryRuntimeLimit {
-                        limit: dur,
-                        frequency: freq,
+        let result = match term_type.to_lowercase().as_str() {
+            "query_runtime" => {
+                let dur_val = config.get("limit").ok_or(
+                    CompassConfigurationError::ExpectedFieldForComponent(
+                        local_scope.clone(),
+                        String::from("limit"),
+                    ),
+                )?;
+                let dur = dur_val.as_duration()?;
+                let freq =
+                    config.get_config_i64(String::from("frequency"), local_scope.clone())? as u64;
+                Ok(T::QueryRuntimeLimit {
+                    limit: dur,
+                    frequency: freq,
+                })
+            }
+            "iterations" => {
+                let iterations =
+                    config.get_config_i64(String::from("limit"), local_scope.clone())? as u64;
+                Ok(T::IterationsLimit { limit: iterations })
+            }
+            "solution_size" => {
+                let solution_size =
+                    config.get_config_i64(String::from("limit"), local_scope.clone())? as usize;
+                Ok(T::SolutionSizeLimit {
+                    limit: solution_size,
+                })
+            }
+            "combined" => {
+                let models_val =
+                    config.get_config_array(String::from("models"), local_scope.clone())?;
+
+                let models = models_val
+                    .iter()
+                    .map(|c| {
+                        let next_scope =
+                            format!("{}.{}", local_scope.clone(), String::from("combined"));
+                        TerminationModelBuilder::build(c, Some(next_scope))
                     })
-                }
-                "iterations" => {
-                    let iters_val = config.get("limit").ok_or(
-                        CompassConfigurationError::ExpectedFieldForComponent(
-                            CompassConfigurationField::Termination.to_string(),
-                            String::from("limit"),
-                        ),
-                    )?;
-                    let iterations = iters_val.as_u64().ok_or(
-                        CompassConfigurationError::ExpectedFieldWithType(
-                            String::from("limit"),
-                            String::from("integer"),
-                        ),
-                    )?;
-                    Ok(T::IterationsLimit { limit: iterations })
-                }
-                "solution_size" => {
-                    let size_val = config.get("limit").ok_or(
-                        CompassConfigurationError::ExpectedFieldForComponent(
-                            CompassConfigurationField::Termination.to_string(),
-                            String::from("limit"),
-                        ),
-                    )?;
-                    let solution_size = size_val.as_u64().ok_or(
-                        CompassConfigurationError::ExpectedFieldWithType(
-                            String::from("limit"),
-                            String::from("integer"),
-                        ),
-                    )?;
-                    Ok(T::SolutionSizeLimit {
-                        limit: solution_size as usize,
-                    })
-                }
-                "combined" => {
-                    let models_val = config
-                        .get("models")
-                        .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                            CompassConfigurationField::Termination.to_string(),
-                            String::from("models"),
-                        ))?
-                        .as_array()
-                        .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                            String::from("models"),
-                            String::from("JSON array"),
-                        ))?;
-                    let models = models_val
-                        .iter()
-                        .map(TerminationModelBuilder::build)
-                        .collect::<Result<Vec<_>, _>>()?;
-                    Ok(T::Combined { models })
-                }
-                _ => Err(CompassConfigurationError::UnknownModelNameForComponent(
-                    term_type,
-                    CompassConfigurationField::Termination.to_string(),
-                    String::from("query_runtime, iterations, solution_size, combined"),
-                )),
-            }?;
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(T::Combined { models })
+            }
+            _ => Err(CompassConfigurationError::UnknownModelNameForComponent(
+                term_type,
+                local_scope,
+                String::from("query_runtime, iterations, solution_size, combined"),
+            )),
+        }?;
 
         log::info!("app termination model: {:?}", result);
         Ok(result)


### PR DESCRIPTION
This PR fixes how we report errors from the termination model builder so that, in the case of a combined model, we give the array index of the failing model.

in this way, when one of a few combined models is missing a key, the user understands where to look. for example, this configuration:

```toml
[termination]
type = "combined"
models = [
    { type = "query_runtime", limit = "00:10:00" },
    { type = "solution_size", limit = 30000000 },
]
```

yields this error message:

```
Could not build CompassApp from config file: expected field frequency for component termination.combined[0] provided by configuration
```

and the 0'th model is in fact missing a key.

Closes #38.