### PR TITLE
Ndr/expose fuel conversion

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -272,7 +272,7 @@ model_input_file = "models/2020_Chevrolet_Colorado_2WD_Diesel.bin"
 model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
-energy_rate_unit = "gallons_gasoline_per_mile"
+energy_rate_unit = "gallons_diesel_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
 
@@ -294,7 +294,7 @@ model_input_file = "models/2020_VW_Golf_2.0TDI.bin"
 model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
-energy_rate_unit = "gallons_gasoline_per_mile"
+energy_rate_unit = "gallons_diesel_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
 

--- a/rust/routee-compass-core/src/model/road_network/graph_loader.rs
+++ b/rust/routee-compass-core/src/model/road_network/graph_loader.rs
@@ -71,7 +71,7 @@ fn get_n_edges<P: AsRef<Path>>(edge_list_csv: &P) -> Result<usize, GraphError> {
         .extension()
         .map(|ext| ext.to_str() == Some("gz"))
         .unwrap_or(false);
-    let n = line_count(edge_list_csv.clone(), is_gzip)?;
+    let n = line_count(edge_list_csv, is_gzip)?;
     if n < 1 {
         return Err(GraphError::EmptyFileSource {
             filename: edge_list_csv.as_ref().to_path_buf(),
@@ -87,7 +87,7 @@ fn get_n_vertices<P: AsRef<Path>>(vertex_list_csv: &P) -> Result<usize, GraphErr
         .extension()
         .map(|ext| ext.to_str() == Some("gz"))
         .unwrap_or(false);
-    let n = line_count(vertex_list_csv.clone(), is_gzip)?;
+    let n = line_count(vertex_list_csv, is_gzip)?;
     if n < 1 {
         return Err(GraphError::EmptyFileSource {
             filename: vertex_list_csv.as_ref().to_path_buf(),

--- a/rust/routee-compass-core/src/util/unit/energy_rate_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/energy_rate_unit.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum EnergyRateUnit {
     GallonsGasolinePerMile,
+    GallonsDieselPerMile,
     KilowattHoursPerMile,
     KilowattHoursPerKilometer,
     KilowattHoursPerMeter,
@@ -17,6 +18,7 @@ impl EnergyRateUnit {
         use EnergyRateUnit as ERU;
         match self {
             ERU::GallonsGasolinePerMile => DU::Miles,
+            ERU::GallonsDieselPerMile => DU::Miles,
             ERU::KilowattHoursPerMile => DU::Miles,
             ERU::KilowattHoursPerKilometer => DU::Kilometers,
             ERU::KilowattHoursPerMeter => DU::Meters,
@@ -29,6 +31,7 @@ impl EnergyRateUnit {
 
         match self {
             ERU::GallonsGasolinePerMile => EU::GallonsGasoline,
+            ERU::GallonsDieselPerMile => EU::GallonsDiesel,
             ERU::KilowattHoursPerMile => EU::KilowattHours,
             ERU::KilowattHoursPerKilometer => EU::KilowattHours,
             ERU::KilowattHoursPerMeter => EU::KilowattHours,

--- a/rust/routee-compass-core/src/util/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/energy_unit.rs
@@ -6,17 +6,24 @@ use super::Energy;
 #[serde(rename_all = "snake_case")]
 pub enum EnergyUnit {
     GallonsGasoline,
+    GallonsDiesel,
     KilowattHours,
 }
 
 impl EnergyUnit {
+    // see https://epact.energy.gov/fuel-conversion-factors
     pub fn convert(&self, value: Energy, target: EnergyUnit) -> Energy {
         use EnergyUnit as S;
         match (self, target) {
             (S::GallonsGasoline, S::GallonsGasoline) => value,
-            (S::GallonsGasoline, S::KilowattHours) => value * 33.41,
-            (S::KilowattHours, S::GallonsGasoline) => value * 0.0299,
+            (S::GallonsGasoline, S::KilowattHours) => value * 32.26,
+            (S::KilowattHours, S::GallonsGasoline) => value * 0.031,
             (S::KilowattHours, S::KilowattHours) => value,
+            (S::GallonsDiesel, S::GallonsDiesel) => value,
+            (S::GallonsDiesel, S::KilowattHours) => value * 40.7,
+            (S::KilowattHours, S::GallonsDiesel) => value * 0.02457,
+            (S::GallonsDiesel, S::GallonsGasoline) => value * 1.155,
+            (S::GallonsGasoline, S::GallonsDiesel) => value * 0.866,
         }
     }
 }

--- a/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
@@ -38,7 +38,7 @@ impl ModelType {
         // Load random forest binary file
         let model: Arc<dyn PredictionModel> = match self {
             ModelType::Smartcore => Arc::new(SmartcoreSpeedGradeModel::new(
-                energy_model_path.clone(),
+                energy_model_path,
                 energy_model_speed_unit,
                 energy_model_grade_unit,
                 energy_model_energy_rate_unit,

--- a/rust/routee-compass-powertrain/src/routee/prediction/smartcore/smartcore_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/smartcore/smartcore_speed_grade_model.rs
@@ -45,7 +45,7 @@ impl SmartcoreSpeedGradeModel {
         energy_rate_unit: EnergyRateUnit,
     ) -> Result<Self, TraversalModelError> {
         // Load random forest binary file
-        let rf_binary = std::fs::read(routee_model_path.clone()).map_err(|e| {
+        let rf_binary = std::fs::read(routee_model_path).map_err(|e| {
             TraversalModelError::FileReadError(
                 routee_model_path.as_ref().to_path_buf(),
                 e.to_string(),

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
@@ -84,6 +84,11 @@ fn build_plugin_hybrid(
         String::from("battery_capacity_unit"),
         vehicle_key.clone(),
     )?;
+
+    let custom_liquid_fuel_to_kwh = parameters.get_config_serde_optional::<f64>(
+        String::from("custom_liquid_fuel_to_kwh"),
+        vehicle_key.clone(),
+    )?;
     let starting_battery_energy = battery_capacity;
     let phev = DualFuelVehicle::new(
         name,
@@ -92,6 +97,7 @@ fn build_plugin_hybrid(
         battery_capacity,
         starting_battery_energy,
         battery_energy_unit,
+        custom_liquid_fuel_to_kwh,
     )?;
     Ok(Arc::new(phev))
 }

--- a/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
@@ -24,10 +24,9 @@ impl TraversalPlugin {
         route: Option<TraversalOutputFormat>,
         tree: Option<TraversalOutputFormat>,
     ) -> Result<TraversalPlugin, PluginError> {
-        let count =
-            fs_utils::line_count(filename.clone(), fs_utils::is_gzip(filename)).map_err(|e| {
-                PluginError::FileReadError(filename.as_ref().to_path_buf(), e.to_string())
-            })?;
+        let count = fs_utils::line_count(filename, fs_utils::is_gzip(filename)).map_err(|e| {
+            PluginError::FileReadError(filename.as_ref().to_path_buf(), e.to_string())
+        })?;
 
         let mut pb = Bar::builder()
             .total(count)
@@ -117,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_geometry_deserialization() {
-        let result = read_raw_file(&mock_geometry_file(), parse_linestring, None).unwrap();
+        let result = read_raw_file(mock_geometry_file(), parse_linestring, None).unwrap();
         assert_eq!(result.len(), 3);
     }
 

--- a/rust/routee-compass/src/plugin/output/default/uuid/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/uuid/plugin.rs
@@ -14,10 +14,9 @@ pub struct UUIDOutputPlugin {
 
 impl UUIDOutputPlugin {
     pub fn from_file<P: AsRef<Path>>(filename: &P) -> Result<UUIDOutputPlugin, PluginError> {
-        let count =
-            fs_utils::line_count(filename.clone(), fs_utils::is_gzip(filename)).map_err(|e| {
-                PluginError::FileReadError(filename.as_ref().to_path_buf(), e.to_string())
-            })?;
+        let count = fs_utils::line_count(filename, fs_utils::is_gzip(filename)).map_err(|e| {
+            PluginError::FileReadError(filename.as_ref().to_path_buf(), e.to_string())
+        })?;
 
         let mut pb = Bar::builder()
             .total(count)


### PR DESCRIPTION
Expose a new "custom_liquid_fuel_to_kwh" parameter to the dual_fuel_vehicle type that will be used to convert the liquid fuel from the charge sustaining model to kwh. If the parameter is not set in the config, the model uses default conversion factors source from: https://epact.energy.gov/fuel-conversion-factors.

Also adds in a new diesel fuel unit.

closes #46 