### PR TITLE
Rjf/fix rtree distance

### DIFF
--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/mod.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/mod.rs
@@ -1,2 +1,4 @@
 pub mod builder;
 pub mod plugin;
+pub mod vertex_r_tree;
+pub mod vertex_r_tree_object;

--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/plugin.rs
@@ -3,83 +3,17 @@ use std::path::Path;
 use crate::plugin::input::input_json_extensions::InputJsonExtensions;
 use crate::plugin::input::input_plugin::InputPlugin;
 use crate::plugin::plugin_error::PluginError;
-use geo::{coord, Coord};
+use geo::Coord;
 use routee_compass_core::{
-    model::{property::vertex::Vertex, road_network::graph::Graph},
+    model::property::vertex::Vertex,
     util::{
         fs::read_utils,
         geo::haversine,
         unit::{Distance, DistanceUnit, BASE_DISTANCE_UNIT},
     },
 };
-use rstar::{PointDistance, RTree, RTreeObject, AABB};
 
-pub struct RTreeVertex {
-    vertex: Vertex,
-}
-
-impl RTreeVertex {
-    pub fn new(vertex: Vertex) -> Self {
-        Self { vertex }
-    }
-    pub fn x(&self) -> f64 {
-        self.vertex.x()
-    }
-    pub fn y(&self) -> f64 {
-        self.vertex.y()
-    }
-}
-
-pub struct VertexRTree {
-    rtree: RTree<RTreeVertex>,
-}
-
-impl VertexRTree {
-    pub fn new(vertices: Vec<Vertex>) -> Self {
-        let rtree_vertices: Vec<RTreeVertex> = vertices.into_iter().map(RTreeVertex::new).collect();
-        let rtree = RTree::bulk_load(rtree_vertices);
-        Self { rtree }
-    }
-
-    pub fn from_directed_graph(graph: &Graph) -> Self {
-        let vertices = graph.vertices.to_vec();
-        Self::new(vertices)
-    }
-
-    pub fn nearest_vertex(&self, point: Coord<f64>) -> Option<&Vertex> {
-        match self.rtree.nearest_neighbor(&point) {
-            Some(rtree_vertex) => Some(&rtree_vertex.vertex),
-            None => None,
-        }
-    }
-
-    pub fn nearest_vertices(&self, point: Coord<f64>, n: usize) -> Vec<&Vertex> {
-        self.rtree
-            .nearest_neighbor_iter(&point)
-            .take(n)
-            .map(|rtv| &rtv.vertex)
-            .collect()
-    }
-}
-
-impl RTreeObject for RTreeVertex {
-    type Envelope = AABB<Coord>;
-
-    fn envelope(&self) -> Self::Envelope {
-        AABB::from_corners(
-            coord! {x: self.x(), y: self.y()},
-            coord! {x: self.x(), y: self.y()},
-        )
-    }
-}
-
-impl PointDistance for RTreeVertex {
-    fn distance_2(&self, point: &Coord) -> f64 {
-        let dx = self.x() - point.x;
-        let dy = self.y() - point.y;
-        dx * dx + dy * dy
-    }
-}
+use super::vertex_r_tree::VertexRTree;
 
 /// Builds an input plugin that uses an RTree to find the nearest vertex to the origin and destination coordinates.
 ///

--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/vertex_r_tree.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/vertex_r_tree.rs
@@ -1,0 +1,38 @@
+use geo_types::Coord;
+use routee_compass_core::model::{property::vertex::Vertex, road_network::graph::Graph};
+use rstar::RTree;
+
+use super::vertex_r_tree_object::VertexRTreeObject;
+
+pub struct VertexRTree {
+    rtree: RTree<VertexRTreeObject>,
+}
+
+impl VertexRTree {
+    pub fn new(vertices: Vec<Vertex>) -> Self {
+        let rtree_vertices: Vec<VertexRTreeObject> =
+            vertices.into_iter().map(VertexRTreeObject::new).collect();
+        let rtree = RTree::bulk_load(rtree_vertices);
+        Self { rtree }
+    }
+
+    pub fn from_directed_graph(graph: &Graph) -> Self {
+        let vertices = graph.vertices.to_vec();
+        Self::new(vertices)
+    }
+
+    pub fn nearest_vertex(&self, point: Coord<f64>) -> Option<&Vertex> {
+        match self.rtree.nearest_neighbor(&point) {
+            Some(rtree_vertex) => Some(&rtree_vertex.vertex),
+            None => None,
+        }
+    }
+
+    pub fn nearest_vertices(&self, point: Coord<f64>, n: usize) -> Vec<&Vertex> {
+        self.rtree
+            .nearest_neighbor_iter(&point)
+            .take(n)
+            .map(|rtv| &rtv.vertex)
+            .collect()
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/vertex_r_tree_object.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/vertex_r_tree_object.rs
@@ -1,0 +1,38 @@
+use geo_types::Coord;
+use routee_compass_core::{
+    model::property::vertex::Vertex,
+    util::{geo::haversine, unit::as_f64::AsF64},
+};
+use rstar::{PointDistance, RTreeObject, AABB};
+
+pub struct VertexRTreeObject {
+    pub vertex: Vertex,
+}
+
+impl VertexRTreeObject {
+    pub fn new(vertex: Vertex) -> Self {
+        Self { vertex }
+    }
+    pub fn x(&self) -> f64 {
+        self.vertex.x()
+    }
+    pub fn y(&self) -> f64 {
+        self.vertex.y()
+    }
+}
+
+impl RTreeObject for VertexRTreeObject {
+    type Envelope = AABB<Coord>;
+
+    fn envelope(&self) -> Self::Envelope {
+        AABB::from_point(self.vertex.coordinate)
+    }
+}
+
+impl PointDistance for VertexRTreeObject {
+    fn distance_2(&self, point: &Coord) -> f64 {
+        haversine::coord_distance_meters(self.vertex.coordinate, *point)
+            .unwrap()
+            .as_f64()
+    }
+}


### PR DESCRIPTION
This PR changes the vertex rtree so it uses haversine for nearest neighbor distance. along the way, i separated the 3 struct definitions in the plugin.rs file so they now each have their own file.

Closes #45.