### PR TITLE
Ndr/54 file error msg

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -101,7 +101,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
         let config_json = config
             .clone()
             .try_deserialize::<serde_json::Value>()?
-            .normalize_file_paths(&root_config_path)?;
+            .normalize_file_paths(&"".to_string(), &root_config_path)?;
 
         let alg_params = config_json.get_config_section(CompassConfigurationField::Algorithm)?;
         let search_algorithm = SearchAlgorithm::try_from(&alg_params)?;

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -101,7 +101,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
         let config_json = config
             .clone()
             .try_deserialize::<serde_json::Value>()?
-            .normalize_file_paths(&"".to_string(), &root_config_path)?;
+            .normalize_file_paths("", &root_config_path)?;
 
         let alg_params = config_json.get_config_section(CompassConfigurationField::Algorithm)?;
         let search_algorithm = SearchAlgorithm::try_from(&alg_params)?;

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
@@ -46,8 +46,6 @@ pub enum CompassConfigurationError {
         Tried: 
          - '{1}'
          - '{2}'
-
-        Make sure the file exists and that the config key ends with '_input_file'.
         "#
     )]
     FileNormalizationNotFound(String, String, String),

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
@@ -39,8 +39,18 @@ pub enum CompassConfigurationError {
     FileNotFoundForComponent(String, String, String),
     #[error("could not normalize incoming file {0}")]
     FileNormalizationError(String),
-    #[error("Could not find incoming configuration file, tried {0} and {1}. Make sure the file exists and that the config key ends with '_input_file'")]
-    FileNormalizationNotFound(String, String),
+    #[error(
+        r#"
+        Could not find incoming configuration file '{1}' for key '{0}'
+
+        Tried: 
+         - '{1}'
+         - '{2}'
+
+        Make sure the file exists and that the config key ends with '_input_file'.
+        "#
+    )]
+    FileNormalizationNotFound(String, String, String),
     #[error("{0}")]
     InsertError(String),
     #[error(transparent)]

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -60,6 +60,7 @@ pub trait ConfigJsonExtensions {
     ) -> Result<Option<T>, CompassConfigurationError>;
     fn normalize_file_paths(
         &self,
+        parent_key: &String,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError>;
 }
@@ -267,6 +268,7 @@ impl ConfigJsonExtensions for serde_json::Value {
     /// * `Result<serde_json::Value, CompassConfigurationError>` - The JSON object with normalized paths.
     fn normalize_file_paths(
         &self,
+        parent_key: &String,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError> {
         match self {
@@ -294,6 +296,7 @@ impl ConfigJsonExtensions for serde_json::Value {
                     } else {
                         // if we can't find the file in either location, we throw an error
                         Err(CompassConfigurationError::FileNormalizationNotFound(
+                            parent_key.clone(),
                             path_string.clone(),
                             new_path_string,
                         ))
@@ -307,7 +310,10 @@ impl ConfigJsonExtensions for serde_json::Value {
                         || value.is_object()
                         || value.is_array()
                     {
-                        new_obj.insert(key.clone(), value.normalize_file_paths(root_config_path)?);
+                        new_obj.insert(
+                            key.clone(),
+                            value.normalize_file_paths(key, root_config_path)?,
+                        );
                     } else {
                         new_obj.insert(key.clone(), value.clone());
                     }
@@ -319,10 +325,10 @@ impl ConfigJsonExtensions for serde_json::Value {
                 for value in arr.iter() {
                     match value {
                         serde_json::Value::Array(_) => {
-                            new_arr.push(value.normalize_file_paths(root_config_path)?)
+                            new_arr.push(value.normalize_file_paths(parent_key, root_config_path)?)
                         }
                         serde_json::Value::Object(_) => {
-                            new_arr.push(value.normalize_file_paths(root_config_path)?)
+                            new_arr.push(value.normalize_file_paths(parent_key, root_config_path)?)
                         }
                         _ => new_arr.push(value.clone()),
                     }

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -256,7 +256,7 @@ impl ConfigJsonExtensions for serde_json::Value {
     /// 3. Relative path to where the application is being run
     ///
     /// This function scans each key value pair in the config and for any key that
-    /// ends with `_file`, it will attempt to normalize the path such that the application
+    /// ends with `_input_file`, it will attempt to normalize the path such that the application
     /// can find the file regardless of where it is being executed.
     ///
     /// Arguments:

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -60,7 +60,7 @@ pub trait ConfigJsonExtensions {
     ) -> Result<Option<T>, CompassConfigurationError>;
     fn normalize_file_paths(
         &self,
-        parent_key: &String,
+        parent_key: &str,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError>;
 }
@@ -268,7 +268,7 @@ impl ConfigJsonExtensions for serde_json::Value {
     /// * `Result<serde_json::Value, CompassConfigurationError>` - The JSON object with normalized paths.
     fn normalize_file_paths(
         &self,
-        parent_key: &String,
+        parent_key: &str,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError> {
         match self {
@@ -296,7 +296,7 @@ impl ConfigJsonExtensions for serde_json::Value {
                     } else {
                         // if we can't find the file in either location, we throw an error
                         Err(CompassConfigurationError::FileNormalizationNotFound(
-                            parent_key.clone(),
+                            parent_key.to_string(),
                             path_string.clone(),
                             new_path_string,
                         ))


### PR DESCRIPTION
Fixes #54 by updating the error message for when a file is not found. With an empty file string in the config, the error would look something like:

```console
[2023-12-01T18:03:43Z ERROR routee_compass] Could not build CompassApp from config file:
            Could not find incoming configuration file '' for key 'dummy_input_file'

            Tried:
             - ''
             - '/Users/nreinick/repos/routee-compass-tomtom/'

            Make sure the file exists and that the config key ends with '_input_file'.

Error: CompassConfigurationError(FileNormalizationNotFound("dummy_input_file", "", "/Users/nreinick/repos/routee-compass-tomtom/"))
```