### PR TITLE
switch to Euclidean squared distance

### DIFF
--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_record.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_record.rs
@@ -47,8 +47,15 @@ impl PointDistance for EdgeRtreeRecord {
             .geometry
             .centroid()
             .unwrap_or_else(|| panic!("empty linestring in geometry file"));
-        let distance = haversine::coord_distance_meters(this_point.0, point.0)
-            .unwrap_or(Distance::new(f64::MAX));
-        distance.as_f64()
+        // as noted in the comments for PointDistance, this should return the squared distance.
+        // haversine *should* work but squared haversine in meters is giving weird results for
+        // the vertex rtree plugin, so, i'm reverting this to euclidean for now. -rjf 2023-12-01
+        // let distance = haversine::coord_distance_meters(this_point.0, point.0)
+        //     .unwrap_or(Distance::new(f64::MAX))
+        //     .as_f64();
+        // distance * distance
+        let dx = this_point.x() - point.x();
+        let dy = this_point.y() - point.y();
+        dx * dx + dy * dy
     }
 }


### PR DESCRIPTION
while working on #58, i discovered i had the wrong understanding of the API for rstar::RTree. it turns out the distance metric should be the _squared euclidean distance_. 

our points are in lat/lon, which is a spherical 2D plane aka non-Euclidean. i would assume a haversine distance formula would produce more accurate values. however, after making this change, a simple test case produced an invalid result.

this PR changes the edge rtree distance function to match the vertex rtree distance function, using the squared Euclidean (lat/lon) distance between points. we can have further discussion in #58 as to whether these should be calculated directly as this is or via some transform for accuracy.