### PR TITLE
Rjf/load balancing heuristic

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_distance.toml
+++ b/python/nrel/routee/compass/resources/osm_default_distance.toml
@@ -10,12 +10,13 @@ type = "distance"
 distance_unit = "miles"
 
 [plugin]
-input_plugins = [
-    { type = "grid_search" },
-    { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },
-]
 output_plugins = [
     { type = "summary" },
     { type = "traversal", route = "geo_json", geometry_input_file = "edges-geometries-enumerated.txt.gz" },
     { type = "uuid", uuid_input_file = "vertices-uuid-enumerated.txt.gz" },
+]
+input_plugins = [
+    { type = "grid_search" },
+    { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },
+    { type = "load_balancer", heuristic = { type = "haversine" } },
 ]

--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -9,6 +9,7 @@ verbose = true
 input_plugins = [
     { type = "grid_search" },
     { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },
+    { type = "load_balancer", heuristic = { type = "haversine" } },
 ]
 output_plugins = [
     { type = "summary" },
@@ -419,7 +420,7 @@ speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
-real_world_energy_adjustment = 1.1252 
+real_world_energy_adjustment = 1.1252
 
 [[traversal.vehicles]]
 type = "dual_fuel"
@@ -443,12 +444,12 @@ speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
-real_world_energy_adjustment = 1.1252 
+real_world_energy_adjustment = 1.1252
 
 [[traversal.vehicles]]
 type = "dual_fuel"
 name = "2016_FORD_C-MAX_(PHEV)"
-battery_capacity = 7.6 
+battery_capacity = 7.6
 battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2016_FORD_C-MAX_(PHEV)_Charge_Depleting"
@@ -467,12 +468,12 @@ speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
-real_world_energy_adjustment = 1.1252 
+real_world_energy_adjustment = 1.1252
 
 [[traversal.vehicles]]
 type = "dual_fuel"
 name = "2016_HYUNDAI_Sonata_PHEV"
-battery_capacity = 9.8 
+battery_capacity = 9.8
 battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2016_HYUNDAI_Sonata_PHEV_Charge_Depleting"
@@ -491,12 +492,12 @@ speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
-real_world_energy_adjustment = 1.1252 
+real_world_energy_adjustment = 1.1252
 
 [[traversal.vehicles]]
 type = "dual_fuel"
 name = "2017_Prius_Prime"
-battery_capacity = 8 
+battery_capacity = 8
 battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2017_Prius_Prime_Charge_Depleting"
@@ -515,4 +516,4 @@ speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
-real_world_energy_adjustment = 1.1252 
+real_world_energy_adjustment = 1.1252

--- a/python/nrel/routee/compass/resources/osm_default_speed.toml
+++ b/python/nrel/routee/compass/resources/osm_default_speed.toml
@@ -16,6 +16,7 @@ output_time_unit = "minutes"
 input_plugins = [
     { type = "grid_search" },
     { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },
+    { type = "load_balancer", heuristic = { type = "haversine" } },
 ]
 output_plugins = [
     { type = "summary" },

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,3 +26,4 @@ chrono = "0.4.26"
 regex = "1.9.5"
 wkt = { version = "0.10.3", features = ["serde"] }
 config = "0.13.3"
+ordered-float = { version = "4.1.1", features = ["serde"] }

--- a/rust/routee-compass-core/Cargo.toml
+++ b/rust/routee-compass-core/Cargo.toml
@@ -17,7 +17,7 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 flate2 = { workspace = true }
 geo = { workspace = true }
-ordered-float = { version = "4.1.1", features = ["serde"] }
+ordered-float = { workspace = true }
 derive_more = "0.99.0"
 priority-queue = "1.3.2"
 csv = { workspace = true }

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -40,3 +40,4 @@ chrono = { workspace = true }
 config = { workspace = true }
 clap = { version = "4.3.19", features = ["derive"] }
 itertools = { workspace = true }
+ordered-float = { workspace = true }

--- a/rust/routee-compass/src/app/compass/compass_app_ops.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_ops.rs
@@ -199,7 +199,7 @@ mod test {
 
     #[test]
     fn test_big_outlier() {
-        let queries: Vec<serde_json::Value> = vec![14, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        let queries: Vec<serde_json::Value> = vec![4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
             .iter()
             .enumerate()
             .map(|(idx, est)| {

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -15,7 +15,8 @@ use crate::plugin::{
     input::{
         default::{
             edge_rtree::edge_rtree_input_plugin_builder::EdgeRtreeInputPluginBuilder,
-            grid_search::builder::GridSearchBuilder, vertex_rtree::builder::VertexRTreeBuilder,
+            grid_search::builder::GridSearchBuilder, load_balancer::builder::LoadBalancerBuilder,
+            vertex_rtree::builder::VertexRTreeBuilder,
         },
         input_plugin::InputPlugin,
     },
@@ -134,10 +135,12 @@ impl CompassAppBuilder {
         let grid_search: Box<dyn InputPluginBuilder> = Box::new(GridSearchBuilder {});
         let vertex_tree: Box<dyn InputPluginBuilder> = Box::new(VertexRTreeBuilder {});
         let edge_rtree: Box<dyn InputPluginBuilder> = Box::new(EdgeRtreeInputPluginBuilder {});
+        let load_balancer: Box<dyn InputPluginBuilder> = Box::new(LoadBalancerBuilder {});
         let input_plugin_builders = HashMap::from([
             (String::from("grid_search"), grid_search),
             (String::from("vertex_rtree"), vertex_tree),
             (String::from("edge_rtree"), edge_rtree),
+            (String::from("load_balancer"), load_balancer),
         ]);
 
         // Output plugin builders

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/builder.rs
@@ -1,0 +1,24 @@
+use crate::{
+    app::compass::config::{
+        builders::InputPluginBuilder, compass_configuration_error::CompassConfigurationError,
+        config_json_extension::ConfigJsonExtensions,
+    },
+    plugin::input::input_plugin::InputPlugin,
+};
+
+use super::{plugin::LoadBalancerPlugin, weight_heuristic::WeightHeuristic};
+
+pub struct LoadBalancerBuilder {}
+
+impl InputPluginBuilder for LoadBalancerBuilder {
+    fn build(
+        &self,
+        params: &serde_json::Value,
+    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
+        let heuristic = params.get_config_serde::<WeightHeuristic>(
+            String::from("weight_heuristic"),
+            String::from("load_balancer"),
+        )?;
+        Ok(Box::new(LoadBalancerPlugin { heuristic }))
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/mod.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/mod.rs
@@ -1,0 +1,3 @@
+pub mod builder;
+pub mod plugin;
+pub mod weight_heuristic;

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/plugin.rs
@@ -1,0 +1,17 @@
+use super::weight_heuristic::WeightHeuristic;
+use crate::plugin::input::input_json_extensions::InputJsonExtensions;
+use crate::plugin::input::input_plugin::InputPlugin;
+use crate::plugin::plugin_error::PluginError;
+
+pub struct LoadBalancerPlugin {
+    pub heuristic: WeightHeuristic,
+}
+
+impl InputPlugin for LoadBalancerPlugin {
+    fn process(&self, query: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
+        let w = self.heuristic.estimate_weight(query.clone())?;
+        let mut updated = query.clone();
+        updated.add_query_weight_estimate(w)?;
+        Ok(vec![updated])
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
@@ -23,7 +23,7 @@ impl WeightHeuristic {
                     None => Err(PluginError::InputError(String::from(
                         "cannot estimate search size without destination coordinate",
                     ))),
-                    Some(d) => haversine::coord_distance_meters(o, d)
+                    Some(d) => haversine::coord_distance(o, d, DistanceUnit::Kilometers)
                         .map(|d| d.as_f64())
                         .map_err(|s| {
                             PluginError::PluginFailed(format!(

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
@@ -1,9 +1,12 @@
 use crate::plugin::{input::input_json_extensions::InputJsonExtensions, plugin_error::PluginError};
-use routee_compass_core::util::{geo::haversine, unit::as_f64::AsF64};
+use routee_compass_core::util::{
+    geo::haversine,
+    unit::{as_f64::AsF64, Distance, DistanceUnit},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum WeightHeuristic {
     /// computes a weight directly as the haversine distance estimation between
     /// trip origin and destination, in meters.
@@ -11,17 +14,21 @@ pub enum WeightHeuristic {
     /// # Arguments
     ///
     /// * `default` - fill value if no destination is provided
-    Haversine { default: f64 },
+    Haversine { default: (Distance, DistanceUnit) },
 }
 
 impl WeightHeuristic {
     pub fn estimate_weight(&self, query: serde_json::Value) -> Result<f64, PluginError> {
         match self {
             WeightHeuristic::Haversine { default } => {
+                let (default_distance, distance_unit) = default;
+                let default_meters = DistanceUnit::Meters
+                    .convert(*default_distance, *distance_unit)
+                    .as_f64();
                 let o = query.get_origin_coordinate()?;
                 let d_option = query.get_destination_coordinate()?;
                 match d_option {
-                    None => Ok(*default),
+                    None => Ok(default_meters),
                     Some(d) => haversine::coord_distance_meters(o, d)
                         .map(|d| d.as_f64())
                         .map_err(|s| {

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
@@ -1,0 +1,37 @@
+use crate::plugin::{input::input_json_extensions::InputJsonExtensions, plugin_error::PluginError};
+use routee_compass_core::util::{geo::haversine, unit::as_f64::AsF64};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum WeightHeuristic {
+    /// computes a weight directly as the haversine distance estimation between
+    /// trip origin and destination, in meters.
+    ///
+    /// # Arguments
+    ///
+    /// * `default` - fill value if no destination is provided
+    Haversine { default: f64 },
+}
+
+impl WeightHeuristic {
+    pub fn estimate_weight(&self, query: serde_json::Value) -> Result<f64, PluginError> {
+        match self {
+            WeightHeuristic::Haversine { default } => {
+                let o = query.get_origin_coordinate()?;
+                let d_option = query.get_destination_coordinate()?;
+                match d_option {
+                    None => Ok(*default),
+                    Some(d) => haversine::coord_distance_meters(o, d)
+                        .map(|d| d.as_f64())
+                        .map_err(|s| {
+                            PluginError::PluginFailed(format!(
+                                "failed calculating load balancing weight value due to {}",
+                                s
+                            ))
+                        }),
+                }
+            }
+        }
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/mod.rs
+++ b/rust/routee-compass/src/plugin/input/default/mod.rs
@@ -1,3 +1,4 @@
 pub mod edge_rtree;
 pub mod grid_search;
+pub mod load_balancer;
 pub mod vertex_rtree;

--- a/rust/routee-compass/src/plugin/input/input_field.rs
+++ b/rust/routee-compass/src/plugin/input/input_field.rs
@@ -10,6 +10,7 @@ pub enum InputField {
     OriginEdge,
     DestinationEdge,
     GridSearch,
+    QueryWeightEstimate,
 }
 
 impl InputField {
@@ -25,6 +26,7 @@ impl InputField {
             I::OriginEdge => "origin_edge",
             I::DestinationEdge => "destination_edge",
             I::GridSearch => "grid_search",
+            I::QueryWeightEstimate => "query_weight_estimate",
         }
     }
 }


### PR DESCRIPTION
this PR introduces query load balancing as an input plugin. if used, a load balancing plugin will assign a `InputField::QueryWeightEstimate` to the query which is an `f64`. this allows for a more efficient batch run. for example, if there are 12 queries, but one takes 4x longer than the result, then we should expect that the 4x long query is in a batch of it's own:

```python
input_weights = [4,1,1,1,1,1,1,1,1,1,1,1]
binned_weights = [[4], [1,1,1,1], [1,1,1,1], [1,1,1]]
```

as a pre-processing step to parallelization in `CompassApp.run`, the app will use the weight values on the set of queries and shuffle these incrementally into bins using a greedy assignment. if there are no weight values, a default value of 1 is used.

### notes
- the load balancer requires a heuristic for weight estimates. an enum `WeightHeuristic` was added with one implementation, `Haversine`, which takes no arguments and produces a `QueryWeightHeuristic` that is the haversine distance from origin to destination in kilometers
- this plugin should always appear at the end of the input plugins. i guess to be more specific, it should appear after any plugins that alter the size of the input queries, such as grid search.
- in order to use the binned JSON values, i swapped `par_chunks` with `par_iter` over the binned and load balanced `Vec<Vec<JSON>>`.
- a few test cases were provided in compass_app_ops.rs that test batches of different types of inputs.

Closes #41.