### PR TITLE
custom load balancing heuristic

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -282,9 +282,38 @@ balanced = [[long], [short, short, short]]
 ```toml
 [[plugin.input_plugins]]
 type = "load_balancer"
-# method for estimating query runtime, currently only haversine distance in kilometers is supported.
+# method for estimating query runtime, in this case haversine distance in kilometers.
 # this heuristic only works for trips with origin/destination pairs.
 weight_heuristic = { type = "haversine" }
+```
+
+if a user has fields on their queries that can be used directly or mapped to weight values, they may use
+the custom weight heuristic. this numeric example expects a field `my_weight_value: float` on each query:
+
+```toml
+[[plugin.input_plugins]]
+type = "load_balancer"
+[plugin.input_plugins.weight_heuristic]
+type = "custom"
+[plugin.input_plugins.weight_heuristic.custom_weight_type]
+type = "numeric"
+column_name = "my_weight_value"
+```
+
+categorical fields are also supported by providing a mapping. this example expects a `mode` field
+and uses values `[walk, bike, drive]` to map to weight values of 1, 10, and 100, for example
+based on observed search sizes for each travel mode.
+
+```toml
+[[plugin.input_plugins]]
+type = "load_balancer"
+[plugin.input_plugins.weight_heuristic]
+type = "custom"
+[plugin.input_plugins.weight_heuristic.custom_weight_type]
+type = "categorical"
+column_name = "mode"
+default = 1
+mapping = { "walk" = 1, "bike" = 10, "drive" = 100 }
 ```
 
 ## Output Plugins

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/custom_weight_type.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/custom_weight_type.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    app::compass::config::config_json_extension::ConfigJsonExtensions,
+    plugin::{input::input_field::InputField, plugin_error::PluginError},
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case", tag = "type")]
+
+pub enum CustomWeightType {
+    /// a weight value found on each query which can be used directly as it is a numeric
+    /// field. will use provided column_name or fall back to InputField::QueryWeightEstimate.
+    /// if a default fill value is provided, it is used when the weight field is missing.
+    Numeric { column_name: Option<String> },
+    /// a weight value found on each query which has a categorical field value. symbols are
+    /// converted to f64 values via a user-provided mapping. will use provided column_name
+    /// or fall back to InputField::QueryWeightEstimate.
+    /// if a default fill value is provided, it is used when the weight field is missing.
+    Categorical {
+        column_name: Option<String>,
+        mapping: HashMap<String, f64>,
+        default: Option<f64>,
+    },
+}
+
+impl CustomWeightType {
+    pub fn get_weight(&self, query: &serde_json::Value) -> Result<f64, PluginError> {
+        match self {
+            CustomWeightType::Numeric { column_name } => {
+                let col: String = column_name
+                    .to_owned()
+                    .unwrap_or(InputField::QueryWeightEstimate.to_string());
+                let value = query
+                    .get_config_f64(col.clone(), String::from("custom_weight_type"))
+                    .map_err(|_| PluginError::ParseError(col, String::from("String")))?;
+                Ok(value)
+            }
+            CustomWeightType::Categorical {
+                column_name,
+                mapping,
+                default,
+            } => {
+                let col: String = column_name
+                    .to_owned()
+                    .unwrap_or(InputField::QueryWeightEstimate.to_string());
+                let categorical_value = query
+                    .get_config_string(col.clone(), String::from("custom_weight_type"))
+                    .map_err(|_| PluginError::ParseError(col.clone(), String::from("String")))?;
+                match (mapping.get(&categorical_value), default) {
+                    (Some(result), _) => Ok(*result),
+                    (None, Some(fallback)) => Ok(*fallback),
+                    _ => Err(PluginError::InputError(format!("load balancing categorical {} not found in mapping and no default was provided", categorical_value))),
+                }
+            }
+        }
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/mod.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/mod.rs
@@ -1,3 +1,4 @@
 pub mod builder;
+pub mod custom_weight_type;
 pub mod plugin;
 pub mod weight_heuristic;

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/weight_heuristic.rs
@@ -1,3 +1,4 @@
+use super::custom_weight_type::CustomWeightType;
 use crate::plugin::{input::input_json_extensions::InputJsonExtensions, plugin_error::PluginError};
 use routee_compass_core::util::{
     geo::haversine,
@@ -5,12 +6,17 @@ use routee_compass_core::util::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum WeightHeuristic {
     /// computes a weight directly as the haversine distance estimation between
     /// trip origin and destination, in kilometers.
     Haversine,
+    /// user provides a field of some custom weight type that is used directly
+    /// for weight estimates.
+    Custom {
+        custom_weight_type: CustomWeightType,
+    },
 }
 
 impl WeightHeuristic {
@@ -33,6 +39,7 @@ impl WeightHeuristic {
                         }),
                 }
             }
+            WeightHeuristic::Custom { custom_weight_type } => custom_weight_type.get_weight(query),
         }
     }
 }


### PR DESCRIPTION
this PR is work done under the MEP project that adds a custom load balancing weight heuristic. it is designed for either numeric or categorical fields. this sets me up in the MEP project to load balance in the absence of trip destinations by keying off of the travel modes.

### examples

##### numeric

```json
{
  "my_weight_value": 3.14159
}
```

```toml
[[plugin.input_plugins]]
type = "load_balancer"

[plugin.input_plugins.weight_heuristic]
type = "custom"

[plugin.input_plugins.weight_heuristic.custom_weight_type]
type = "numeric"
column_name = "my_weight_value"
```

##### categorical

```json
{
  "mode": "bike"
}
```

```toml
[[plugin.input_plugins]]
type = "load_balancer"

[plugin.input_plugins.weight_heuristic]
type = "custom"

[plugin.input_plugins.weight_heuristic.custom_weight_type]
type = "categorical"
column_name = "mode"
default = 1
mapping = { "walk" = 1, "bike" = 10, "drive" = 100 }
```