### PR TITLE
Rjf/expose graph ops

### DIFF
--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -109,6 +109,21 @@ class CompassApp:
         if single_query and len(results) == 1:
             return results[0]
         return results
+    
+    def graph_edge_origin(self, edge_id: int) -> int:
+        return self._app.graph_edge_origin(edge_id)
+
+    def graph_edge_destination(self, edge_id: int) -> int:
+        return self._app.graph_edge_destination(edge_id)
+
+    def graph_edge_distance(self, edge_id: int, distance_unit: Optional[str]) -> float:
+        return self._app.graph_edge_distance(edge_id, distance_unit)
+
+    def graph_get_out_edge_ids(self, vertex_id: int) -> List[int]:
+        return self._app.graph_get_out_edge_ids(vertex_id)
+
+    def graph_get_in_edge_ids(self, vertex_id: int) -> List[int]:
+        return self._app.graph_get_in_edge_ids(vertex_id)
 
 
 def inject_to_disk_plugin(output_file: str, toml_config: dict) -> dict:

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -109,7 +109,7 @@ class CompassApp:
         if single_query and len(results) == 1:
             return results[0]
         return results
-    
+
     def graph_edge_origin(self, edge_id: int) -> int:
         return self._app.graph_edge_origin(edge_id)
 

--- a/rust/routee-compass-core/src/algorithm/search/direction.rs
+++ b/rust/routee-compass-core/src/algorithm/search/direction.rs
@@ -1,4 +1,7 @@
-#[derive(Copy, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Serialize, Deserialize)]
+#[serde(rename = "snake_case")]
 pub enum Direction {
     Forward,
     Reverse,

--- a/rust/routee-compass-py/Cargo.toml
+++ b/rust/routee-compass-py/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/routee-compass"
 
 [dependencies]
 routee-compass = { path = "../routee-compass", version = "0.4.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.4.0" }
 pyo3 = { version = "0.20.0", features = ["extension-module"] }
 serde_json = { workspace = true }
 config = { workspace = true }

--- a/rust/routee-compass-py/src/app_graph_ops.rs
+++ b/rust/routee-compass-py/src/app_graph_ops.rs
@@ -1,0 +1,98 @@
+use pyo3::{exceptions::PyException, PyErr, PyResult};
+use routee_compass::app::search::search_app_graph_ops::SearchAppGraphOps;
+use routee_compass_core::{
+    algorithm::search::direction::Direction,
+    model::road_network::{edge_id::EdgeId, vertex_id::VertexId},
+    util::unit::{as_f64::AsF64, DistanceUnit},
+};
+
+use crate::app_wrapper::CompassAppWrapper;
+
+pub fn graph_edge_origin(app: &CompassAppWrapper, edge_id: usize) -> PyResult<usize> {
+    let edge_id_internal = EdgeId(edge_id);
+    app.routee_compass
+        .search_app
+        .get_edge_origin(edge_id_internal)
+        .map(|o| o.0)
+        .map_err(|e| {
+            PyException::new_err(format!(
+                "error retrieving edge origin for edge_id {}: {}",
+                edge_id, e
+            ))
+        })
+}
+
+pub fn graph_edge_destination(app: &CompassAppWrapper, edge_id: usize) -> PyResult<usize> {
+    let edge_id_internal = EdgeId(edge_id);
+    app.routee_compass
+        .search_app
+        .get_edge_destination(edge_id_internal)
+        .map(|o| o.0)
+        .map_err(|e| {
+            PyException::new_err(format!(
+                "error retrieving edge destination for edge_id {}: {}",
+                edge_id, e
+            ))
+        })
+}
+
+pub fn graph_edge_distance(
+    app: &CompassAppWrapper,
+    edge_id: usize,
+    distance_unit: Option<String>,
+) -> PyResult<f64> {
+    let du_internal_result: PyResult<Option<DistanceUnit>> = match distance_unit {
+        Some(du_str) => {
+            let mut enquoted = du_str.clone();
+            enquoted.insert(0, '"');
+            enquoted.push('"');
+            let du = serde_json::from_str::<DistanceUnit>(enquoted.as_str()).map_err(|_| {
+                PyException::new_err(format!("could not deserialize distance unit '{}'", du_str))
+            })?;
+
+            Ok(Some(du))
+        }
+
+        None => Ok(None),
+    };
+    let du_internal = du_internal_result?;
+    let edge_id_internal = EdgeId(edge_id);
+    app.routee_compass
+        .search_app
+        .get_edge_distance(edge_id_internal, du_internal)
+        .map(|o| o.as_f64())
+        .map_err(|e| {
+            PyException::new_err(format!(
+                "error retrieving edge destination for edge_id {}: {}",
+                edge_id, e
+            ))
+        })
+}
+
+pub fn get_out_edge_ids(app: &CompassAppWrapper, vertex_id: usize) -> PyResult<Vec<usize>> {
+    let vertex_id_internal = VertexId(vertex_id);
+    app.routee_compass
+        .search_app
+        .get_incident_edge_ids(vertex_id_internal, Direction::Forward)
+        .map(|es| es.iter().map(|e| e.0).collect())
+        .map_err(|e| {
+            PyException::new_err(format!(
+                "error retrieving out edges for vertex_id {}: {}",
+                vertex_id, e
+            ))
+        })
+}
+
+pub fn get_in_edge_ids(app: &CompassAppWrapper, vertex_id: usize) -> PyResult<Vec<usize>> {
+    let vertex_id_internal = VertexId(vertex_id);
+    app.routee_compass
+        .search_app
+        .get_incident_edge_ids(vertex_id_internal, Direction::Reverse)
+        .map(|es| es.iter().map(|e| e.0).collect())
+        .map_err(|e| {
+            PyException::new_err(format!(
+                "error retrieving in edges for vertex_id {}: {}",
+                vertex_id, e
+            ))
+        })
+}

--- a/rust/routee-compass-py/src/app_wrapper.rs
+++ b/rust/routee-compass-py/src/app_wrapper.rs
@@ -1,18 +1,47 @@
 use std::path::Path;
 
+use crate::app_graph_ops as ops;
 use pyo3::{exceptions::PyException, prelude::*, types::PyType};
-use routee_compass::app::compass::{
-    compass_app::CompassApp, compass_app_ops::read_config_from_string,
-    config::compass_app_builder::CompassAppBuilder,
+use routee_compass::app::{
+    compass::{
+        compass_app::CompassApp, compass_app_ops::read_config_from_string,
+        config::compass_app_builder::CompassAppBuilder,
+    },
+    search::search_app_graph_ops::SearchAppGraphOps,
 };
+use routee_compass_core::model::road_network::edge_id::EdgeId;
 
 #[pyclass]
 pub struct CompassAppWrapper {
-    routee_compass: CompassApp,
+    pub routee_compass: CompassApp,
 }
 
 #[pymethods]
 impl CompassAppWrapper {
+    pub fn graph_edge_origin(&self, edge_id: usize) -> PyResult<usize> {
+        ops::graph_edge_origin(self, edge_id)
+    }
+
+    pub fn graph_edge_destination(&self, edge_id: usize) -> PyResult<usize> {
+        ops::graph_edge_destination(self, edge_id)
+    }
+
+    pub fn graph_edge_distance(
+        &self,
+        edge_id: usize,
+        distance_unit: Option<String>,
+    ) -> PyResult<f64> {
+        ops::graph_edge_distance(self, edge_id, distance_unit)
+    }
+
+    pub fn graph_get_out_edge_ids(&self, vertex_id: usize) -> PyResult<Vec<usize>> {
+        ops::get_out_edge_ids(self, vertex_id)
+    }
+
+    pub fn graph_get_in_edge_ids(&self, vertex_id: usize) -> PyResult<Vec<usize>> {
+        ops::get_in_edge_ids(self, vertex_id)
+    }
+
     #[classmethod]
     pub fn _from_config_toml_string(
         _cls: &PyType,

--- a/rust/routee-compass-py/src/lib.rs
+++ b/rust/routee-compass-py/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("doc.md")]
 
+pub mod app_graph_ops;
 pub mod app_wrapper;
 
 use app_wrapper::CompassAppWrapper;

--- a/rust/routee-compass/src/app/search/mod.rs
+++ b/rust/routee-compass/src/app/search/mod.rs
@@ -1,2 +1,3 @@
 pub mod search_app;
+pub mod search_app_graph_ops;
 pub mod search_app_result;

--- a/rust/routee-compass/src/app/search/search_app.rs
+++ b/rust/routee-compass/src/app/search/search_app.rs
@@ -198,4 +198,8 @@ impl SearchApp {
             .build(query)?;
         Ok(tm)
     }
+
+    pub fn get_graph_reference(&self) -> Arc<ExecutorReadOnlyLock<Graph>> {
+        Arc::new(self.graph.read_only())
+    }
 }

--- a/rust/routee-compass/src/app/search/search_app_graph_ops.rs
+++ b/rust/routee-compass/src/app/search/search_app_graph_ops.rs
@@ -1,0 +1,91 @@
+use routee_compass_core::{
+    algorithm::search::direction::Direction,
+    model::road_network::{edge_id::EdgeId, graph::Graph, vertex_id::VertexId},
+    util::unit::{Distance, DistanceUnit},
+};
+
+use crate::app::compass::compass_app_error::CompassAppError;
+
+use super::search_app::SearchApp;
+
+pub trait SearchAppGraphOps {
+    fn get_edge_origin(&self, edge_id: EdgeId) -> Result<VertexId, CompassAppError>;
+    fn get_edge_destination(&self, edge_id: EdgeId) -> Result<VertexId, CompassAppError>;
+    fn get_edge_distance(
+        &self,
+        edge_id: EdgeId,
+        distance_unit: Option<DistanceUnit>,
+    ) -> Result<Distance, CompassAppError>;
+    fn get_incident_edge_ids(
+        &self,
+        vertex_id: VertexId,
+        direction: Direction,
+    ) -> Result<Vec<EdgeId>, CompassAppError>;
+}
+
+impl SearchAppGraphOps for SearchApp {
+    fn get_edge_origin(&self, edge_id: EdgeId) -> Result<VertexId, CompassAppError> {
+        let op = move |g: &Graph| {
+            let edge = g.get_edge(edge_id).map_err(CompassAppError::GraphError)?;
+            Ok(edge.src_vertex_id)
+        };
+        let result: VertexId = graph_op(self, &op)?;
+        Ok(result)
+    }
+
+    fn get_edge_destination(&self, edge_id: EdgeId) -> Result<VertexId, CompassAppError> {
+        let op = move |g: &Graph| {
+            let edge = g.get_edge(edge_id).map_err(CompassAppError::GraphError)?;
+            Ok(edge.dst_vertex_id)
+        };
+        let result: VertexId = graph_op(self, &op)?;
+        Ok(result)
+    }
+
+    fn get_edge_distance(
+        &self,
+        edge_id: EdgeId,
+        distance_unit: Option<DistanceUnit>,
+    ) -> Result<Distance, CompassAppError> {
+        let op = move |g: &Graph| {
+            let edge = g.get_edge(edge_id).map_err(CompassAppError::GraphError)?;
+            Ok(edge.distance)
+        };
+        let result_base: Distance = graph_op(self, &op)?;
+        let result = match distance_unit {
+            Some(du) => DistanceUnit::Meters.convert(result_base, du),
+            None => result_base,
+        };
+        Ok(result)
+    }
+
+    fn get_incident_edge_ids(
+        &self,
+        vertex_id: VertexId,
+        direction: Direction,
+    ) -> Result<Vec<EdgeId>, CompassAppError> {
+        let op = move |g: &Graph| {
+            let incident_edges = g
+                .incident_edges(vertex_id, direction)
+                .map_err(CompassAppError::GraphError)?;
+            Ok(incident_edges)
+        };
+        let result: Vec<EdgeId> = graph_op(self, &op)?;
+        Ok(result)
+    }
+}
+
+fn graph_op<T>(
+    app: &SearchApp,
+    op: &dyn Fn(&Graph) -> Result<T, CompassAppError>,
+) -> Result<T, CompassAppError>
+where
+    T: Send,
+{
+    let g_ref = app.get_graph_reference();
+    let g = g_ref
+        .read()
+        .map_err(|e| CompassAppError::ReadOnlyPoisonError(e.to_string()))?;
+    let result = op(&g)?;
+    Ok(result)
+}


### PR DESCRIPTION
this PR adds a few simple commands to inspect graph attributes from CompassApp and CompassAppWrapper / python CompassApp. that includes:

```python
    def graph_edge_origin(self, edge_id: int) -> int:
    def graph_edge_destination(self, edge_id: int) -> int:
    def graph_edge_distance(self, edge_id: int, distance_unit: Optional[str]) -> float:
    def graph_get_out_edge_ids(self, vertex_id: int) -> List[int]:
    def graph_get_in_edge_ids(self, vertex_id: int) -> List[int]:
```

each time one of these methods is called, we clone the `Arc<DriverReadOnlyLock<Graph>>`, which is a small performance hit which may be acceptable for some one-off operations but may slow things down for large batch queries. if that becomes a bottleneck we can add some batch operations that follow the pattern of these methods to amortize the clone runtime hit.

### example

using the golden, co test case in the notebook example, i have this for my edges-compass.csv.gz file:

```
      edge_id  src_vertex_id  dst_vertex_id  distance
0           0              0            429   474.918
1           1              2              3    71.722
2           2              2            173    33.589
3           3              2            178   111.341
4           4              3              2    71.722
...       ...            ...            ...       ...
1755     1755            743            474    59.098
1756     1756            743            744    25.754     <---- this row in example
1757     1757            744            732    31.905
1758     1758            745            574    21.303
1759     1759            745            663   217.939

```

i run these queries and get this result:
```python
(
    app.graph_edge_origin(1756),
    app.graph_edge_destination(1756),
    app.graph_edge_distance(1756, None),
    app.graph_edge_distance(1756, 'meters'),       
    app.graph_edge_distance(1756, 'kilometers'),
    app.graph_edge_distance(1756, 'miles'),
    app.graph_get_out_edge_ids(743),
    app.graph_get_in_edge_ids(744)
)
(743,
 744,
 25.754,
 25.754,                  # meters is default
 0.025754000000000003,    # 25.75 / 1000
 0.0160062150410092,      # 25.75 / 1609
 [1755, 1756],            # includes test row id
 [1733, 1756])            # includes test row id
```


Closes #15.