### PR TITLE
parameterize frontier model at query time via service

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -32,7 +32,7 @@ impl SearchAlgorithm {
         destination: Option<VertexId>,
         graph: Arc<ExecutorReadOnlyLock<Graph>>,
         traversal_model: Arc<dyn TraversalModel>,
-        frontier_model: Arc<ExecutorReadOnlyLock<Box<dyn FrontierModel>>>,
+        frontier_model: Arc<dyn FrontierModel>,
         termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
     ) -> Result<MinSearchTree, SearchError> {
         match self {
@@ -52,7 +52,7 @@ impl SearchAlgorithm {
         destination: Option<EdgeId>,
         graph: Arc<ExecutorReadOnlyLock<Graph>>,
         traversal_model: Arc<dyn TraversalModel>,
-        frontier_model: Arc<ExecutorReadOnlyLock<Box<dyn FrontierModel>>>,
+        frontier_model: Arc<dyn FrontierModel>,
         termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
     ) -> Result<MinSearchTree, SearchError> {
         match self {

--- a/rust/routee-compass-core/src/model/frontier/default/no_restriction.rs
+++ b/rust/routee-compass-core/src/model/frontier/default/no_restriction.rs
@@ -1,5 +1,20 @@
-use crate::model::frontier::frontier_model::FrontierModel;
+use std::sync::Arc;
 
+use crate::model::frontier::{
+    frontier_model::FrontierModel, frontier_model_error::FrontierModelError,
+    frontier_model_service::FrontierModelService,
+};
+
+#[derive(Clone)]
 pub struct NoRestriction {}
 
 impl FrontierModel for NoRestriction {}
+
+impl FrontierModelService for NoRestriction {
+    fn build(
+        &self,
+        _query: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModel>, FrontierModelError> {
+        Ok(Arc::new(self.clone()))
+    }
+}

--- a/rust/routee-compass-core/src/model/frontier/default/road_class.rs
+++ b/rust/routee-compass-core/src/model/frontier/default/road_class.rs
@@ -1,25 +1,47 @@
+use std::sync::Arc;
+
 use crate::model::{
-    frontier::{frontier_model::FrontierModel, frontier_model_error::FrontierModelError},
+    frontier::{
+        frontier_model::FrontierModel, frontier_model_error::FrontierModelError,
+        frontier_model_service::FrontierModelService,
+    },
     property::edge::Edge,
     traversal::state::traversal_state::TraversalState,
 };
 
-pub struct RoadClassFrontierModel {
-    pub road_class_lookup: Vec<bool>,
+#[derive(Clone)]
+pub struct RoadClassFrontierService {
+    pub road_class_lookup: Arc<Vec<bool>>,
 }
 
-impl FrontierModel for RoadClassFrontierModel {
+pub struct RoadClassFrontier {
+    pub service: Arc<RoadClassFrontierService>,
+}
+
+impl FrontierModel for RoadClassFrontier {
     fn valid_frontier(
         &self,
         edge: &Edge,
         _state: &TraversalState,
     ) -> Result<bool, FrontierModelError> {
-        self.road_class_lookup
+        self.service
+            .road_class_lookup
             .get(edge.edge_id.0)
             .ok_or(FrontierModelError::MissingIndex(format!(
                 "{}",
                 edge.edge_id
             )))
             .cloned()
+    }
+}
+
+impl FrontierModelService for RoadClassFrontierService {
+    fn build(
+        &self,
+        _query: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModel>, FrontierModelError> {
+        let service: Arc<RoadClassFrontierService> = Arc::new(self.clone());
+        let model = RoadClassFrontier { service };
+        Ok(Arc::new(model))
     }
 }

--- a/rust/routee-compass-core/src/model/frontier/frontier_model_builder.rs
+++ b/rust/routee-compass-core/src/model/frontier/frontier_model_builder.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use super::{
+    frontier_model_error::FrontierModelError, frontier_model_service::FrontierModelService,
+};
+
+/// A [`FrontierModelBuilder`] takes a JSON object describing the configuration of a
+/// frontier model and builds a [FrontierModel].
+///
+/// A [`FrontierModelBuilder`] instance should be an empty struct that implements
+/// this trait.
+///
+/// [FrontierModel]: routee_compass_core::model::frontier::frontier_model::FrontierModel
+pub trait FrontierModelBuilder {
+    /// Builds a [FrontierModel] from JSON configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `parameters` - the contents of the "frontier" TOML config section
+    ///
+    /// # Returns
+    ///
+    /// A [FrontierModel] designed to persist the duration of the CompassApp.
+    ///
+    /// [FrontierModel]: routee_compass_core::model::frontier::frontier_model::FrontierModel
+    fn build(
+        &self,
+        parameters: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModelService>, FrontierModelError>;
+}

--- a/rust/routee-compass-core/src/model/frontier/frontier_model_error.rs
+++ b/rust/routee-compass-core/src/model/frontier/frontier_model_error.rs
@@ -1,7 +1,7 @@
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum FrontierModelError {
-    #[error("failure building frontier model")]
-    BuildError,
+    #[error("failure building frontier model: {0}")]
+    BuildError(String),
     #[error("edge id {0} missing from frontier model file")]
     MissingIndex(String),
 }

--- a/rust/routee-compass-core/src/model/frontier/frontier_model_service.rs
+++ b/rust/routee-compass-core/src/model/frontier/frontier_model_service.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use super::{frontier_model::FrontierModel, frontier_model_error::FrontierModelError};
+
+/// A [`FrontierModelService`] is a persistent builder of [FrontierModel] instances.
+/// Building a [`FrontierModelService`] may require parametrizing the frontier model
+/// based on the incoming query.
+/// The service then builds a [FrontierModel] instance for each route query.
+/// [`FrontierModelService`] must be read across the thread pool and so it implements
+/// Send and Sync.
+///
+/// [TraversalModel]: routee_compass_core::model::traversal::traversal_model::TraversalModel
+pub trait FrontierModelService: Send + Sync {
+    /// Builds a [FrontierModel] for the incoming query, used as parameters for this
+    /// build operation.
+    ///
+    /// The query is passed as parameters to this operation so that any query-time
+    /// coefficients may be applied to the [FrontierModel].
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - the incoming query which may contain parameters for building the [FrontierModel]
+    ///
+    /// # Returns
+    ///
+    /// The [FrontierModel] instance for this query, or an error
+    ///
+    /// [FrontierModel]: routee_compass_core::model::traversal::traversal_model::FrontierModel
+    fn build(
+        &self,
+        query: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModel>, FrontierModelError>;
+}

--- a/rust/routee-compass-core/src/model/frontier/frontier_model_service.rs
+++ b/rust/routee-compass-core/src/model/frontier/frontier_model_service.rs
@@ -9,7 +9,7 @@ use super::{frontier_model::FrontierModel, frontier_model_error::FrontierModelEr
 /// [`FrontierModelService`] must be read across the thread pool and so it implements
 /// Send and Sync.
 ///
-/// [TraversalModel]: routee_compass_core::model::traversal::traversal_model::TraversalModel
+/// [FrontierModel]: routee_compass_core::model::traversal::traversal_model::FrontierModel
 pub trait FrontierModelService: Send + Sync {
     /// Builds a [FrontierModel] for the incoming query, used as parameters for this
     /// build operation.

--- a/rust/routee-compass-core/src/model/frontier/mod.rs
+++ b/rust/routee-compass-core/src/model/frontier/mod.rs
@@ -1,3 +1,5 @@
 pub mod default;
 pub mod frontier_model;
+pub mod frontier_model_builder;
 pub mod frontier_model_error;
+pub mod frontier_model_service;

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -123,7 +123,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
         let frontier_start = Local::now();
         let frontier_params =
             config_json.get_config_section(CompassConfigurationField::Frontier)?;
-        let frontier_model = builder.build_frontier_model(frontier_params)?;
+        let frontier_model_service = builder.build_frontier_model_service(frontier_params)?;
         let frontier_duration = (Local::now() - frontier_start)
             .to_std()
             .map_err(|e| CompassAppError::InternalError(e.to_string()))?;
@@ -156,7 +156,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
             search_algorithm,
             graph,
             traversal_model_service,
-            frontier_model,
+            frontier_model_service,
             termination_model,
         );
         let search_app_duration = to_std(Local::now() - search_app_start)?;

--- a/rust/routee-compass/src/app/compass/compass_app_error.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_error.rs
@@ -7,7 +7,7 @@ use config::ConfigError;
 use routee_compass_core::{
     algorithm::search::search_error::SearchError,
     model::{
-        road_network::graph_error::GraphError,
+        frontier::frontier_model_error::FrontierModelError, road_network::graph_error::GraphError,
         traversal::traversal_model_error::TraversalModelError,
     },
 };
@@ -16,6 +16,8 @@ use routee_compass_core::{
 pub enum CompassAppError {
     #[error(transparent)]
     SearchError(#[from] SearchError),
+    #[error(transparent)]
+    FrontierModelError(#[from] FrontierModelError),
     #[error(transparent)]
     TraversalModelError(#[from] TraversalModelError),
     #[error(transparent)]

--- a/rust/routee-compass/src/app/compass/config/builders.rs
+++ b/rust/routee-compass/src/app/compass/config/builders.rs
@@ -1,31 +1,5 @@
 use super::compass_configuration_error::CompassConfigurationError;
 use crate::plugin::{input::input_plugin::InputPlugin, output::output_plugin::OutputPlugin};
-use routee_compass_core::model::frontier::frontier_model::FrontierModel;
-
-/// A [`FrontierModelBuilder`] takes a JSON object describing the configuration of a
-/// frontier model and builds a [FrontierModel].
-///
-/// A [`FrontierModelBuilder`] instance should be an empty struct that implements
-/// this trait.
-///
-/// [FrontierModel]: compass_core::model::frontier::frontier_model::FrontierModel
-pub trait FrontierModelBuilder {
-    /// Builds a [FrontierModel] from JSON configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - the contents of the "frontier" TOML config section
-    ///
-    /// # Returns
-    ///
-    /// A [FrontierModel] designed to persist the duration of the CompassApp.
-    ///
-    /// [FrontierModel]: compass_core::model::frontier::frontier_model::FrontierModel
-    fn build(
-        &self,
-        parameters: &serde_json::Value,
-    ) -> Result<Box<dyn FrontierModel>, CompassConfigurationError>;
-}
 
 /// A [`InputPluginBuilder`] takes a JSON object describing the configuration of an
 /// input plugin and builds a [InputPlugin].

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
@@ -2,7 +2,7 @@ use crate::plugin::plugin_error::PluginError;
 use config::ConfigError;
 use routee_compass_core::{
     model::{
-        road_network::graph_error::GraphError,
+        frontier::frontier_model_error::FrontierModelError, road_network::graph_error::GraphError,
         traversal::traversal_model_error::TraversalModelError,
     },
     util::conversion::conversion_error::ConversionError,
@@ -63,6 +63,8 @@ pub enum CompassConfigurationError {
     ConversionError(#[from] ConversionError),
     #[error(transparent)]
     TraversalModelError(#[from] TraversalModelError),
+    #[error(transparent)]
+    FrontierModelError(#[from] FrontierModelError),
     #[error(transparent)]
     PluginError(#[from] PluginError),
 }

--- a/rust/routee-compass/src/app/compass/config/frontier_model/no_restriction_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/no_restriction_builder.rs
@@ -1,10 +1,8 @@
 use routee_compass_core::model::frontier::{
-    default::no_restriction::NoRestriction, frontier_model::FrontierModel,
+    default::no_restriction::NoRestriction, frontier_model_builder::FrontierModelBuilder,
+    frontier_model_error::FrontierModelError, frontier_model_service::FrontierModelService,
 };
-
-use crate::app::compass::config::{
-    builders::FrontierModelBuilder, compass_configuration_error::CompassConfigurationError,
-};
+use std::sync::Arc;
 
 pub struct NoRestrictionBuilder {}
 
@@ -12,7 +10,7 @@ impl FrontierModelBuilder for NoRestrictionBuilder {
     fn build(
         &self,
         _parameters: &serde_json::Value,
-    ) -> Result<Box<dyn FrontierModel>, CompassConfigurationError> {
-        Ok(Box::new(NoRestriction {}))
+    ) -> Result<Arc<dyn FrontierModelService>, FrontierModelError> {
+        Ok(Arc::new(NoRestriction {}))
     }
 }

--- a/rust/routee-compass/src/app/compass/config/frontier_model/road_class_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/road_class_builder.rs
@@ -1,13 +1,16 @@
 use crate::app::compass::config::{
-    builders::FrontierModelBuilder, compass_configuration_error::CompassConfigurationError,
     compass_configuration_field::CompassConfigurationField,
     config_json_extension::ConfigJsonExtensions,
 };
 use routee_compass_core::{
-    model::frontier::{default::road_class::RoadClassFrontierModel, frontier_model::FrontierModel},
+    model::frontier::{
+        default::road_class::RoadClassFrontierService,
+        frontier_model_builder::FrontierModelBuilder, frontier_model_error::FrontierModelError,
+        frontier_model_service::FrontierModelService,
+    },
     util::fs::{read_decoders, read_utils},
 };
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 pub struct RoadClassBuilder {}
 
@@ -15,22 +18,43 @@ impl FrontierModelBuilder for RoadClassBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn FrontierModel>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn FrontierModelService>, FrontierModelError> {
         let frontier_key = CompassConfigurationField::Frontier.to_string();
         let road_class_file_key = String::from("road_class_input_file");
         let valid_road_class_key = String::from("valid_road_classes");
 
-        let road_class_file =
-            parameters.get_config_path(road_class_file_key.clone(), frontier_key.clone())?;
+        let road_class_file = parameters
+            .get_config_path(road_class_file_key.clone(), frontier_key.clone())
+            .map_err(|e| {
+                FrontierModelError::BuildError(format!(
+                    "configuration error due to {}: {}",
+                    road_class_file_key.clone(),
+                    e
+                ))
+            })?;
 
         let road_classes_vec = parameters
-            .get_config_serde::<Vec<String>>(valid_road_class_key.clone(), frontier_key.clone())?;
+            .get_config_serde::<Vec<String>>(valid_road_class_key.clone(), frontier_key.clone())
+            .map_err(|e| {
+                FrontierModelError::BuildError(format!(
+                    "configuration error due to {}: {}",
+                    valid_road_class_key.clone(),
+                    e
+                ))
+            })?;
         let road_classes: HashSet<String> = HashSet::from_iter(road_classes_vec.to_vec());
 
         log::debug!("valid road classes (raw/hashset): {:?}", road_classes_vec);
 
         let road_class_lookup: Vec<bool> =
-            read_utils::read_raw_file(road_class_file, read_decoders::string, None)?
+            read_utils::read_raw_file(road_class_file.clone(), read_decoders::string, None)
+                .map_err(|e| {
+                    FrontierModelError::BuildError(format!(
+                        "failed to load file at {:?}: {}",
+                        road_class_file.clone().to_str(),
+                        e
+                    ))
+                })?
                 .iter()
                 .map(|rc| road_classes.contains(rc.trim()))
                 .collect();
@@ -42,7 +66,9 @@ impl FrontierModelBuilder for RoadClassBuilder {
             road_class_lookup.len()
         );
 
-        let m: Box<dyn FrontierModel> = Box::new(RoadClassFrontierModel { road_class_lookup });
+        let m: Arc<dyn FrontierModelService> = Arc::new(RoadClassFrontierService {
+            road_class_lookup: Arc::new(road_class_lookup),
+        });
         Ok(m)
     }
 }


### PR DESCRIPTION
this PR done as part of the MEP task sets up FrontierModels to have the same kind of query-time parameterization as TraversalModels do. this will open up frontier rules for MEP queries so that, at query time, we can restrict roadways based on travel mode (walk, bike, drive).