### PR TITLE
inject input plugin

### DIFF
--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -15,8 +15,8 @@ use crate::plugin::{
     input::{
         default::{
             edge_rtree::edge_rtree_input_plugin_builder::EdgeRtreeInputPluginBuilder,
-            grid_search::builder::GridSearchBuilder, load_balancer::builder::LoadBalancerBuilder,
-            vertex_rtree::builder::VertexRTreeBuilder,
+            grid_search::builder::GridSearchBuilder, inject::inject_builder::InjectPluginBuilder,
+            load_balancer::builder::LoadBalancerBuilder, vertex_rtree::builder::VertexRTreeBuilder,
         },
         input_plugin::InputPlugin,
     },
@@ -138,11 +138,13 @@ impl CompassAppBuilder {
         let vertex_tree: Box<dyn InputPluginBuilder> = Box::new(VertexRTreeBuilder {});
         let edge_rtree: Box<dyn InputPluginBuilder> = Box::new(EdgeRtreeInputPluginBuilder {});
         let load_balancer: Box<dyn InputPluginBuilder> = Box::new(LoadBalancerBuilder {});
+        let inject: Box<dyn InputPluginBuilder> = Box::new(InjectPluginBuilder {});
         let input_plugin_builders = HashMap::from([
             (String::from("grid_search"), grid_search),
             (String::from("vertex_rtree"), vertex_tree),
             (String::from("edge_rtree"), edge_rtree),
             (String::from("load_balancer"), load_balancer),
+            (String::from("inject"), inject),
         ]);
 
         // Output plugin builders

--- a/rust/routee-compass/src/plugin/input/default/inject/inject_builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/inject_builder.rs
@@ -1,0 +1,26 @@
+use super::inject_format::InjectFormat;
+use crate::{
+    app::compass::config::{
+        builders::InputPluginBuilder, compass_configuration_error::CompassConfigurationError,
+        config_json_extension::ConfigJsonExtensions,
+    },
+    plugin::input::{default::inject::inject_plugin::InjectInputPlugin, input_plugin::InputPlugin},
+};
+
+pub struct InjectPluginBuilder {}
+
+impl InputPluginBuilder for InjectPluginBuilder {
+    fn build(
+        &self,
+        parameters: &serde_json::Value,
+    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
+        let key = parameters.get_config_string(String::from("key"), String::from("inject"))?;
+        let value_string =
+            parameters.get_config_string(String::from("value"), String::from("inject"))?;
+        let format: InjectFormat =
+            parameters.get_config_serde(String::from("format"), String::from("inject"))?;
+        let value = format.to_json(&value_string)?;
+        let plugin = InjectInputPlugin::new(key, value);
+        Ok(Box::new(plugin))
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/inject/inject_format.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/inject_format.rs
@@ -1,0 +1,41 @@
+use routee_compass_core::util::serde_ops;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    app::compass::config::compass_configuration_error::CompassConfigurationError,
+    plugin::plugin_error::PluginError,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum InjectFormat {
+    String,
+    Json,
+    Toml,
+}
+
+impl InjectFormat {
+    pub fn to_json(&self, value: &str) -> Result<serde_json::Value, CompassConfigurationError> {
+        match self {
+            InjectFormat::String => {
+                let decode_result = serde_ops::string_deserialize(value);
+                decode_result.map_err(|e| {
+                    CompassConfigurationError::PluginError(PluginError::InputError(format!(
+                        "could not deserialize inject value as string: {}",
+                        e
+                    )))
+                })
+            }
+            InjectFormat::Json => {
+                let result = serde_json::from_str(value);
+                result.map_err(|e| {
+                    CompassConfigurationError::PluginError(PluginError::InputError(format!(
+                        "could not deserialize inject value as JSON: {}",
+                        e
+                    )))
+                })
+            }
+            InjectFormat::Toml => todo!(),
+        }
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/inject/inject_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/inject_plugin.rs
@@ -1,0 +1,28 @@
+use serde_json::json;
+
+use crate::plugin::{input::input_plugin::InputPlugin, plugin_error::PluginError};
+
+pub struct InjectInputPlugin {
+    key: String,
+    value: serde_json::Value,
+}
+
+impl InjectInputPlugin {
+    pub fn new(key: String, value: serde_json::Value) -> InjectInputPlugin {
+        InjectInputPlugin { key, value }
+    }
+}
+
+impl InputPlugin for InjectInputPlugin {
+    fn process(&self, input: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
+        let mut updated_obj = input.clone();
+        let updated = updated_obj
+            .as_object_mut()
+            .ok_or(PluginError::InternalError(format!(
+                "expected input JSON to be an object, found {}",
+                input
+            )))?;
+        updated.insert(self.key.clone(), self.value.clone());
+        Ok(vec![json!(updated)])
+    }
+}

--- a/rust/routee-compass/src/plugin/input/default/inject/mod.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/mod.rs
@@ -1,0 +1,3 @@
+pub mod inject_builder;
+pub mod inject_format;
+pub mod inject_plugin;

--- a/rust/routee-compass/src/plugin/input/default/mod.rs
+++ b/rust/routee-compass/src/plugin/input/default/mod.rs
@@ -1,4 +1,5 @@
 pub mod edge_rtree;
 pub mod grid_search;
+pub mod inject;
 pub mod load_balancer;
 pub mod vertex_rtree;


### PR DESCRIPTION
this MEP task improvement is so that i can inject something i want to appear in _every_ query for some input file.

i have 12501226 rows of queries covering every US state. i want to keep that dataset small as possible, but i also want to append this hulking JSON value as the `grid_search`: `{"modes":[{"mode":"walk","road_classes":["4","5","6","7"]},{"mode":"bike","road_classes":["4","5","6","7"]},{"mode":"drive","road_classes":["1","2","3","4","5","6"]}]}`.

this plugin allows me to specify some key and value to inject into each input query. usage looks like this:

```toml
[[plugin.input_plugins]]
type = "inject"
key = "grid_search"
value = '{"modes":[{"mode":"walk","road_classes":["4","5","6","7"]},{"mode":"bike","road_classes":["4","5","6","7"]},{"mode":"drive","road_classes":["1","2","3","4","5","6"]}]}'
format = "json"
```
