### PR TITLE
Rjf/search orientation

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_distance.toml
+++ b/python/nrel/routee/compass/resources/osm_default_distance.toml
@@ -1,4 +1,5 @@
 parallelism = 2
+search_orientation = "vertex"
 
 [graph]
 edge_list_input_file = "edges-compass.csv.gz"

--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -1,4 +1,5 @@
 parallelism = 2
+search_orientation = "vertex"
 
 [graph]
 edge_list_input_file = "edges-compass.csv.gz"

--- a/python/nrel/routee/compass/resources/osm_default_speed.toml
+++ b/python/nrel/routee/compass/resources/osm_default_speed.toml
@@ -1,4 +1,5 @@
 parallelism = 2
+search_orientation = "vertex"
 
 [graph]
 edge_list_input_file = "edges-compass.csv.gz"

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -324,7 +324,7 @@ mod tests {
 
     use super::*;
     use crate::algorithm::search::backtrack::vertex_oriented_route;
-    use crate::model::frontier::default::no_restriction::{self, NoRestriction};
+    use crate::model::frontier::default::no_restriction::{NoRestriction};
     use crate::model::property::edge::Edge;
     use crate::model::property::vertex::Vertex;
     use crate::model::road_network::graph::Graph;

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -324,7 +324,7 @@ mod tests {
 
     use super::*;
     use crate::algorithm::search::backtrack::vertex_oriented_route;
-    use crate::model::frontier::default::no_restriction::{NoRestriction};
+    use crate::model::frontier::default::no_restriction::NoRestriction;
     use crate::model::property::edge::Edge;
     use crate::model::property::vertex::Vertex;
     use crate::model::road_network::graph::Graph;

--- a/rust/routee-compass-py/src/app_wrapper.rs
+++ b/rust/routee-compass-py/src/app_wrapper.rs
@@ -2,13 +2,10 @@ use std::path::Path;
 
 use crate::app_graph_ops as ops;
 use pyo3::{exceptions::PyException, prelude::*, types::PyType};
-use routee_compass::app::{
-    compass::{
-        compass_app::CompassApp, compass_app_ops::read_config_from_string,
-        config::compass_app_builder::CompassAppBuilder,
-    },
+use routee_compass::app::compass::{
+    compass_app::CompassApp, compass_app_ops::read_config_from_string,
+    config::compass_app_builder::CompassAppBuilder,
 };
-
 
 #[pyclass]
 pub struct CompassAppWrapper {

--- a/rust/routee-compass-py/src/app_wrapper.rs
+++ b/rust/routee-compass-py/src/app_wrapper.rs
@@ -7,9 +7,8 @@ use routee_compass::app::{
         compass_app::CompassApp, compass_app_ops::read_config_from_string,
         config::compass_app_builder::CompassAppBuilder,
     },
-    search::search_app_graph_ops::SearchAppGraphOps,
 };
-use routee_compass_core::model::road_network::edge_id::EdgeId;
+
 
 #[pyclass]
 pub struct CompassAppWrapper {

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -180,6 +180,12 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
         let search_orientation = config
             .get::<SearchOrientation>(CompassConfigurationField::SearchOrientation.to_str())?;
 
+        log::info!(
+            "additional parameters - parallelism={}, search orientation={:?}",
+            parallelism,
+            search_orientation
+        );
+
         Ok(CompassApp {
             search_app,
             input_plugins,

--- a/rust/routee-compass/src/app/compass/config.default.toml
+++ b/rust/routee-compass/src/app/compass/config.default.toml
@@ -1,4 +1,5 @@
 parallelism = 2
+search_orientation = "vertex"
 
 [graph]
 verbose = true

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
@@ -15,6 +15,7 @@ pub enum CompassConfigurationField {
     IncludeTree,
     ChargeDepleting,
     ChargeSustaining,
+    SearchOrientation,
 }
 
 impl CompassConfigurationField {
@@ -33,6 +34,7 @@ impl CompassConfigurationField {
             CompassConfigurationField::OutputPlugins => "output_plugins",
             CompassConfigurationField::ChargeDepleting => "charge_depleting",
             CompassConfigurationField::ChargeSustaining => "charge_sustaining",
+            CompassConfigurationField::SearchOrientation => "search_orientation",
         }
     }
 }

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -5,3 +5,4 @@ pub mod compass_app_ops;
 pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod config;
+pub mod search_orientation;

--- a/rust/routee-compass/src/app/compass/search_orientation.rs
+++ b/rust/routee-compass/src/app/compass/search_orientation.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchOrientation {
+    Vertex,
+    Edge,
+}


### PR DESCRIPTION
this PR introduces a top-level configuration key "search_orientation" into the compass configuration file which explicitly determines which sort of search app we are running: "vertex" or "edge". the field is not optional but the config.default.toml file provides a default of "vertex".

Closes #68.