### PR TITLE
LRU Cache

### DIFF
--- a/rust/routee-compass-core/Cargo.toml
+++ b/rust/routee-compass-core/Cargo.toml
@@ -20,6 +20,7 @@ geo = { workspace = true }
 ordered-float = { workspace = true }
 derive_more = "0.99.0"
 priority-queue = "1.3.2"
+lru = "0.12"
 csv = { workspace = true }
 kdam = { workspace = true }
 log = { workspace = true }

--- a/rust/routee-compass-core/src/model/traversal/traversal_model_error.rs
+++ b/rust/routee-compass-core/src/model/traversal/traversal_model_error.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use super::state::traversal_state::TraversalState;
+use crate::util::cache_policy::cache_error::CacheError;
 use crate::util::unit::UnitError;
 
 #[derive(thiserror::Error, Debug)]
@@ -19,6 +20,8 @@ pub enum TraversalModelError {
     InternalError(String),
     #[error(transparent)]
     TraversalUnitsError(#[from] UnitError),
+    #[error(transparent)]
+    CacheError(#[from] CacheError),
     #[error("prediction model failed with error {0}")]
     PredictionModel(String),
 }

--- a/rust/routee-compass-core/src/util/cache_policy/cache_error.rs
+++ b/rust/routee-compass-core/src/util/cache_policy/cache_error.rs
@@ -1,0 +1,7 @@
+#[derive(thiserror::Error, Debug)]
+pub enum CacheError {
+    #[error("Could not build cache policy due to {0}")]
+    BuildError(String),
+    #[error("Could not get value from cache due to {0}")]
+    RuntimeError(String),
+}

--- a/rust/routee-compass-core/src/util/cache_policy/float_cache_policy.rs
+++ b/rust/routee-compass-core/src/util/cache_policy/float_cache_policy.rs
@@ -1,0 +1,132 @@
+use std::{num::NonZeroUsize, sync::Mutex};
+
+use lru::LruCache;
+use serde::{Deserialize, Serialize};
+
+use super::cache_error::CacheError;
+
+fn to_precision(value: f64, precision: usize) -> i64 {
+    let multiplier = 10f64.powi(precision as i32);
+    (value * multiplier).round() as i64
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FloatCachePolicyConfig {
+    pub cache_size: usize,
+    pub key_precisions: Vec<usize>,
+}
+
+/// A cache policy that uses a float key to store a float value
+/// The key is rounded to the specified precision.
+///
+/// # Example
+///
+/// ```
+/// use routee_compass_core::util::cache_policy::float_cache_policy::{FloatCachePolicy, FloatCachePolicyConfig};
+/// use std::num::NonZeroUsize;
+///
+/// let config = FloatCachePolicyConfig {
+///    cache_size: 100,
+///    key_precisions: vec![2, 2],
+/// };
+///
+/// let cache_policy = FloatCachePolicy::from_config(config).unwrap();
+///
+/// // stores keys as [123, 235]
+/// cache_policy.update(&[1.234, 2.345], 3.456).unwrap();
+///
+/// let value = cache_policy.get(&[1.234, 2.345]).unwrap().unwrap();
+/// assert_eq!(value, 3.456);
+///
+/// // 1.233 rounds to 123
+/// let value = cache_policy.get(&[1.233, 2.345]).unwrap().unwrap();
+/// assert_eq!(value, 3.456);
+///
+/// // 1.2 rounds to 120
+/// let value = cache_policy.get(&[1.2, 2.345]).unwrap();
+/// assert_eq!(value, None);
+///
+/// // 2.344 rounds to 234
+/// let value = cache_policy.get(&[1.234, 2.344]).unwrap();
+/// assert_eq!(value, None);
+pub struct FloatCachePolicy {
+    cache: Mutex<LruCache<Vec<i64>, f64>>,
+    key_precisions: Vec<usize>,
+}
+
+impl FloatCachePolicy {
+    pub fn from_config(config: FloatCachePolicyConfig) -> Result<Self, CacheError> {
+        let size = NonZeroUsize::new(config.cache_size).ok_or(CacheError::BuildError(
+            "maximum_cache_size must be greater than 0".to_string(),
+        ))?;
+        let cache = Mutex::new(LruCache::new(size));
+        for precision in config.key_precisions.iter() {
+            if *precision > 10 {
+                return Err(CacheError::BuildError(
+                    "key_precision must be less than 10".to_string(),
+                ));
+            }
+        }
+        Ok(Self {
+            cache,
+            key_precisions: config.key_precisions,
+        })
+    }
+
+    pub fn float_key_to_int_key(&self, key: &[f64]) -> Vec<i64> {
+        key.iter()
+            .zip(self.key_precisions.iter())
+            .map(|(v, p)| to_precision(*v, *p))
+            .collect()
+    }
+
+    pub fn get(&self, key: &[f64]) -> Result<Option<f64>, CacheError> {
+        let int_key = self.float_key_to_int_key(key);
+        let mut cache = self.cache.lock().map_err(|e| {
+            CacheError::RuntimeError(format!("Could not get lock on cache due to {}", e))
+        })?;
+        Ok(cache.get(&int_key).copied())
+    }
+
+    pub fn update(&self, key: &[f64], value: f64) -> Result<(), CacheError> {
+        let int_key = self.float_key_to_int_key(key);
+        let mut cache = self.cache.lock().map_err(|e| {
+            CacheError::RuntimeError(format!("Could not get lock on cache due to {}", e))
+        })?;
+        cache.put(int_key, value);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_float_cache_policy() {
+        let config = FloatCachePolicyConfig {
+            cache_size: 100,
+            key_precisions: vec![2, 2],
+        };
+
+        let cache_policy = FloatCachePolicy::from_config(config).unwrap();
+
+        // should store keys as [123, 235]
+        cache_policy.update(&[1.234, 2.345], 3.456).unwrap();
+
+        let value = cache_policy.get(&[1.234, 2.345]).unwrap().unwrap();
+        assert_eq!(value, 3.456);
+
+        // 1.233 rounds to 123
+        let value = cache_policy.get(&[1.233, 2.345]).unwrap().unwrap();
+        assert_eq!(value, 3.456);
+
+        // 1.2 rounds to 120
+        let value = cache_policy.get(&[1.2, 2.345]).unwrap();
+        assert_eq!(value, None);
+
+        // 2.344 rounds to 234
+        let value = cache_policy.get(&[1.234, 2.344]).unwrap();
+        assert_eq!(value, None);
+    }
+}

--- a/rust/routee-compass-core/src/util/cache_policy/mod.rs
+++ b/rust/routee-compass-core/src/util/cache_policy/mod.rs
@@ -1,0 +1,2 @@
+pub mod cache_error;
+pub mod float_cache_policy;

--- a/rust/routee-compass-core/src/util/mod.rs
+++ b/rust/routee-compass-core/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache_policy;
 pub mod conversion;
 pub mod duration_extension;
 pub mod fs;

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -23,15 +23,9 @@ serde_repr = "0.1"
 serde_json = { workspace = true }
 ndarray = "0.15"
 ort = { version = "2.0.0-alpha.2", optional = true }
+lru = { version = "0.12" }
 rayon = { workspace = true }
 
 [features]
 default = ["onnx"]
-onnx = ["ort", "ureq", "flate2", "tar", "zip", "sha256"]
-
-[build-dependencies]
-sha256 = { version = "1.4", optional = true }
-ureq = { version = "2.9", optional = true }
-flate2 = { workspace = true, optional = true }
-tar = { version = "0.4", optional = true }
-zip = { version = "0.6", optional = true }
+onnx = ["ort"]

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -23,7 +23,6 @@ serde_repr = "0.1"
 serde_json = { workspace = true }
 ndarray = "0.15"
 ort = { version = "2.0.0-alpha.2", optional = true }
-lru = { version = "0.12" }
 rayon = { workspace = true }
 
 [features]

--- a/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
@@ -280,6 +280,7 @@ mod tests {
             EnergyRateUnit::GallonsGasolinePerMile,
             None,
             None,
+            None,
         )
         .unwrap();
 

--- a/rust/routee-compass-powertrain/src/routee/prediction/onnx/onnx_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/onnx/onnx_speed_grade_model.rs
@@ -23,6 +23,7 @@ impl PredictionModel for OnnxSpeedGradeModel {
     ) -> Result<(EnergyRate, EnergyRateUnit), TraversalModelError> {
         let (speed, speed_unit) = speed;
         let (grade, grade_unit) = grade;
+
         let speed_value: f32 = speed_unit.convert(speed, self.speed_unit).as_f64() as f32;
         let grade_value: f32 = grade_unit.convert(grade, self.grade_unit).as_f64() as f32;
         let array = ndarray::Array1::from(vec![speed_value, grade_value])

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
@@ -1,10 +1,9 @@
 use std::{
-    num::NonZeroUsize,
     path::Path,
-    sync::{Arc, Mutex},
+    sync::{Arc},
 };
 
-use lru::LruCache;
+
 use routee_compass_core::{
     model::traversal::traversal_model_error::TraversalModelError,
     util::unit::{EnergyRate, EnergyRateUnit, Grade, GradeUnit, Speed, SpeedUnit},

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
@@ -1,8 +1,4 @@
-use std::{
-    path::Path,
-    sync::{Arc},
-};
-
+use std::{path::Path, sync::Arc};
 
 use routee_compass_core::{
     model::traversal::traversal_model_error::TraversalModelError,

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
@@ -2,7 +2,10 @@ use std::{path::Path, sync::Arc};
 
 use routee_compass_core::{
     model::traversal::traversal_model_error::TraversalModelError,
-    util::unit::{EnergyRate, EnergyRateUnit, Grade, GradeUnit, Speed, SpeedUnit},
+    util::{
+        cache_policy::float_cache_policy::FloatCachePolicy,
+        unit::{EnergyRate, EnergyRateUnit, Grade, GradeUnit, Speed, SpeedUnit},
+    },
 };
 
 use super::{
@@ -15,7 +18,7 @@ use crate::routee::prediction::onnx::onnx_speed_grade_model::OnnxSpeedGradeModel
 
 #[allow(clippy::too_many_arguments)]
 pub fn load_prediction_model<P: AsRef<Path>>(
-    model_name: String,
+    name: String,
     model_path: &P,
     model_type: ModelType,
     speed_unit: SpeedUnit,
@@ -23,7 +26,7 @@ pub fn load_prediction_model<P: AsRef<Path>>(
     energy_rate_unit: EnergyRateUnit,
     ideal_energy_rate_option: Option<EnergyRate>,
     real_world_energy_adjustment_option: Option<f64>,
-    max_cache_size: Option<usize>,
+    cache: Option<FloatCachePolicy>,
 ) -> Result<PredictionModelRecord, TraversalModelError> {
     let prediction_model: Arc<dyn PredictionModel> = match model_type {
         ModelType::Smartcore => {
@@ -58,8 +61,8 @@ pub fn load_prediction_model<P: AsRef<Path>>(
 
     let real_world_energy_adjustment = real_world_energy_adjustment_option.unwrap_or(1.0);
 
-    PredictionModelRecord::new(
-        model_name,
+    Ok(PredictionModelRecord {
+        name,
         prediction_model,
         model_type,
         speed_unit,
@@ -67,8 +70,8 @@ pub fn load_prediction_model<P: AsRef<Path>>(
         energy_rate_unit,
         ideal_energy_rate,
         real_world_energy_adjustment,
-        max_cache_size,
-    )
+        cache,
+    })
 }
 
 /// sweep a fixed set of speed and grade values to find the minimum energy per mile rate from the incoming rf model

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_record.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_record.rs
@@ -23,10 +23,11 @@ pub struct PredictionModelRecord {
     pub energy_rate_unit: EnergyRateUnit,
     pub ideal_energy_rate: EnergyRate,
     pub real_world_energy_adjustment: f64,
-    cache: Mutex<LruCache<(i32, i32), EnergyRate>>,
+    cache: Option<Mutex<LruCache<(i32, i32), EnergyRate>>>,
 }
 
 impl PredictionModelRecord {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
         prediction_model: Arc<dyn PredictionModel>,
@@ -38,12 +39,17 @@ impl PredictionModelRecord {
         real_world_energy_adjustment: f64,
         max_cache_size: Option<usize>,
     ) -> Result<Self, TraversalModelError> {
-        let max_cache_size = NonZeroUsize::new(max_cache_size.unwrap_or(10000)).ok_or(
-            TraversalModelError::BuildError(
-                "maximum_cache_size must be greater than 0".to_string(),
-            ),
-        )?;
-        let cache = LruCache::new(max_cache_size);
+        let cache = match max_cache_size {
+            Some(s) => {
+                let size = NonZeroUsize::new(s).ok_or(TraversalModelError::BuildError(
+                    "maximum_cache_size must be greater than 0".to_string(),
+                ))?;
+                let cache = LruCache::new(size);
+                Some(Mutex::new(cache))
+            }
+            None => None,
+        };
+
         Ok(Self {
             name,
             prediction_model,
@@ -53,7 +59,7 @@ impl PredictionModelRecord {
             energy_rate_unit,
             ideal_energy_rate,
             real_world_energy_adjustment,
-            cache: Mutex::new(cache),
+            cache,
         })
     }
     pub fn predict(
@@ -63,25 +69,37 @@ impl PredictionModelRecord {
         distance: (Distance, DistanceUnit),
     ) -> Result<(Energy, EnergyUnit), TraversalModelError> {
         let (distance, distance_unit) = distance;
-        // convert speed to kph and then round to nearest integer
-        let speed_kph_int = speed
-            .1
-            .convert(speed.0, SpeedUnit::KilometersPerHour)
-            .as_f64()
-            .round() as i32;
-        let grade_millis_int = grade.1.convert(grade.0, GradeUnit::Millis).as_f64().round() as i32;
 
-        let mut cache = self.cache.lock().unwrap();
-        let energy_rate = match cache.get(&(speed_kph_int, grade_millis_int)) {
-            Some(er) => *er,
+        let energy_rate = match &self.cache {
+            Some(cache) => {
+                // convert speed to kph and then round to nearest integer
+                let speed_kph_int = speed
+                    .1
+                    .convert(speed.0, SpeedUnit::KilometersPerHour)
+                    .as_f64()
+                    .round() as i32;
+                let grade_millis_int =
+                    grade.1.convert(grade.0, GradeUnit::Millis).as_f64().round() as i32;
+
+                let mut cache = cache.lock().unwrap();
+                let energy_rate = match cache.get(&(speed_kph_int, grade_millis_int)) {
+                    Some(er) => *er,
+                    None => {
+                        let (energy_rate, _energy_rate_unit) =
+                            self.prediction_model.predict(speed, grade)?;
+                        energy_rate
+                    }
+                };
+                cache.put((speed_kph_int, grade_millis_int), energy_rate);
+                std::mem::drop(cache);
+                energy_rate
+            }
             None => {
                 let (energy_rate, _energy_rate_unit) =
                     self.prediction_model.predict(speed, grade)?;
                 energy_rate
             }
         };
-        cache.put((speed_kph_int, grade_millis_int), energy_rate);
-        std::mem::drop(cache);
 
         let energy_rate_real_world = energy_rate * self.real_world_energy_adjustment;
 

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_record.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_record.rs
@@ -1,10 +1,14 @@
-use std::sync::Arc;
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+};
 
+use lru::LruCache;
 use routee_compass_core::{
     model::traversal::traversal_model_error::TraversalModelError,
     util::unit::{
-        Distance, DistanceUnit, Energy, EnergyRate, EnergyRateUnit, EnergyUnit, Grade, GradeUnit,
-        Speed, SpeedUnit,
+        as_f64::AsF64, Distance, DistanceUnit, Energy, EnergyRate, EnergyRateUnit, EnergyUnit,
+        Grade, GradeUnit, Speed, SpeedUnit,
     },
 };
 
@@ -19,9 +23,39 @@ pub struct PredictionModelRecord {
     pub energy_rate_unit: EnergyRateUnit,
     pub ideal_energy_rate: EnergyRate,
     pub real_world_energy_adjustment: f64,
+    cache: Mutex<LruCache<(i32, i32), EnergyRate>>,
 }
 
 impl PredictionModelRecord {
+    pub fn new(
+        name: String,
+        prediction_model: Arc<dyn PredictionModel>,
+        model_type: ModelType,
+        speed_unit: SpeedUnit,
+        grade_unit: GradeUnit,
+        energy_rate_unit: EnergyRateUnit,
+        ideal_energy_rate: EnergyRate,
+        real_world_energy_adjustment: f64,
+        max_cache_size: Option<usize>,
+    ) -> Result<Self, TraversalModelError> {
+        let max_cache_size = NonZeroUsize::new(max_cache_size.unwrap_or(10000)).ok_or(
+            TraversalModelError::BuildError(
+                "maximum_cache_size must be greater than 0".to_string(),
+            ),
+        )?;
+        let cache = LruCache::new(max_cache_size);
+        Ok(Self {
+            name,
+            prediction_model,
+            model_type,
+            speed_unit,
+            grade_unit,
+            energy_rate_unit,
+            ideal_energy_rate,
+            real_world_energy_adjustment,
+            cache: Mutex::new(cache),
+        })
+    }
     pub fn predict(
         &self,
         speed: (Speed, SpeedUnit),
@@ -29,7 +63,25 @@ impl PredictionModelRecord {
         distance: (Distance, DistanceUnit),
     ) -> Result<(Energy, EnergyUnit), TraversalModelError> {
         let (distance, distance_unit) = distance;
-        let (energy_rate, _energy_rate_unit) = self.prediction_model.predict(speed, grade)?;
+        // convert speed to kph and then round to nearest integer
+        let speed_kph_int = speed
+            .1
+            .convert(speed.0, SpeedUnit::KilometersPerHour)
+            .as_f64()
+            .round() as i32;
+        let grade_millis_int = grade.1.convert(grade.0, GradeUnit::Millis).as_f64().round() as i32;
+
+        let mut cache = self.cache.lock().unwrap();
+        let energy_rate = match cache.get(&(speed_kph_int, grade_millis_int)) {
+            Some(er) => *er,
+            None => {
+                let (energy_rate, _energy_rate_unit) =
+                    self.prediction_model.predict(speed, grade)?;
+                energy_rate
+            }
+        };
+        cache.put((speed_kph_int, grade_millis_int), energy_rate);
+        std::mem::drop(cache);
 
         let energy_rate_real_world = energy_rate * self.real_world_energy_adjustment;
 
@@ -39,6 +91,7 @@ impl PredictionModelRecord {
             distance,
             distance_unit,
         )?;
+
         Ok((energy, energy_unit))
     }
 }

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/dual_fuel_vehicle.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/dual_fuel_vehicle.rs
@@ -299,6 +299,7 @@ mod tests {
             EnergyRateUnit::GallonsGasolinePerMile,
             Some(EnergyRate::new(0.02)),
             Some(1.1252),
+            None,
         )
         .unwrap();
         let charge_depleting_model_record = load_prediction_model(
@@ -310,6 +311,7 @@ mod tests {
             EnergyRateUnit::KilowattHoursPerMile,
             Some(EnergyRate::new(0.2)),
             Some(1.3958),
+            None,
         )
         .unwrap();
 

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_error.rs
@@ -5,7 +5,7 @@ use routee_compass_core::{
         frontier::frontier_model_error::FrontierModelError, road_network::graph_error::GraphError,
         traversal::traversal_model_error::TraversalModelError,
     },
-    util::conversion::conversion_error::ConversionError,
+    util::{cache_policy::cache_error::CacheError, conversion::conversion_error::ConversionError},
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -61,6 +61,8 @@ pub enum CompassConfigurationError {
     SerdeDeserializationError(#[from] serde_json::Error),
     #[error(transparent)]
     ConversionError(#[from] ConversionError),
+    #[error(transparent)]
+    CacheError(#[from] CacheError),
     #[error(transparent)]
     TraversalModelError(#[from] TraversalModelError),
     #[error(transparent)]

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use routee_compass_core::util::unit::{
-    Energy, EnergyRate, EnergyRateUnit, EnergyUnit, GradeUnit, SpeedUnit,
+use routee_compass_core::util::{
+    cache_policy::float_cache_policy::{FloatCachePolicy, FloatCachePolicyConfig},
+    unit::{Energy, EnergyRate, EnergyRateUnit, EnergyUnit, GradeUnit, SpeedUnit},
 };
 use routee_compass_powertrain::routee::{
     prediction::{load_prediction_model, model_type::ModelType, PredictionModelRecord},
@@ -127,8 +128,15 @@ fn get_model_record_from_params(
         parent_key.clone(),
     )?;
 
-    let cache_size = parameters
-        .get_config_serde_optional::<usize>(String::from("cache_size"), parent_key.clone())?;
+    let cache_config = parameters.get_config_serde_optional::<FloatCachePolicyConfig>(
+        String::from("float_cache_policy"),
+        parent_key.clone(),
+    )?;
+
+    let cache = match cache_config {
+        Some(config) => Some(FloatCachePolicy::from_config(config)?),
+        None => None,
+    };
 
     let model_record = load_prediction_model(
         name.clone(),
@@ -139,7 +147,7 @@ fn get_model_record_from_params(
         energy_rate_unit,
         ideal_energy_rate_option,
         real_world_energy_adjustment_option,
-        cache_size,
+        cache,
     )?;
 
     Ok(model_record)

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
@@ -127,10 +127,8 @@ fn get_model_record_from_params(
         parent_key.clone(),
     )?;
 
-    let cache_size = parameters.get_config_serde_optional::<usize>(
-        String::from("cache_size"),
-        parent_key.clone(),
-    )?;
+    let cache_size = parameters
+        .get_config_serde_optional::<usize>(String::from("cache_size"), parent_key.clone())?;
 
     let model_record = load_prediction_model(
         name.clone(),

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
@@ -127,8 +127,8 @@ fn get_model_record_from_params(
         parent_key.clone(),
     )?;
 
-    let maximum_cache_size = parameters.get_config_serde_optional::<usize>(
-        String::from("maximum_cache_size"),
+    let cache_size = parameters.get_config_serde_optional::<usize>(
+        String::from("cache_size"),
         parent_key.clone(),
     )?;
 
@@ -141,7 +141,7 @@ fn get_model_record_from_params(
         energy_rate_unit,
         ideal_energy_rate_option,
         real_world_energy_adjustment_option,
-        maximum_cache_size,
+        cache_size,
     )?;
 
     Ok(model_record)

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
@@ -127,6 +127,11 @@ fn get_model_record_from_params(
         parent_key.clone(),
     )?;
 
+    let maximum_cache_size = parameters.get_config_serde_optional::<usize>(
+        String::from("maximum_cache_size"),
+        parent_key.clone(),
+    )?;
+
     let model_record = load_prediction_model(
         name.clone(),
         &model_path,
@@ -136,6 +141,7 @@ fn get_model_record_from_params(
         energy_rate_unit,
         ideal_energy_rate_option,
         real_world_energy_adjustment_option,
+        maximum_cache_size,
     )?;
 
     Ok(model_record)


### PR DESCRIPTION
After noting that the ONNX models were taking 26 minutes to run for our national beer run, I added in the option to use an LRU Cache for energy models to see if we could cut down on the large run times. I tested this with 10,000 cache entries on the national beer run over 5 parallel queries and noted that the runtime decreased to around 4 minutes per query (the smartcore models saw an increase in runtime from about 3.5 minutes to 4 minutes).

This does convert speed values into kph integers and grade values into milli integers. This might be too strong an assumption but was made considering that our current data sources typically store speed and grade at this resolution anyways.

The default behavior is to not use any caching but if the key `cache_size` is present in the vehicle configuration, the model will build an LRU cache. 