### PR TITLE
normalize energy based on vehicle specific parameters

### DIFF
--- a/rust/routee-compass-core/src/util/unit/energy.rs
+++ b/rust/routee-compass-core/src/util/unit/energy.rs
@@ -1,6 +1,7 @@
-use derive_more::{Add, Div, Mul, Neg, Sub, Sum};
+use derive_more::{Add, Mul, Neg, Sub, Sum};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
+use std::ops::Div;
 use std::{cmp::Ordering, fmt::Display};
 
 use super::{
@@ -21,7 +22,6 @@ use super::{
     Add,
     Sub,
     Mul,
-    Div,
     Sum,
     Neg,
 )]
@@ -38,6 +38,14 @@ impl From<(EnergyRate, Distance)> for Energy {
         let (energy_rate, distance) = value;
         let energy_value = energy_rate.as_f64() * distance.as_f64();
         Energy::new(energy_value)
+    }
+}
+
+impl Div for Energy {
+    type Output = Energy;
+    fn div(self, rhs: Self) -> Self::Output {
+        let value = self.0 / rhs.0;
+        Energy(value)
     }
 }
 

--- a/rust/routee-compass-core/src/util/unit/time.rs
+++ b/rust/routee-compass-core/src/util/unit/time.rs
@@ -1,6 +1,7 @@
-use derive_more::{Add, Div, Mul, Neg, Sub, Sum};
+use derive_more::{Add, Mul, Neg, Sub, Sum};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
+use std::ops::Div;
 use std::{cmp::Ordering, fmt::Display};
 
 use super::{
@@ -20,7 +21,6 @@ use super::{
     Add,
     Sub,
     Mul,
-    Div,
     Sum,
     Neg,
 )]
@@ -43,6 +43,14 @@ impl From<(Distance, Speed)> for Time {
 impl PartialOrd for Time {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.0.cmp(&other.0))
+    }
+}
+
+impl Div for Time {
+    type Output = Time;
+    fn div(self, rhs: Self) -> Self::Output {
+        let value = self.0 / rhs.0;
+        Time(value)
     }
 }
 

--- a/rust/routee-compass-core/src/util/unit/time_unit.rs
+++ b/rust/routee-compass-core/src/util/unit/time_unit.rs
@@ -3,7 +3,7 @@ use crate::util::serde_ops::string_deserialize;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum TimeUnit {
     Hours,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/vehicle_type.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/vehicle_type.rs
@@ -79,4 +79,13 @@ pub trait VehicleType: Send + Sync {
         &self,
         query: &serde_json::Value,
     ) -> Result<Arc<dyn VehicleType>, TraversalModelError>;
+
+    /// Normalize the energy into a value between 0 and 1
+    ///
+    /// Arguments:
+    /// * `energy` - The energy to normalize
+    ///
+    /// Returns:
+    /// * `f64` - The normalized energy in range [0, 1]
+    fn normalize_energy(&self, energy: (Energy, EnergyUnit)) -> f64;
 }

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
@@ -56,7 +56,12 @@ fn build_conventional(
 
     let model_record = get_model_record_from_params(parameters, name.clone())?;
 
-    let vehicle = ICE::new(name, model_record)?;
+    let max_energy_delta = parameters.get_config_serde_optional::<Energy>(
+        String::from("max_link_energy_delta"),
+        vehicle_key.clone(),
+    )?;
+
+    let vehicle = ICE::new(name, model_record, max_energy_delta);
 
     Ok(Arc::new(vehicle))
 }
@@ -77,12 +82,18 @@ fn build_battery_electric(
     )?;
     let starting_battery_energy = battery_capacity;
 
+    let max_energy_delta = parameters.get_config_serde_optional::<Energy>(
+        String::from("max_link_energy_delta"),
+        vehicle_key.clone(),
+    )?;
+
     let vehicle = BEV::new(
         name,
         model_record,
         battery_capacity,
         starting_battery_energy,
         battery_energy_unit,
+        max_energy_delta,
     );
 
     Ok(Arc::new(vehicle))
@@ -120,6 +131,10 @@ fn build_plugin_hybrid(
         String::from("custom_liquid_fuel_to_kwh"),
         vehicle_key.clone(),
     )?;
+    let max_energy_delta = parameters.get_config_serde_optional::<Energy>(
+        String::from("max_link_engine_energy_delta"),
+        vehicle_key.clone(),
+    )?;
     let starting_battery_energy = battery_capacity;
     let phev = PHEV::new(
         name,
@@ -129,7 +144,8 @@ fn build_plugin_hybrid(
         starting_battery_energy,
         battery_energy_unit,
         custom_liquid_fuel_to_kwh,
-    )?;
+        max_energy_delta,
+    );
     Ok(Arc::new(phev))
 }
 


### PR DESCRIPTION
Adds in an optional parameter to a vehicle to indicate the maximum expected energy delta on a link. Then, with this value, each vehicle will normalize their energy values to be between 0-1. Each vehicle does this differently. For example, the BEV will offset the energy value first and then normalize the energy based on that new offset value to make sure the result is never negative. The time values are also normalized to be between 0-1 by using 30 minutes as the maximum link time delta.

When running a sweep over 6 energy cost coefficients from 0 to 1, I'm starting to see some intermediate routes (yellow being shortest time and blue being least energy):

![image](https://github.com/NREL/routee-compass/assets/1743744/8f962651-f686-4bb0-b814-6dca2d03c2be)

![image](https://github.com/NREL/routee-compass/assets/1743744/061be1b4-8fa0-4644-82df-1518cfffa152)
