### PR TITLE
Pull out energy offset

### DIFF
--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -64,6 +64,7 @@ impl VehicleType for BEV {
             distance,
             distance_unit,
         )?;
+
         Ok(energy)
     }
     fn consume_energy(
@@ -79,11 +80,8 @@ impl VehicleType for BEV {
 
         let updated_state = update_state(state, electrical_energy, self.battery_capacity);
 
-        // offset the electrical energy by the battery capacity to capture negative values
-        let offset_energy = electrical_energy + self.battery_capacity;
-
         Ok(VehicleEnergyResult {
-            energy: offset_energy,
+            energy: electrical_energy,
             energy_unit: electrical_energy_unit,
             updated_state,
         })


### PR DESCRIPTION
Removes the addition of the energy offset to the battery electric energy (which can be negative) due to problems with using this approach producing inverted results. With the offset included, we get results that look like this:

<details>
<summary>Query</summary>
```json
{
  "model_name": "2017_CHEVROLET_Bolt",
  "starting_soc_percent": 100,
  "grid_search": {
    "energy_cost_coefficient": [
      0,
      0.2,
      0.4,
      0.6000000000000001,
      0.8,
      1
    ]
  },
  "destination_y": 39.96400556338435,
  "destination_x": -105.09385002667304,
  "origin_y": 39.62257436349091,
  "origin_x": -104.88747463756835
}
```
</details>

<details>
<summary>Config</summary>

```toml
parallelism = 2
search_orientation = "edge"

[graph]
edge_list_input_file = "data/tomtom_metro_denver_network/edges-compass.csv.gz"
vertex_list_input_file = "data/tomtom_metro_denver_network/vertices-compass.csv.gz"
verbose = true

[traversal]
type = "energy_model"
speed_table_input_file = "data/tomtom_metro_denver_network/edges-free-flow-speed-enumerated.txt.gz"
speed_table_speed_unit = "kilometers_per_hour"
grade_table_input_file = "data/tomtom_metro_denver_network/edges-grade-enumerated.txt.gz"
grade_table_grade_unit = "decimal"
output_time_unit = "minutes"
output_distance_unit = "miles"

[[traversal.vehicles]]
name = "2017_CHEVROLET_Bolt"
type = "bev"
model_input_file = "data/2017_CHEVROLET_Bolt.bin"
model_type = "smartcore"
speed_unit = "miles_per_hour"
grade_unit = "decimal"
energy_rate_unit = "kilowatt_hours_per_mile"
battery_capacity = 60
battery_capacity_unit = "kilowatt_hours"
ideal_energy_rate = 0.1
real_world_energy_adjustment = 1.3958

[frontier]
type = "road_class"
road_class_input_file = "data/tomtom_metro_denver_network/edges-road-class-enumerated.txt.gz"

[plugin]
input_plugins = [
    { type = "edge_rtree", geometry_input_file = "data/tomtom_metro_denver_network/edges-geometries-enumerated.txt.gz", road_class_input_file = "data/tomtom_metro_denver_network/edges-road-class-enumerated.txt.gz" },
    { type = "grid_search" },
    { type = "load_balancer", weight_heuristic = { type = "haversine" } },
    { type = "inject", key = "road_classes", value = '["1","2","3","4","5","6"]', format = "json" },
]
output_plugins = [
    { type = "summary" },
    { type = "traversal", route = "geo_json", geometry_input_file = "data/tomtom_metro_denver_network/edges-geometries-enumerated.txt.gz" }
]
```

</details>

<details>
<summary>Offset included</summary>

![image](https://github.com/NREL/routee-compass/assets/1743744/f9a36ae5-b8af-441c-9974-40615b3ac336)

![image](https://github.com/NREL/routee-compass/assets/1743744/b7f61029-5836-4802-b503-514f1b02f822)

![image](https://github.com/NREL/routee-compass/assets/1743744/04332027-04d2-4099-9599-c090022749cf)

</details>

<details>
<summary>No offset</summary>

![image](https://github.com/NREL/routee-compass/assets/1743744/be5f6da2-91c2-4424-9982-a391c4f63c9e)

![image](https://github.com/NREL/routee-compass/assets/1743744/7787a727-4306-4b26-b4b2-f3933ba3502c)

![image](https://github.com/NREL/routee-compass/assets/1743744/c0854db5-d5d2-4342-9cda-b3d463d58ce9)
</details>