### PR TITLE
relax JSON string arg types

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -105,7 +105,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
         let config_json = config
             .clone()
             .try_deserialize::<serde_json::Value>()?
-            .normalize_file_paths("", &root_config_path)?;
+            .normalize_file_paths(&"", &root_config_path)?;
 
         let alg_params = config_json.get_config_section(CompassConfigurationField::Algorithm)?;
         let search_algorithm = SearchAlgorithm::try_from(&alg_params)?;

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -1,7 +1,7 @@
 use super::{
     builders::{InputPluginBuilder, OutputPluginBuilder},
     compass_configuration_error::CompassConfigurationError,
-    compass_configuration_field::CompassConfigurationField as ConfField,
+    compass_configuration_field::CompassConfigurationField,
     config_json_extension::ConfigJsonExtensions,
     frontier_model::{
         no_restriction_builder::NoRestrictionBuilder,
@@ -180,7 +180,7 @@ impl CompassAppBuilder {
             config
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    ConfField::Traversal.to_string(),
+                    CompassConfigurationField::Traversal.to_string(),
                     String::from("type"),
                 ))?;
         let tm_type: String = tm_type_obj
@@ -215,7 +215,7 @@ impl CompassAppBuilder {
             config
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    ConfField::Frontier.to_string(),
+                    CompassConfigurationField::Frontier.to_string(),
                     String::from("type"),
                 ))?;
         let fm_type: String = fm_type_obj
@@ -242,8 +242,10 @@ impl CompassAppBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<Vec<Box<dyn InputPlugin>>, CompassConfigurationError> {
-        let input_plugins =
-            config.get_config_array(&ConfField::InputPlugins, &ConfField::Plugins)?;
+        let input_plugins = config.get_config_array(
+            &CompassConfigurationField::InputPlugins,
+            &CompassConfigurationField::Plugins,
+        )?;
 
         let mut plugins: Vec<Box<dyn InputPlugin>> = Vec::new();
         for plugin_json in input_plugins.into_iter() {
@@ -257,7 +259,7 @@ impl CompassAppBuilder {
             let plugin_type: String = plugin_type_obj
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    ConfField::InputPlugins.to_string(),
+                    CompassConfigurationField::InputPlugins.to_string(),
                     String::from("type"),
                 ))?
                 .as_str()
@@ -283,8 +285,10 @@ impl CompassAppBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<Vec<Box<dyn OutputPlugin>>, CompassConfigurationError> {
-        let output_plugins =
-            config.get_config_array(&ConfField::OutputPlugins, &ConfField::Plugins)?;
+        let output_plugins = config.get_config_array(
+            &CompassConfigurationField::OutputPlugins,
+            &CompassConfigurationField::Plugins,
+        )?;
 
         let mut plugins: Vec<Box<dyn OutputPlugin>> = Vec::new();
         for plugin_json in output_plugins.into_iter() {
@@ -298,7 +302,7 @@ impl CompassAppBuilder {
             let plugin_type: String = plugin_json_obj
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    ConfField::OutputPlugins.to_string(),
+                    CompassConfigurationField::OutputPlugins.to_string(),
                     String::from("type"),
                 ))?
                 .as_str()

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -1,7 +1,7 @@
 use super::{
     builders::{InputPluginBuilder, OutputPluginBuilder},
     compass_configuration_error::CompassConfigurationError,
-    compass_configuration_field::CompassConfigurationField,
+    compass_configuration_field::CompassConfigurationField as ConfField,
     config_json_extension::ConfigJsonExtensions,
     frontier_model::{
         no_restriction_builder::NoRestrictionBuilder,
@@ -180,7 +180,7 @@ impl CompassAppBuilder {
             config
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::Traversal.to_string(),
+                    ConfField::Traversal.to_string(),
                     String::from("type"),
                 ))?;
         let tm_type: String = tm_type_obj
@@ -215,7 +215,7 @@ impl CompassAppBuilder {
             config
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::Frontier.to_string(),
+                    ConfField::Frontier.to_string(),
                     String::from("type"),
                 ))?;
         let fm_type: String = fm_type_obj
@@ -242,10 +242,8 @@ impl CompassAppBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<Vec<Box<dyn InputPlugin>>, CompassConfigurationError> {
-        let input_plugins = config.get_config_array(
-            CompassConfigurationField::InputPlugins.to_string(),
-            CompassConfigurationField::Plugins.to_string(),
-        )?;
+        let input_plugins =
+            config.get_config_array(&ConfField::InputPlugins, &ConfField::Plugins)?;
 
         let mut plugins: Vec<Box<dyn InputPlugin>> = Vec::new();
         for plugin_json in input_plugins.into_iter() {
@@ -259,7 +257,7 @@ impl CompassAppBuilder {
             let plugin_type: String = plugin_type_obj
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::InputPlugins.to_string(),
+                    ConfField::InputPlugins.to_string(),
                     String::from("type"),
                 ))?
                 .as_str()
@@ -285,10 +283,8 @@ impl CompassAppBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<Vec<Box<dyn OutputPlugin>>, CompassConfigurationError> {
-        let output_plugins = config.get_config_array(
-            CompassConfigurationField::OutputPlugins.to_string(),
-            CompassConfigurationField::Plugins.to_string(),
-        )?;
+        let output_plugins =
+            config.get_config_array(&ConfField::OutputPlugins, &ConfField::Plugins)?;
 
         let mut plugins: Vec<Box<dyn OutputPlugin>> = Vec::new();
         for plugin_json in output_plugins.into_iter() {
@@ -302,7 +298,7 @@ impl CompassAppBuilder {
             let plugin_type: String = plugin_json_obj
                 .get("type")
                 .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::OutputPlugins.to_string(),
+                    ConfField::OutputPlugins.to_string(),
                     String::from("type"),
                 ))?
                 .as_str()

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
@@ -45,6 +45,12 @@ impl From<CompassConfigurationField> for String {
     }
 }
 
+impl AsRef<str> for CompassConfigurationField {
+    fn as_ref(&self) -> &str {
+        self.to_str()
+    }
+}
+
 impl Display for CompassConfigurationField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_str())

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -15,52 +15,52 @@ pub trait ConfigJsonExtensions {
     ) -> Result<serde_json::Value, CompassConfigurationError>;
     fn get_config_path(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<PathBuf, CompassConfigurationError>;
     fn get_config_path_optional(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<Option<PathBuf>, CompassConfigurationError>;
     fn get_config_string(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<String, CompassConfigurationError>;
     fn get_config_array(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<Vec<serde_json::Value>, CompassConfigurationError>;
     fn get_config_i64(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<i64, CompassConfigurationError>;
     fn get_config_f64(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<f64, CompassConfigurationError>;
     fn get_config_from_str<T: FromStr>(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<T, CompassConfigurationError>;
     fn get_config_serde<T: de::DeserializeOwned>(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<T, CompassConfigurationError>;
     fn get_config_serde_optional<T: de::DeserializeOwned>(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<Option<T>, CompassConfigurationError>;
     fn normalize_file_paths(
         &self,
-        parent_key: &impl Into<String>,
+        parent_key: &dyn AsRef<str>,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError>;
 }
@@ -82,11 +82,10 @@ impl ConfigJsonExtensions for serde_json::Value {
     }
     fn get_config_path_optional(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<Option<PathBuf>, CompassConfigurationError> {
-        let index: String = (*key).into();
-        match self.get(index) {
+        match self.get(key.as_ref()) {
             None => Ok(None),
             Some(_) => {
                 let config_path = self.get_config_path(key, parent_key)?;
@@ -96,8 +95,8 @@ impl ConfigJsonExtensions for serde_json::Value {
     }
     fn get_config_path(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<PathBuf, CompassConfigurationError> {
         let path_string = self.get_config_string(key, parent_key)?;
         let path = PathBuf::from(&path_string);
@@ -109,27 +108,26 @@ impl ConfigJsonExtensions for serde_json::Value {
             // can't find the file
             Err(CompassConfigurationError::FileNotFoundForComponent(
                 path_string,
-                (*key).into(),
-                (*parent_key).into(),
+                String::from(key.as_ref()),
+                String::from(parent_key.as_ref()),
             ))
         }
     }
     fn get_config_string(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<String, CompassConfigurationError> {
-        let index: String = (*key).into();
         let value = self
-            .get(index)
+            .get(key.as_ref())
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                (*key).into(),
-                (*parent_key).into(),
+                String::from(key.as_ref()),
+                String::from(parent_key.as_ref()),
             ))?
             .as_str()
             .map(String::from)
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                (*key).into(),
+                String::from(key.as_ref()),
                 String::from("String"),
             ))?;
         Ok(value)
@@ -137,19 +135,18 @@ impl ConfigJsonExtensions for serde_json::Value {
 
     fn get_config_array(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<Vec<serde_json::Value>, CompassConfigurationError> {
-        let index: String = (*key).into();
         let array = self
-            .get(index)
+            .get(key.as_ref())
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                (*key).into(),
-                (*parent_key).into(),
+                String::from(key.as_ref()),
+                String::from(parent_key.as_ref()),
             ))?
             .as_array()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                (*key).into(),
+                String::from(key.as_ref()),
                 String::from("Array"),
             ))?
             .to_owned();
@@ -158,19 +155,18 @@ impl ConfigJsonExtensions for serde_json::Value {
 
     fn get_config_i64(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<i64, CompassConfigurationError> {
-        let index: String = (*key).into();
         let value = self
-            .get(index)
+            .get(key.as_ref())
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                (*key).into(),
-                (*parent_key).into(),
+                String::from(key.as_ref()),
+                String::from(parent_key.as_ref()),
             ))?
             .as_i64()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                (*key).into(),
+                String::from(key.as_ref()),
                 String::from("64-bit signed integer"),
             ))?;
         Ok(value)
@@ -178,19 +174,18 @@ impl ConfigJsonExtensions for serde_json::Value {
 
     fn get_config_f64(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<f64, CompassConfigurationError> {
-        let index: String = (*key).into();
         let value = self
-            .get(index)
+            .get(key.as_ref())
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                (*key).into(),
-                (*parent_key).into(),
+                String::from(key.as_ref()),
+                String::from(parent_key.as_ref()),
             ))?
             .as_f64()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                (*key).into(),
+                String::from(key.as_ref()),
                 String::from("64-bit floating point"),
             ))?;
         Ok(value)
@@ -198,24 +193,23 @@ impl ConfigJsonExtensions for serde_json::Value {
 
     fn get_config_from_str<T: FromStr>(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<T, CompassConfigurationError> {
-        let index: String = (*key).into();
         let value = self
-            .get(index)
+            .get(key.as_ref())
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                (*key).into(),
-                (*parent_key).into(),
+                String::from(key.as_ref()),
+                String::from(parent_key.as_ref()),
             ))?
             .as_str()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                (*key).into(),
+                String::from(key.as_ref()),
                 String::from("string-parseable"),
             ))?;
         let result = T::from_str(value).map_err(|_| {
             CompassConfigurationError::ExpectedFieldWithType(
-                (*key).into(),
+                String::from(key.as_ref()),
                 format!("failed to parse type from string {}", value),
             )
         })?;
@@ -224,15 +218,14 @@ impl ConfigJsonExtensions for serde_json::Value {
 
     fn get_config_serde<T: de::DeserializeOwned>(
         &self,
-        key: &impl Into<String>,
-        parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
     ) -> Result<T, CompassConfigurationError> {
-        let index: String = (*key).into();
         let value = self
-            .get(index)
+            .get(key.as_ref())
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                (*key).into(),
-                (*parent_key).into(),
+                String::from(key.as_ref()),
+                String::from(parent_key.as_ref()),
             ))?
             .to_owned();
 
@@ -242,14 +235,13 @@ impl ConfigJsonExtensions for serde_json::Value {
     }
     fn get_config_serde_optional<T: de::DeserializeOwned>(
         &self,
-        key: &impl Into<String>,
-        _parent_key: &impl Into<String>,
+        key: &dyn AsRef<str>,
+        _parent_key: &dyn AsRef<str>,
     ) -> Result<Option<T>, CompassConfigurationError> {
-        let index: String = (*key).into();
-        match self.get(index) {
+        match self.get(key.as_ref()) {
             None => Ok(None),
             Some(value) => {
-                let result: T = serde_json::from_value(*value)
+                let result: T = serde_json::from_value(value.to_owned())
                     .map_err(CompassConfigurationError::SerdeDeserializationError)?;
                 Ok(Some(result))
             }
@@ -276,7 +268,7 @@ impl ConfigJsonExtensions for serde_json::Value {
     /// * `Result<serde_json::Value, CompassConfigurationError>` - The JSON object with normalized paths.
     fn normalize_file_paths(
         &self,
-        parent_key: &impl Into<String>,
+        parent_key: &dyn AsRef<str>,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError> {
         match self {
@@ -304,7 +296,7 @@ impl ConfigJsonExtensions for serde_json::Value {
                     } else {
                         // if we can't find the file in either location, we throw an error
                         Err(CompassConfigurationError::FileNormalizationNotFound(
-                            (*parent_key).into(),
+                            String::from(parent_key.as_ref()),
                             path_string.clone(),
                             new_path_string,
                         ))
@@ -319,11 +311,11 @@ impl ConfigJsonExtensions for serde_json::Value {
                         || value.is_array()
                     {
                         new_obj.insert(
-                            (*key).into(),
+                            String::from(key),
                             value.normalize_file_paths(key, root_config_path)?,
                         );
                     } else {
-                        new_obj.insert((*key).into(), value.clone());
+                        new_obj.insert(String::from(key), value.clone());
                     }
                 }
                 Ok(serde_json::Value::Object(new_obj))

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -13,54 +13,54 @@ pub trait ConfigJsonExtensions {
         &self,
         section: CompassConfigurationField,
     ) -> Result<serde_json::Value, CompassConfigurationError>;
-    fn get_config_path<A: Into<String>, B: Into<String>>(
+    fn get_config_path(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<PathBuf, CompassConfigurationError>;
-    fn get_config_path_optional<A: Into<String>, B: Into<String>>(
+    fn get_config_path_optional(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<Option<PathBuf>, CompassConfigurationError>;
-    fn get_config_string<A: Into<String>, B: Into<String>>(
+    fn get_config_string(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<String, CompassConfigurationError>;
-    fn get_config_array<A: Into<String>, B: Into<String>>(
+    fn get_config_array(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<Vec<serde_json::Value>, CompassConfigurationError>;
-    fn get_config_i64<A: Into<String>, B: Into<String>>(
+    fn get_config_i64(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<i64, CompassConfigurationError>;
-    fn get_config_f64<A: Into<String>, B: Into<String>>(
+    fn get_config_f64(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<f64, CompassConfigurationError>;
-    fn get_config_from_str<A: Into<String>, B: Into<String>, T: FromStr>(
+    fn get_config_from_str<T: FromStr>(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<T, CompassConfigurationError>;
-    fn get_config_serde<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
+    fn get_config_serde<T: de::DeserializeOwned>(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<T, CompassConfigurationError>;
-    fn get_config_serde_optional<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
+    fn get_config_serde_optional<T: de::DeserializeOwned>(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<Option<T>, CompassConfigurationError>;
-    fn normalize_file_paths<S: Into<String>>(
+    fn normalize_file_paths(
         &self,
-        parent_key: &S,
+        parent_key: &impl Into<String>,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError>;
 }
@@ -80,10 +80,10 @@ impl ConfigJsonExtensions for serde_json::Value {
 
         Ok(section)
     }
-    fn get_config_path_optional<A: Into<String>, B: Into<String>>(
+    fn get_config_path_optional(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<Option<PathBuf>, CompassConfigurationError> {
         let index: String = (*key).into();
         match self.get(index) {
@@ -94,10 +94,10 @@ impl ConfigJsonExtensions for serde_json::Value {
             }
         }
     }
-    fn get_config_path<A: Into<String>, B: Into<String>>(
+    fn get_config_path(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<PathBuf, CompassConfigurationError> {
         let path_string = self.get_config_string(key, parent_key)?;
         let path = PathBuf::from(&path_string);
@@ -114,10 +114,10 @@ impl ConfigJsonExtensions for serde_json::Value {
             ))
         }
     }
-    fn get_config_string<A: Into<String>, B: Into<String>>(
+    fn get_config_string(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<String, CompassConfigurationError> {
         let index: String = (*key).into();
         let value = self
@@ -135,10 +135,10 @@ impl ConfigJsonExtensions for serde_json::Value {
         Ok(value)
     }
 
-    fn get_config_array<A: Into<String>, B: Into<String>>(
+    fn get_config_array(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<Vec<serde_json::Value>, CompassConfigurationError> {
         let index: String = (*key).into();
         let array = self
@@ -156,10 +156,10 @@ impl ConfigJsonExtensions for serde_json::Value {
         Ok(array)
     }
 
-    fn get_config_i64<A: Into<String>, B: Into<String>>(
+    fn get_config_i64(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<i64, CompassConfigurationError> {
         let index: String = (*key).into();
         let value = self
@@ -176,10 +176,10 @@ impl ConfigJsonExtensions for serde_json::Value {
         Ok(value)
     }
 
-    fn get_config_f64<A: Into<String>, B: Into<String>>(
+    fn get_config_f64(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<f64, CompassConfigurationError> {
         let index: String = (*key).into();
         let value = self
@@ -196,10 +196,10 @@ impl ConfigJsonExtensions for serde_json::Value {
         Ok(value)
     }
 
-    fn get_config_from_str<A: Into<String>, B: Into<String>, T: FromStr>(
+    fn get_config_from_str<T: FromStr>(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<T, CompassConfigurationError> {
         let index: String = (*key).into();
         let value = self
@@ -222,10 +222,10 @@ impl ConfigJsonExtensions for serde_json::Value {
         Ok(result)
     }
 
-    fn get_config_serde<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
+    fn get_config_serde<T: de::DeserializeOwned>(
         &self,
-        key: &A,
-        parent_key: &B,
+        key: &impl Into<String>,
+        parent_key: &impl Into<String>,
     ) -> Result<T, CompassConfigurationError> {
         let index: String = (*key).into();
         let value = self
@@ -240,10 +240,10 @@ impl ConfigJsonExtensions for serde_json::Value {
             .map_err(CompassConfigurationError::SerdeDeserializationError)?;
         Ok(result)
     }
-    fn get_config_serde_optional<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
+    fn get_config_serde_optional<T: de::DeserializeOwned>(
         &self,
-        key: &A,
-        _parent_key: &B,
+        key: &impl Into<String>,
+        _parent_key: &impl Into<String>,
     ) -> Result<Option<T>, CompassConfigurationError> {
         let index: String = (*key).into();
         match self.get(index) {
@@ -274,9 +274,9 @@ impl ConfigJsonExtensions for serde_json::Value {
     /// Returns:
     ///
     /// * `Result<serde_json::Value, CompassConfigurationError>` - The JSON object with normalized paths.
-    fn normalize_file_paths<S: Into<String>>(
+    fn normalize_file_paths(
         &self,
-        parent_key: &S,
+        parent_key: &impl Into<String>,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError> {
         match self {

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -13,54 +13,54 @@ pub trait ConfigJsonExtensions {
         &self,
         section: CompassConfigurationField,
     ) -> Result<serde_json::Value, CompassConfigurationError>;
-    fn get_config_path(
+    fn get_config_path<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<PathBuf, CompassConfigurationError>;
-    fn get_config_path_optional(
+    fn get_config_path_optional<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<Option<PathBuf>, CompassConfigurationError>;
-    fn get_config_string(
+    fn get_config_string<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<String, CompassConfigurationError>;
-    fn get_config_array(
+    fn get_config_array<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<Vec<serde_json::Value>, CompassConfigurationError>;
-    fn get_config_i64(
+    fn get_config_i64<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<i64, CompassConfigurationError>;
-    fn get_config_f64(
+    fn get_config_f64<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<f64, CompassConfigurationError>;
-    fn get_config_from_str<T: FromStr>(
+    fn get_config_from_str<A: Into<String>, B: Into<String>, T: FromStr>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<T, CompassConfigurationError>;
-    fn get_config_serde<T: de::DeserializeOwned>(
+    fn get_config_serde<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<T, CompassConfigurationError>;
-    fn get_config_serde_optional<T: de::DeserializeOwned>(
+    fn get_config_serde_optional<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<Option<T>, CompassConfigurationError>;
-    fn normalize_file_paths(
+    fn normalize_file_paths<S: Into<String>>(
         &self,
-        parent_key: &str,
+        parent_key: &S,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError>;
 }
@@ -80,12 +80,13 @@ impl ConfigJsonExtensions for serde_json::Value {
 
         Ok(section)
     }
-    fn get_config_path_optional(
+    fn get_config_path_optional<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<Option<PathBuf>, CompassConfigurationError> {
-        match self.get(key.clone()) {
+        let index: String = (*key).into();
+        match self.get(index) {
             None => Ok(None),
             Some(_) => {
                 let config_path = self.get_config_path(key, parent_key)?;
@@ -93,12 +94,12 @@ impl ConfigJsonExtensions for serde_json::Value {
             }
         }
     }
-    fn get_config_path(
+    fn get_config_path<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<PathBuf, CompassConfigurationError> {
-        let path_string = self.get_config_string(key.clone(), parent_key.clone())?;
+        let path_string = self.get_config_string(key, parent_key)?;
         let path = PathBuf::from(&path_string);
 
         // if file can be found, just it
@@ -108,124 +109,130 @@ impl ConfigJsonExtensions for serde_json::Value {
             // can't find the file
             Err(CompassConfigurationError::FileNotFoundForComponent(
                 path_string,
-                key,
-                parent_key,
+                (*key).into(),
+                (*parent_key).into(),
             ))
         }
     }
-    fn get_config_string(
+    fn get_config_string<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<String, CompassConfigurationError> {
+        let index: String = (*key).into();
         let value = self
-            .get(&key)
+            .get(index)
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                key.clone(),
-                parent_key.clone(),
+                (*key).into(),
+                (*parent_key).into(),
             ))?
             .as_str()
             .map(String::from)
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                key.clone(),
+                (*key).into(),
                 String::from("String"),
             ))?;
         Ok(value)
     }
 
-    fn get_config_array(
+    fn get_config_array<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<Vec<serde_json::Value>, CompassConfigurationError> {
+        let index: String = (*key).into();
         let array = self
-            .get(&key)
+            .get(index)
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                key.clone(),
-                parent_key.clone(),
+                (*key).into(),
+                (*parent_key).into(),
             ))?
             .as_array()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                key.clone(),
+                (*key).into(),
                 String::from("Array"),
             ))?
             .to_owned();
         Ok(array)
     }
 
-    fn get_config_i64(
+    fn get_config_i64<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<i64, CompassConfigurationError> {
+        let index: String = (*key).into();
         let value = self
-            .get(&key)
+            .get(index)
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                key.clone(),
-                parent_key.clone(),
+                (*key).into(),
+                (*parent_key).into(),
             ))?
             .as_i64()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                key.clone(),
+                (*key).into(),
                 String::from("64-bit signed integer"),
             ))?;
         Ok(value)
     }
 
-    fn get_config_f64(
+    fn get_config_f64<A: Into<String>, B: Into<String>>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<f64, CompassConfigurationError> {
+        let index: String = (*key).into();
         let value = self
-            .get(&key)
+            .get(index)
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                key.clone(),
-                parent_key.clone(),
+                (*key).into(),
+                (*parent_key).into(),
             ))?
             .as_f64()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                key.clone(),
+                (*key).into(),
                 String::from("64-bit floating point"),
             ))?;
         Ok(value)
     }
 
-    fn get_config_from_str<T: FromStr>(
+    fn get_config_from_str<A: Into<String>, B: Into<String>, T: FromStr>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<T, CompassConfigurationError> {
+        let index: String = (*key).into();
         let value = self
-            .get(&key)
+            .get(index)
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                key.clone(),
-                parent_key.clone(),
+                (*key).into(),
+                (*parent_key).into(),
             ))?
             .as_str()
             .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                key.clone(),
+                (*key).into(),
                 String::from("string-parseable"),
             ))?;
         let result = T::from_str(value).map_err(|_| {
             CompassConfigurationError::ExpectedFieldWithType(
-                key.clone(),
+                (*key).into(),
                 format!("failed to parse type from string {}", value),
             )
         })?;
         Ok(result)
     }
 
-    fn get_config_serde<T: de::DeserializeOwned>(
+    fn get_config_serde<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
         &self,
-        key: String,
-        parent_key: String,
+        key: &A,
+        parent_key: &B,
     ) -> Result<T, CompassConfigurationError> {
+        let index: String = (*key).into();
         let value = self
-            .get(key.clone())
+            .get(index)
             .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                key.clone(),
-                parent_key.clone(),
+                (*key).into(),
+                (*parent_key).into(),
             ))?
             .to_owned();
 
@@ -233,15 +240,16 @@ impl ConfigJsonExtensions for serde_json::Value {
             .map_err(CompassConfigurationError::SerdeDeserializationError)?;
         Ok(result)
     }
-    fn get_config_serde_optional<T: de::DeserializeOwned>(
+    fn get_config_serde_optional<A: Into<String>, B: Into<String>, T: de::DeserializeOwned>(
         &self,
-        key: String,
-        _parent_key: String,
+        key: &A,
+        _parent_key: &B,
     ) -> Result<Option<T>, CompassConfigurationError> {
-        match self.get(key.clone()) {
+        let index: String = (*key).into();
+        match self.get(index) {
             None => Ok(None),
             Some(value) => {
-                let result: T = serde_json::from_value(value.clone())
+                let result: T = serde_json::from_value(*value)
                     .map_err(CompassConfigurationError::SerdeDeserializationError)?;
                 Ok(Some(result))
             }
@@ -266,9 +274,9 @@ impl ConfigJsonExtensions for serde_json::Value {
     /// Returns:
     ///
     /// * `Result<serde_json::Value, CompassConfigurationError>` - The JSON object with normalized paths.
-    fn normalize_file_paths(
+    fn normalize_file_paths<S: Into<String>>(
         &self,
-        parent_key: &str,
+        parent_key: &S,
         root_config_path: &Path,
     ) -> Result<serde_json::Value, CompassConfigurationError> {
         match self {
@@ -296,7 +304,7 @@ impl ConfigJsonExtensions for serde_json::Value {
                     } else {
                         // if we can't find the file in either location, we throw an error
                         Err(CompassConfigurationError::FileNormalizationNotFound(
-                            parent_key.to_string(),
+                            (*parent_key).into(),
                             path_string.clone(),
                             new_path_string,
                         ))
@@ -311,11 +319,11 @@ impl ConfigJsonExtensions for serde_json::Value {
                         || value.is_array()
                     {
                         new_obj.insert(
-                            key.clone(),
+                            (*key).into(),
                             value.normalize_file_paths(key, root_config_path)?,
                         );
                     } else {
-                        new_obj.insert(key.clone(), value.clone());
+                        new_obj.insert((*key).into(), value.clone());
                     }
                 }
                 Ok(serde_json::Value::Object(new_obj))

--- a/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_builder.rs
@@ -23,7 +23,7 @@ impl FrontierModelBuilder for RoadClassBuilder {
         let road_class_file_key = String::from("road_class_input_file");
 
         let road_class_file = parameters
-            .get_config_path(road_class_file_key.clone(), frontier_key.clone())
+            .get_config_path(&road_class_file_key, &frontier_key)
             .map_err(|e| {
                 FrontierModelError::BuildError(format!(
                     "configuration error due to {}: {}",
@@ -33,14 +33,15 @@ impl FrontierModelBuilder for RoadClassBuilder {
             })?;
 
         let road_class_lookup: Box<[String]> =
-            read_utils::read_raw_file(road_class_file.clone(), read_decoders::string, None)
-                .map_err(|e| {
+            read_utils::read_raw_file(&road_class_file, read_decoders::string, None).map_err(
+                |e| {
                     FrontierModelError::BuildError(format!(
                         "failed to load file at {:?}: {}",
                         road_class_file.clone().to_str(),
                         e
                     ))
-                })?;
+                },
+            )?;
 
         let m: Arc<dyn FrontierModelService> = Arc::new(RoadClassFrontierService {
             road_class_lookup: Arc::new(road_class_lookup),

--- a/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_service.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_service.rs
@@ -17,9 +17,8 @@ impl FrontierModelService for RoadClassFrontierService {
         query: &serde_json::Value,
     ) -> Result<Arc<dyn FrontierModel>, FrontierModelError> {
         let service: Arc<RoadClassFrontierService> = Arc::new(self.clone());
-        let road_classes_key = String::from("road_classes");
         let road_classes = query
-            .get_config_serde_optional::<HashSet<String>>(road_classes_key, String::from(""))
+            .get_config_serde_optional::<HashSet<String>>(&"road_classes", &"")
             .map_err(|e| {
                 FrontierModelError::BuildError(format!("unable to deserialize as array: {}", e))
             })?;

--- a/rust/routee-compass/src/app/compass/config/graph_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/graph_builder.rs
@@ -27,16 +27,11 @@ impl DefaultGraphBuilder {
     /// A graph instance, or an error if an IO error occurred.
     pub fn build(params: &serde_json::Value) -> Result<Graph, CompassConfigurationError> {
         let graph_key = CompassConfigurationField::Graph.to_string();
-        let edge_list_csv =
-            params.get_config_path(String::from("edge_list_input_file"), graph_key.clone())?;
-        let vertex_list_csv =
-            params.get_config_path(String::from("vertex_list_input_file"), graph_key.clone())?;
-        let n_edges =
-            params.get_config_serde_optional(String::from("n_edges"), graph_key.clone())?;
-        let n_vertices =
-            params.get_config_serde_optional(String::from("n_vertices"), graph_key.clone())?;
-        let verbose: Option<bool> =
-            params.get_config_serde_optional(String::from("verbose"), graph_key.clone())?;
+        let edge_list_csv = params.get_config_path(&"edge_list_input_file", &graph_key)?;
+        let vertex_list_csv = params.get_config_path(&"vertex_list_input_file", &graph_key)?;
+        let n_edges = params.get_config_serde_optional(&"n_edges", &graph_key)?;
+        let n_vertices = params.get_config_serde_optional(&"n_vertices", &graph_key)?;
+        let verbose: Option<bool> = params.get_config_serde_optional(&"verbose", &graph_key)?;
 
         let graph = Graph::from_files(
             &edge_list_csv,

--- a/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
@@ -17,7 +17,7 @@ impl TerminationModelBuilder {
     ) -> Result<TerminationModel, CompassConfigurationError> {
         use routee_compass_core::model::termination::termination_model::TerminationModel as T;
         let local_scope = scope.unwrap_or(CompassConfigurationField::Termination.to_string());
-        let term_type = config.get_config_string(String::from("type"), local_scope.clone())?;
+        let term_type = config.get_config_string(&"type", &local_scope)?;
 
         let result = match term_type.to_lowercase().as_str() {
             "query_runtime" => {
@@ -28,28 +28,24 @@ impl TerminationModelBuilder {
                     ),
                 )?;
                 let dur = dur_val.as_duration()?;
-                let freq =
-                    config.get_config_i64(String::from("frequency"), local_scope.clone())? as u64;
+                let freq = config.get_config_i64(&"frequency", &local_scope)? as u64;
                 Ok(T::QueryRuntimeLimit {
                     limit: dur,
                     frequency: freq,
                 })
             }
             "iterations" => {
-                let iterations =
-                    config.get_config_i64(String::from("limit"), local_scope.clone())? as u64;
+                let iterations = config.get_config_i64(&"limit", &local_scope)? as u64;
                 Ok(T::IterationsLimit { limit: iterations })
             }
             "solution_size" => {
-                let solution_size =
-                    config.get_config_i64(String::from("limit"), local_scope.clone())? as usize;
+                let solution_size = config.get_config_i64(&"limit", &local_scope)? as usize;
                 Ok(T::SolutionSizeLimit {
                     limit: solution_size,
                 })
             }
             "combined" => {
-                let models_val =
-                    config.get_config_array(String::from("models"), local_scope.clone())?;
+                let models_val = config.get_config_array(&"models", &local_scope)?;
 
                 let models = models_val
                     .iter()

--- a/rust/routee-compass/src/app/compass/config/traversal_model/distance_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/distance_builder.rs
@@ -23,10 +23,7 @@ impl TraversalModelBuilder for DistanceBuilder {
     ) -> Result<Arc<dyn TraversalModelService>, TraversalModelError> {
         let traversal_key = CompassConfigurationField::Traversal.to_string();
         let distance_unit_option = parameters
-            .get_config_serde_optional::<DistanceUnit>(
-                String::from("distance_unit"),
-                traversal_key.clone(),
-            )
+            .get_config_serde_optional::<DistanceUnit>(&"distance_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let distance_unit = distance_unit_option.unwrap_or(BASE_DISTANCE_UNIT);
         let m: Arc<dyn TraversalModelService> = Arc::new(DistanceService { distance_unit });

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
@@ -21,40 +21,28 @@ impl TraversalModelBuilder for EnergyModelBuilder {
         let traversal_key = CompassConfigurationField::Traversal.to_string();
 
         let speed_table_path = params
-            .get_config_path(
-                String::from("speed_table_input_file"),
-                traversal_key.clone(),
-            )
+            .get_config_path(&"speed_table_input_file", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let speed_table_speed_unit = params
-            .get_config_serde::<SpeedUnit>(
-                String::from("speed_table_speed_unit"),
-                traversal_key.clone(),
-            )
+            .get_config_serde::<SpeedUnit>(&"speed_table_speed_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let grade_table_path = params
-            .get_config_path_optional(
-                String::from("grade_table_input_file"),
-                traversal_key.clone(),
-            )
+            .get_config_path_optional(&"grade_table_input_file", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let grade_table_grade_unit = params
-            .get_config_serde_optional::<GradeUnit>(
-                String::from("graph_grade_unit"),
-                traversal_key.clone(),
-            )
+            .get_config_serde_optional::<GradeUnit>(&"graph_grade_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let vehicle_configs = params
-            .get_config_array("vehicles".to_string(), traversal_key.clone())
+            .get_config_array(&"vehicles", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let mut vehicle_library = HashMap::new();
 
         for vehicle_config in vehicle_configs {
             let vehicle_type = vehicle_config
-                .get_config_string(String::from("type"), traversal_key.clone())
+                .get_config_string(&"type", &traversal_key)
                 .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
             let vehicle_builder = VehicleBuilder::from_string(vehicle_type).map_err(|e| {
                 TraversalModelError::BuildError(format!("Error building vehicle builder: {}", e))
@@ -66,16 +54,10 @@ impl TraversalModelBuilder for EnergyModelBuilder {
         }
 
         let output_time_unit_option = params
-            .get_config_serde_optional::<TimeUnit>(
-                String::from("output_time_unit"),
-                traversal_key.clone(),
-            )
+            .get_config_serde_optional::<TimeUnit>(&"output_time_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let output_distance_unit_option = params
-            .get_config_serde_optional::<DistanceUnit>(
-                String::from("output_distance_unit"),
-                traversal_key.clone(),
-            )
+            .get_config_serde_optional::<DistanceUnit>(&"output_distance_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let service = EnergyModelService::new(

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_vehicle_builders.rs
@@ -52,9 +52,9 @@ fn build_conventional(
     parameters: &serde_json::Value,
 ) -> Result<Arc<dyn VehicleType>, CompassConfigurationError> {
     let vehicle_key = String::from("ice");
-    let name = parameters.get_config_string(String::from("name"), vehicle_key.clone())?;
+    let name = parameters.get_config_string(&"name", &vehicle_key)?;
 
-    let model_record = get_model_record_from_params(parameters, name.clone())?;
+    let model_record = get_model_record_from_params(parameters, &name)?;
 
     let vehicle = ICE::new(name, model_record)?;
 
@@ -64,17 +64,13 @@ fn build_conventional(
 fn build_battery_electric(
     parameters: &serde_json::Value,
 ) -> Result<Arc<dyn VehicleType>, CompassConfigurationError> {
-    let vehicle_key = String::from("bev");
-    let name = parameters.get_config_string(String::from("name"), vehicle_key.clone())?;
+    let name = parameters.get_config_string(&"name", &"bev")?;
 
-    let model_record = get_model_record_from_params(parameters, name.clone())?;
+    let model_record = get_model_record_from_params(parameters, &name)?;
 
-    let battery_capacity = parameters
-        .get_config_serde::<Energy>(String::from("battery_capacity"), vehicle_key.clone())?;
-    let battery_energy_unit = parameters.get_config_serde::<EnergyUnit>(
-        String::from("battery_capacity_unit"),
-        vehicle_key.clone(),
-    )?;
+    let battery_capacity = parameters.get_config_serde::<Energy>(&"battery_capacity", &"bev")?;
+    let battery_energy_unit =
+        parameters.get_config_serde::<EnergyUnit>(&"battery_capacity_unit", &"bev")?;
     let starting_battery_energy = battery_capacity;
 
     let vehicle = BEV::new(
@@ -91,35 +87,29 @@ fn build_battery_electric(
 fn build_plugin_hybrid(
     parameters: &serde_json::Value,
 ) -> Result<Arc<dyn VehicleType>, CompassConfigurationError> {
-    let vehicle_key = String::from("phev");
-    let name = parameters.get_config_string(String::from("name"), vehicle_key.clone())?;
+    let name = parameters.get_config_string(&"name", &"phev")?;
 
     let charge_depleting_params =
         parameters.get_config_section(CompassConfigurationField::ChargeDepleting)?;
 
     let charge_depleting_record = get_model_record_from_params(
         &charge_depleting_params,
-        format!("charge_depleting: {}", name.clone()),
+        &format!("charge_depleting: {}", &name),
     )?;
     let charge_sustain_params =
         parameters.get_config_section(CompassConfigurationField::ChargeSustaining)?;
 
     let charge_sustain_record = get_model_record_from_params(
         &charge_sustain_params,
-        format!("charge_sustain: {}", name.clone()),
+        &format!("charge_sustain: {}", &name),
     )?;
 
-    let battery_capacity = parameters
-        .get_config_serde::<Energy>(String::from("battery_capacity"), vehicle_key.clone())?;
-    let battery_energy_unit = parameters.get_config_serde::<EnergyUnit>(
-        String::from("battery_capacity_unit"),
-        vehicle_key.clone(),
-    )?;
+    let battery_capacity = parameters.get_config_serde::<Energy>(&"battery_capacity", &"phev")?;
+    let battery_energy_unit =
+        parameters.get_config_serde::<EnergyUnit>(&"battery_capacity_unit", &"phev")?;
 
-    let custom_liquid_fuel_to_kwh = parameters.get_config_serde_optional::<f64>(
-        String::from("custom_liquid_fuel_to_kwh"),
-        vehicle_key.clone(),
-    )?;
+    let custom_liquid_fuel_to_kwh =
+        parameters.get_config_serde_optional::<f64>(&"custom_liquid_fuel_to_kwh", &"phev")?;
     let starting_battery_energy = battery_capacity;
     let phev = PHEV::new(
         name,
@@ -135,33 +125,23 @@ fn build_plugin_hybrid(
 
 fn get_model_record_from_params(
     parameters: &serde_json::Value,
-    parent_key: String,
+    parent_key: &String,
 ) -> Result<PredictionModelRecord, CompassConfigurationError> {
-    let name = parameters.get_config_string(String::from("name"), parent_key.clone())?;
-    let model_path =
-        parameters.get_config_path(String::from("model_input_file"), parent_key.clone())?;
-    let model_type =
-        parameters.get_config_serde::<ModelType>(String::from("model_type"), parent_key.clone())?;
-    let speed_unit =
-        parameters.get_config_serde::<SpeedUnit>(String::from("speed_unit"), parent_key.clone())?;
-    let ideal_energy_rate_option = parameters.get_config_serde_optional::<EnergyRate>(
-        String::from("ideal_energy_rate"),
-        parent_key.clone(),
-    )?;
-    let grade_unit =
-        parameters.get_config_serde::<GradeUnit>(String::from("grade_unit"), parent_key.clone())?;
+    let name = parameters.get_config_string(&"name", &parent_key)?;
+    let model_path = parameters.get_config_path(&"model_input_file", &parent_key)?;
+    let model_type = parameters.get_config_serde::<ModelType>(&"model_type", &parent_key)?;
+    let speed_unit = parameters.get_config_serde::<SpeedUnit>(&"speed_unit", &parent_key)?;
+    let ideal_energy_rate_option =
+        parameters.get_config_serde_optional::<EnergyRate>(&"ideal_energy_rate", &parent_key)?;
+    let grade_unit = parameters.get_config_serde::<GradeUnit>(&"grade_unit", &parent_key)?;
 
-    let energy_rate_unit = parameters
-        .get_config_serde::<EnergyRateUnit>(String::from("energy_rate_unit"), parent_key.clone())?;
-    let real_world_energy_adjustment_option = parameters.get_config_serde_optional::<f64>(
-        String::from("real_world_energy_adjustment"),
-        parent_key.clone(),
-    )?;
+    let energy_rate_unit =
+        parameters.get_config_serde::<EnergyRateUnit>(&"energy_rate_unit", &parent_key)?;
+    let real_world_energy_adjustment_option = parameters
+        .get_config_serde_optional::<f64>(&"real_world_energy_adjustment", &parent_key)?;
 
-    let cache_config = parameters.get_config_serde_optional::<FloatCachePolicyConfig>(
-        String::from("float_cache_policy"),
-        parent_key.clone(),
-    )?;
+    let cache_config = parameters
+        .get_config_serde_optional::<FloatCachePolicyConfig>(&"float_cache_policy", parent_key)?;
 
     let cache = match cache_config {
         Some(config) => Some(FloatCachePolicy::from_config(config)?),

--- a/rust/routee-compass/src/app/compass/config/traversal_model/speed_lookup_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/speed_lookup_builder.rs
@@ -22,25 +22,16 @@ impl TraversalModelBuilder for SpeedLookupBuilder {
         let traversal_key = CompassConfigurationField::Traversal.to_string();
         // todo: optional output time unit
         let filename = params
-            .get_config_path(
-                String::from("speed_table_input_file"),
-                traversal_key.clone(),
-            )
+            .get_config_path(&"speed_table_input_file", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let speed_unit = params
-            .get_config_serde::<SpeedUnit>(String::from("speed_unit"), traversal_key.clone())
+            .get_config_serde::<SpeedUnit>(&"speed_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let distance_unit = params
-            .get_config_serde_optional::<DistanceUnit>(
-                String::from("output_distance_unit"),
-                traversal_key.clone(),
-            )
+            .get_config_serde_optional::<DistanceUnit>(&"output_distance_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let time_unit = params
-            .get_config_serde_optional::<TimeUnit>(
-                String::from("output_time_unit"),
-                traversal_key.clone(),
-            )
+            .get_config_serde_optional::<TimeUnit>(&"output_time_unit", &traversal_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let m = SpeedLookupModel::new(&filename, speed_unit, distance_unit, time_unit)?;

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
@@ -30,9 +30,8 @@ impl InputPlugin for EdgeRtreeInputPlugin {
     /// finds the nearest edge ids to the user-provided origin and destination coordinates.
     /// optionally restricts the search to a subset of road classes tagged by the user.
     fn process(&self, query: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
-        let road_classes_key = String::from("road_classes");
         let road_classes = query
-            .get_config_serde_optional::<HashSet<String>>(road_classes_key, String::from(""))
+            .get_config_serde_optional::<HashSet<String>>(&"road_classes", &"")
             .map_err(|e| {
                 PluginError::InputError(format!("unable to deserialize as array: {}", e))
             })?;

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
@@ -16,19 +16,13 @@ impl InputPluginBuilder for EdgeRtreeInputPluginBuilder {
         parameters: &serde_json::Value,
     ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("edge_rtree");
-        let linestring_file =
-            parameters.get_config_path(String::from("geometry_input_file"), parent_key.clone())?;
-        let road_class_file = parameters
-            .get_config_path(String::from("road_class_input_file"), parent_key.clone())?;
+        let linestring_file = parameters.get_config_path(&"geometry_input_file", &parent_key)?;
+        let road_class_file = parameters.get_config_path(&"road_class_input_file", &parent_key)?;
 
-        let distance_tolerance_option = parameters.get_config_serde_optional::<Distance>(
-            String::from("distance_tolerance"),
-            parent_key.clone(),
-        )?;
-        let distance_unit_option = parameters.get_config_serde_optional::<DistanceUnit>(
-            String::from("distance_unit"),
-            parent_key.clone(),
-        )?;
+        let distance_tolerance_option =
+            parameters.get_config_serde_optional::<Distance>(&"distance_tolerance", &parent_key)?;
+        let distance_unit_option =
+            parameters.get_config_serde_optional::<DistanceUnit>(&"distance_unit", &parent_key)?;
 
         let plugin = EdgeRtreeInputPlugin::new(
             &road_class_file,

--- a/rust/routee-compass/src/plugin/input/default/inject/inject_builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/inject_builder.rs
@@ -14,11 +14,9 @@ impl InputPluginBuilder for InjectPluginBuilder {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
-        let key = parameters.get_config_string(String::from("key"), String::from("inject"))?;
-        let value_string =
-            parameters.get_config_string(String::from("value"), String::from("inject"))?;
-        let format: InjectFormat =
-            parameters.get_config_serde(String::from("format"), String::from("inject"))?;
+        let key = parameters.get_config_string(&"key", &"inject")?;
+        let value_string = parameters.get_config_string(&"value", &"inject")?;
+        let format: InjectFormat = parameters.get_config_serde(&"format", &"inject")?;
         let value = format.to_json(&value_string)?;
         let plugin = InjectInputPlugin::new(key, value);
         Ok(Box::new(plugin))

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/builder.rs
@@ -15,10 +15,8 @@ impl InputPluginBuilder for LoadBalancerBuilder {
         &self,
         params: &serde_json::Value,
     ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
-        let heuristic = params.get_config_serde::<WeightHeuristic>(
-            String::from("weight_heuristic"),
-            String::from("load_balancer"),
-        )?;
+        let heuristic =
+            params.get_config_serde::<WeightHeuristic>(&"weight_heuristic", &"load_balancer")?;
         Ok(Box::new(LoadBalancerPlugin { heuristic }))
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/custom_weight_type.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/custom_weight_type.rs
@@ -34,7 +34,7 @@ impl CustomWeightType {
                     .to_owned()
                     .unwrap_or(InputField::QueryWeightEstimate.to_string());
                 let value = query
-                    .get_config_f64(col.clone(), String::from("custom_weight_type"))
+                    .get_config_f64(&col, &"custom_weight_type")
                     .map_err(|_| PluginError::ParseError(col, String::from("String")))?;
                 Ok(value)
             }
@@ -47,7 +47,7 @@ impl CustomWeightType {
                     .to_owned()
                     .unwrap_or(InputField::QueryWeightEstimate.to_string());
                 let categorical_value = query
-                    .get_config_string(col.clone(), String::from("custom_weight_type"))
+                    .get_config_string(&col, &"custom_weight_type")
                     .map_err(|_| PluginError::ParseError(col.clone(), String::from("String")))?;
                 match (mapping.get(&categorical_value), default) {
                     (Some(result), _) => Ok(*result),

--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/builder.rs
@@ -18,16 +18,11 @@ impl InputPluginBuilder for VertexRTreeBuilder {
         parameters: &serde_json::Value,
     ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("Vertex RTree Input Plugin");
-        let vertex_filename_key = String::from("vertices_input_file");
-        let vertex_path = parameters.get_config_path(vertex_filename_key, parent_key.clone())?;
-        let tolerance_distance = parameters.get_config_serde_optional::<Distance>(
-            String::from("distance_tolerance"),
-            parent_key.clone(),
-        )?;
-        let distance_unit = parameters.get_config_serde_optional::<DistanceUnit>(
-            String::from("distance_unit"),
-            parent_key.clone(),
-        )?;
+        let vertex_path = parameters.get_config_path(&"vertices_input_file", &parent_key)?;
+        let tolerance_distance =
+            parameters.get_config_serde_optional::<Distance>(&"distance_tolerance", &parent_key)?;
+        let distance_unit =
+            parameters.get_config_serde_optional::<DistanceUnit>(&"distance_unit", &parent_key)?;
         let rtree = RTreePlugin::new(&vertex_path, tolerance_distance, distance_unit)
             .map_err(CompassConfigurationError::PluginError)?;
         let m: Box<dyn InputPlugin> = Box::new(rtree);

--- a/rust/routee-compass/src/plugin/output/default/to_disk/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/to_disk/builder.rs
@@ -21,10 +21,7 @@ impl OutputPluginBuilder for ToDiskOutputPluginBuilder {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
-        let output_filename_key = String::from("output_file");
-        let output_filename =
-            parameters.get_config_string(output_filename_key, String::from("output"))?;
-
+        let output_filename = parameters.get_config_string(&"output_file", &"output")?;
         let output_file_path = PathBuf::from(&output_filename);
 
         // initialize the file with nothing

--- a/rust/routee-compass/src/plugin/output/default/traversal/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/builder.rs
@@ -40,16 +40,12 @@ impl OutputPluginBuilder for TraversalPluginBuilder {
         parameters: &serde_json::Value,
     ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("traversal");
-        let geometry_filename_key = String::from("geometry_input_file");
-        let route_geometry_key = String::from("route");
-        let tree_geometry_key = String::from("tree");
 
-        let geometry_filename =
-            parameters.get_config_path(geometry_filename_key, parent_key.clone())?;
+        let geometry_filename = parameters.get_config_path(&"geometry_input_file", &parent_key)?;
         let route: Option<TraversalOutputFormat> =
-            parameters.get_config_serde_optional(route_geometry_key, parent_key.clone())?;
+            parameters.get_config_serde_optional(&"route", &parent_key)?;
         let tree: Option<TraversalOutputFormat> =
-            parameters.get_config_serde_optional(tree_geometry_key, parent_key.clone())?;
+            parameters.get_config_serde_optional(&"tree", &parent_key)?;
 
         let geom_plugin = TraversalPlugin::from_file(&geometry_filename, route, tree)?;
         Ok(Box::new(geom_plugin))

--- a/rust/routee-compass/src/plugin/output/default/uuid/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/uuid/builder.rs
@@ -15,8 +15,7 @@ impl OutputPluginBuilder for UUIDOutputPluginBuilder {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
-        let uuid_filename_key = String::from("uuid_input_file");
-        let uuid_filename = parameters.get_config_path(uuid_filename_key, String::from("uuid"))?;
+        let uuid_filename = parameters.get_config_path(&"uuid_input_file", &"uuid")?;
 
         let uuid_plugin = UUIDOutputPlugin::from_file(&uuid_filename)
             .map_err(CompassConfigurationError::PluginError)?;


### PR DESCRIPTION
### edit

this PR modified the signature of methods in `config_json_extension.rs` so that string arguments are _references_ and they can be `String` or `str` types. this makes it so cloning of key names is no longer required for using these methods and at the same time, allows `'static str` arguments, which greatly reduces boilerplate for some applications.

### original post

Nick - started this work to relax what we can pass as arguments to the JSON getter extensions we have. this
1. removes the need to `.clone()` keys a lot
2. relax the types we can pass as arguments, so that &str and &String arguments are both valid:

```rust
let parent_1 = String::from("iteration termination function");
let x = config.get_config_i64(&"limit", &parent_1);
```

just letting you know about it, it's going to touch a lot of files, just making sure this doesn't mess with anything you are up to this morning.

Closes #79.