### PR TITLE
Add turn restrictions

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -30,7 +30,7 @@ pub fn run_a_star(
     directed_graph: Arc<ExecutorReadOnlyLock<Graph>>,
     m: Arc<dyn TraversalModel>,
     u: CostModel,
-    f: Arc<dyn FrontierModel>,
+    f: &[Arc<dyn FrontierModel>],
     termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
 ) -> Result<MinSearchTree, SearchError> {
     if target.map_or(false, |t| t == source) {
@@ -106,6 +106,12 @@ pub fn run_a_star(
                 current_vertex_id
             ))
         })?;
+        // grab the previous edge, if it exists
+        let previous_edge = current
+            .prev_edge_id
+            .map(|prev_edge_id| g.get_edge(prev_edge_id))
+            .transpose()
+            .map_err(SearchError::GraphError)?;
 
         // visit all neighbors of this source vertex
         let neighbor_triplets = g
@@ -114,8 +120,10 @@ pub fn run_a_star(
         for (src_id, edge_id, dst_id) in neighbor_triplets {
             // first make sure we have a valid edge
             let e = g.get_edge(edge_id).map_err(SearchError::GraphError)?;
-            if !f.valid_frontier(e, &current.state)? {
-                continue;
+            for frontier_model in f {
+                if !frontier_model.valid_frontier(&e, &current.state, previous_edge)? {
+                    continue;
+                }
             }
             let et = EdgeTraversal::perform_traversal(
                 edge_id,
@@ -197,7 +205,7 @@ pub fn run_a_star_edge_oriented(
     directed_graph: Arc<ExecutorReadOnlyLock<Graph>>,
     m: Arc<dyn TraversalModel>,
     u: CostModel,
-    f: Arc<dyn FrontierModel>,
+    f: &[Arc<dyn FrontierModel>],
     termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
 ) -> Result<MinSearchTree, SearchError> {
     // 1. guard against edge conditions (src==dst, src.dst_v == dst.src_v)
@@ -225,7 +233,7 @@ pub fn run_a_star_edge_oriented(
                 directed_graph.clone(),
                 m.clone(),
                 u,
-                f.clone(),
+                f,
                 termination_model,
             )?;
             if !tree.contains_key(&source_edge_dst_vertex_id) {
@@ -274,7 +282,7 @@ pub fn run_a_star_edge_oriented(
                     directed_graph.clone(),
                     m.clone(),
                     u,
-                    f.clone(),
+                    f,
                     termination_model,
                 )?;
 
@@ -336,7 +344,6 @@ pub fn h_cost(
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::algorithm::search::backtrack::vertex_oriented_route;
     use crate::model::cost::cost_aggregation::CostAggregation;
@@ -461,9 +468,9 @@ mod tests {
                     Arc::new(HashMap::new()),
                     CostAggregation::Sum,
                 );
-                let fm_inner = Arc::new(NoRestriction {});
+                let fm_inner: Vec<Arc<dyn FrontierModel>> = vec![Arc::new(NoRestriction {})];
                 let rm_inner = Arc::new(driver_rm.read_only());
-                run_a_star(o, Some(d), dg_inner, dist_tm, dist_um, fm_inner, rm_inner)
+                run_a_star(o, Some(d), dg_inner, dist_tm, dist_um, &fm_inner, rm_inner)
             })
             .collect();
 

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -121,7 +121,7 @@ pub fn run_a_star(
             // first make sure we have a valid edge
             let e = g.get_edge(edge_id).map_err(SearchError::GraphError)?;
             for frontier_model in f {
-                if !frontier_model.valid_frontier(&e, &current.state, previous_edge)? {
+                if !frontier_model.valid_frontier(e, &current.state, previous_edge)? {
                     continue;
                 }
             }

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -27,6 +27,7 @@ impl TryFrom<&serde_json::Value> for SearchAlgorithm {
 }
 
 impl SearchAlgorithm {
+    #[allow(clippy::too_many_arguments)]
     pub fn run_vertex_oriented(
         &self,
         origin: VertexId,
@@ -49,6 +50,7 @@ impl SearchAlgorithm {
             ),
         }
     }
+    #[allow(clippy::too_many_arguments)]
     pub fn run_edge_oriented(
         &self,
         origin: EdgeId,

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -34,7 +34,7 @@ impl SearchAlgorithm {
         graph: Arc<ExecutorReadOnlyLock<Graph>>,
         traversal_model: Arc<dyn TraversalModel>,
         cost_model: CostModel,
-        frontier_model: &[Arc<dyn FrontierModel>],
+        frontier_model: Arc<dyn FrontierModel>,
         termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
     ) -> Result<MinSearchTree, SearchError> {
         match self {
@@ -56,7 +56,7 @@ impl SearchAlgorithm {
         graph: Arc<ExecutorReadOnlyLock<Graph>>,
         traversal_model: Arc<dyn TraversalModel>,
         cost_model: CostModel,
-        frontier_model: &[Arc<dyn FrontierModel>],
+        frontier_model: Arc<dyn FrontierModel>,
         termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
     ) -> Result<MinSearchTree, SearchError> {
         match self {

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -34,7 +34,7 @@ impl SearchAlgorithm {
         graph: Arc<ExecutorReadOnlyLock<Graph>>,
         traversal_model: Arc<dyn TraversalModel>,
         cost_model: CostModel,
-        frontier_model: Arc<dyn FrontierModel>,
+        frontier_model: &[Arc<dyn FrontierModel>],
         termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
     ) -> Result<MinSearchTree, SearchError> {
         match self {
@@ -56,7 +56,7 @@ impl SearchAlgorithm {
         graph: Arc<ExecutorReadOnlyLock<Graph>>,
         traversal_model: Arc<dyn TraversalModel>,
         cost_model: CostModel,
-        frontier_model: Arc<dyn FrontierModel>,
+        frontier_model: &[Arc<dyn FrontierModel>],
         termination_model: Arc<ExecutorReadOnlyLock<TerminationModel>>,
     ) -> Result<MinSearchTree, SearchError> {
         match self {

--- a/rust/routee-compass-core/src/model/frontier/frontier_model.rs
+++ b/rust/routee-compass-core/src/model/frontier/frontier_model.rs
@@ -15,6 +15,7 @@ pub trait FrontierModel: Send + Sync {
     ///
     /// * `edge` - the edge to traverse
     /// * `state` - the state of the traversal at the beginning of this edge
+    /// * `previous_edge` - the edge that was traversed to reach this edge
     ///
     /// # Returns
     ///
@@ -23,6 +24,7 @@ pub trait FrontierModel: Send + Sync {
         &self,
         _edge: &Edge,
         _state: &TraversalState,
+        _previous_edge: Option<&Edge>,
     ) -> Result<bool, FrontierModelError> {
         Ok(true)
     }

--- a/rust/routee-compass/src/app/compass/config/builders.rs
+++ b/rust/routee-compass/src/app/compass/config/builders.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::compass_configuration_error::CompassConfigurationError;
 use crate::plugin::{input::input_plugin::InputPlugin, output::output_plugin::OutputPlugin};
 
@@ -23,7 +25,7 @@ pub trait InputPluginBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError>;
+    ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError>;
 }
 
 /// A [`OutputPluginBuilder`] takes a JSON object describing the configuration of an
@@ -48,5 +50,5 @@ pub trait OutputPluginBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError>;
+    ) -> Result<Arc<dyn OutputPlugin>, CompassConfigurationError>;
 }

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -6,6 +6,7 @@ use super::{
     frontier_model::{
         no_restriction_builder::NoRestrictionBuilder,
         road_class::road_class_builder::RoadClassBuilder,
+        turn_restrictions::turn_restriction_builder::TurnRestrictionBuilder,
     },
     traversal_model::{
         distance_builder::DistanceBuilder, energy_model_builder::EnergyModelBuilder,
@@ -129,9 +130,11 @@ impl CompassAppBuilder {
         // Frontier model builders
         let no_restriction: Box<dyn FrontierModelBuilder> = Box::new(NoRestrictionBuilder {});
         let road_class: Box<dyn FrontierModelBuilder> = Box::new(RoadClassBuilder {});
+        let turn_restruction: Box<dyn FrontierModelBuilder> = Box::new(TurnRestrictionBuilder {});
         let frontier_builders: HashMap<String, Box<dyn FrontierModelBuilder>> = HashMap::from([
             (String::from("no_restriction"), no_restriction),
             (String::from("road_class"), road_class),
+            (String::from("turn_restriction"), turn_restruction),
         ]);
 
         // Input plugin builders
@@ -209,7 +212,7 @@ impl CompassAppBuilder {
     /// frontier model configuration JSON
     pub fn build_frontier_model_service(
         &self,
-        config: serde_json::Value,
+        config: &serde_json::Value,
     ) -> Result<Arc<dyn FrontierModelService>, CompassConfigurationError> {
         let fm_type_obj =
             config
@@ -233,7 +236,7 @@ impl CompassAppBuilder {
                 self.frontier_builders.keys().join(", "),
             ))
             .and_then(|b| {
-                b.build(&config)
+                b.build(config)
                     .map_err(CompassConfigurationError::FrontierModelError)
             })
     }

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -4,7 +4,7 @@ use super::{
     compass_configuration_field::CompassConfigurationField,
     config_json_extension::ConfigJsonExtensions,
     frontier_model::{
-        no_restriction_builder::NoRestrictionBuilder,
+        combined::combined_builder::CombinedBuilder, no_restriction_builder::NoRestrictionBuilder,
         road_class::road_class_builder::RoadClassBuilder,
         turn_restrictions::turn_restriction_builder::TurnRestrictionBuilder,
     },
@@ -32,6 +32,7 @@ use crate::plugin::{
         output_plugin::OutputPlugin,
     },
 };
+use clap::builder::Str;
 use itertools::Itertools;
 use routee_compass_core::model::{
     frontier::{
@@ -42,7 +43,7 @@ use routee_compass_core::model::{
         traversal_model_service::TraversalModelService,
     },
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc, sync::Arc};
 
 /// Upstream component factory of [`crate::app::compass::compass_app::CompassApp`]
 /// that builds components when constructing a CompassApp instance.
@@ -67,10 +68,10 @@ use std::{collections::HashMap, sync::Arc};
 /// * `output_plugin_builders` - a mapping of OutputPlugin `type` names to builders
 ///
 pub struct CompassAppBuilder {
-    pub traversal_model_builders: HashMap<String, Box<dyn TraversalModelBuilder>>,
-    pub frontier_builders: HashMap<String, Box<dyn FrontierModelBuilder>>,
-    pub input_plugin_builders: HashMap<String, Box<dyn InputPluginBuilder>>,
-    pub output_plugin_builders: HashMap<String, Box<dyn OutputPluginBuilder>>,
+    pub traversal_model_builders: HashMap<String, Rc<dyn TraversalModelBuilder>>,
+    pub frontier_builders: HashMap<String, Rc<dyn FrontierModelBuilder>>,
+    pub input_plugin_builders: HashMap<String, Rc<dyn InputPluginBuilder>>,
+    pub output_plugin_builders: HashMap<String, Rc<dyn OutputPluginBuilder>>,
 }
 
 impl CompassAppBuilder {
@@ -93,19 +94,19 @@ impl CompassAppBuilder {
         }
     }
 
-    pub fn add_traversal_model(&mut self, name: String, builder: Box<dyn TraversalModelBuilder>) {
+    pub fn add_traversal_model(&mut self, name: String, builder: Rc<dyn TraversalModelBuilder>) {
         let _ = self.traversal_model_builders.insert(name, builder);
     }
 
-    pub fn add_frontier_model(&mut self, name: String, builder: Box<dyn FrontierModelBuilder>) {
+    pub fn add_frontier_model(&mut self, name: String, builder: Rc<dyn FrontierModelBuilder>) {
         let _ = self.frontier_builders.insert(name, builder);
     }
 
-    pub fn add_input_plugin(&mut self, name: String, builder: Box<dyn InputPluginBuilder>) {
+    pub fn add_input_plugin(&mut self, name: String, builder: Rc<dyn InputPluginBuilder>) {
         let _ = self.input_plugin_builders.insert(name, builder);
     }
 
-    pub fn add_output_plugin(&mut self, name: String, builder: Box<dyn OutputPluginBuilder>) {
+    pub fn add_output_plugin(&mut self, name: String, builder: Rc<dyn OutputPluginBuilder>) {
         let _ = self.output_plugin_builders.insert(name, builder);
     }
 
@@ -118,31 +119,37 @@ impl CompassAppBuilder {
     /// * an instance of a CompassAppBuilder that can be used to build a CompassApp
     fn default() -> CompassAppBuilder {
         // Traversal model builders
-        let dist: Box<dyn TraversalModelBuilder> = Box::new(DistanceBuilder {});
-        let velo: Box<dyn TraversalModelBuilder> = Box::new(SpeedLookupBuilder {});
-        let energy_model: Box<dyn TraversalModelBuilder> = Box::new(EnergyModelBuilder {});
-        let tm_builders: HashMap<String, Box<dyn TraversalModelBuilder>> = HashMap::from([
+        let dist: Rc<dyn TraversalModelBuilder> = Rc::new(DistanceBuilder {});
+        let velo: Rc<dyn TraversalModelBuilder> = Rc::new(SpeedLookupBuilder {});
+        let energy_model: Rc<dyn TraversalModelBuilder> = Rc::new(EnergyModelBuilder {});
+        let tm_builders: HashMap<String, Rc<dyn TraversalModelBuilder>> = HashMap::from([
             (String::from("distance"), dist),
             (String::from("speed_table"), velo),
             (String::from("energy_model"), energy_model),
         ]);
 
         // Frontier model builders
-        let no_restriction: Box<dyn FrontierModelBuilder> = Box::new(NoRestrictionBuilder {});
-        let road_class: Box<dyn FrontierModelBuilder> = Box::new(RoadClassBuilder {});
-        let turn_restruction: Box<dyn FrontierModelBuilder> = Box::new(TurnRestrictionBuilder {});
-        let frontier_builders: HashMap<String, Box<dyn FrontierModelBuilder>> = HashMap::from([
-            (String::from("no_restriction"), no_restriction),
-            (String::from("road_class"), road_class),
-            (String::from("turn_restriction"), turn_restruction),
-        ]);
+        let no_restriction: Rc<dyn FrontierModelBuilder> = Rc::new(NoRestrictionBuilder {});
+        let road_class: Rc<dyn FrontierModelBuilder> = Rc::new(RoadClassBuilder {});
+        let turn_restruction: Rc<dyn FrontierModelBuilder> = Rc::new(TurnRestrictionBuilder {});
+        let base_frontier_builders: HashMap<String, Rc<dyn FrontierModelBuilder>> =
+            HashMap::from([
+                (String::from("no_restriction"), no_restriction),
+                (String::from("road_class"), road_class),
+                (String::from("turn_restriction"), turn_restruction),
+            ]);
+        let combined = Rc::new(CombinedBuilder {
+            builders: base_frontier_builders.clone(),
+        });
+        let mut all_frontier_builders = base_frontier_builders.clone();
+        all_frontier_builders.insert(String::from("combined"), combined);
 
         // Input plugin builders
-        let grid_search: Box<dyn InputPluginBuilder> = Box::new(GridSearchBuilder {});
-        let vertex_tree: Box<dyn InputPluginBuilder> = Box::new(VertexRTreeBuilder {});
-        let edge_rtree: Box<dyn InputPluginBuilder> = Box::new(EdgeRtreeInputPluginBuilder {});
-        let load_balancer: Box<dyn InputPluginBuilder> = Box::new(LoadBalancerBuilder {});
-        let inject: Box<dyn InputPluginBuilder> = Box::new(InjectPluginBuilder {});
+        let grid_search: Rc<dyn InputPluginBuilder> = Rc::new(GridSearchBuilder {});
+        let vertex_tree: Rc<dyn InputPluginBuilder> = Rc::new(VertexRTreeBuilder {});
+        let edge_rtree: Rc<dyn InputPluginBuilder> = Rc::new(EdgeRtreeInputPluginBuilder {});
+        let load_balancer: Rc<dyn InputPluginBuilder> = Rc::new(LoadBalancerBuilder {});
+        let inject: Rc<dyn InputPluginBuilder> = Rc::new(InjectPluginBuilder {});
         let input_plugin_builders = HashMap::from([
             (String::from("grid_search"), grid_search),
             (String::from("vertex_rtree"), vertex_tree),
@@ -152,11 +159,11 @@ impl CompassAppBuilder {
         ]);
 
         // Output plugin builders
-        let traversal: Box<dyn OutputPluginBuilder> = Box::new(TraversalPluginBuilder {});
-        let summary: Box<dyn OutputPluginBuilder> = Box::new(SummaryOutputPluginBuilder {});
-        let uuid: Box<dyn OutputPluginBuilder> = Box::new(UUIDOutputPluginBuilder {});
-        let edge_id_list: Box<dyn OutputPluginBuilder> = Box::new(EdgeIdListOutputPluginBuilder {});
-        let to_disk: Box<dyn OutputPluginBuilder> = Box::new(ToDiskOutputPluginBuilder {});
+        let traversal: Rc<dyn OutputPluginBuilder> = Rc::new(TraversalPluginBuilder {});
+        let summary: Rc<dyn OutputPluginBuilder> = Rc::new(SummaryOutputPluginBuilder {});
+        let uuid: Rc<dyn OutputPluginBuilder> = Rc::new(UUIDOutputPluginBuilder {});
+        let edge_id_list: Rc<dyn OutputPluginBuilder> = Rc::new(EdgeIdListOutputPluginBuilder {});
+        let to_disk: Rc<dyn OutputPluginBuilder> = Rc::new(ToDiskOutputPluginBuilder {});
         let output_plugin_builders = HashMap::from([
             (String::from("traversal"), traversal),
             (String::from("summary"), summary),
@@ -167,7 +174,7 @@ impl CompassAppBuilder {
 
         CompassAppBuilder {
             traversal_model_builders: tm_builders,
-            frontier_builders,
+            frontier_builders: all_frontier_builders,
             input_plugin_builders,
             output_plugin_builders,
         }
@@ -244,13 +251,13 @@ impl CompassAppBuilder {
     pub fn build_input_plugins(
         &self,
         config: &serde_json::Value,
-    ) -> Result<Vec<Box<dyn InputPlugin>>, CompassConfigurationError> {
+    ) -> Result<Vec<Arc<dyn InputPlugin>>, CompassConfigurationError> {
         let input_plugins = config.get_config_array(
             &CompassConfigurationField::InputPlugins,
             &CompassConfigurationField::Plugins,
         )?;
 
-        let mut plugins: Vec<Box<dyn InputPlugin>> = Vec::new();
+        let mut plugins: Vec<Arc<dyn InputPlugin>> = Vec::new();
         for plugin_json in input_plugins.into_iter() {
             let plugin_type_obj =
                 plugin_json
@@ -287,13 +294,13 @@ impl CompassAppBuilder {
     pub fn build_output_plugins(
         &self,
         config: &serde_json::Value,
-    ) -> Result<Vec<Box<dyn OutputPlugin>>, CompassConfigurationError> {
+    ) -> Result<Vec<Arc<dyn OutputPlugin>>, CompassConfigurationError> {
         let output_plugins = config.get_config_array(
             &CompassConfigurationField::OutputPlugins,
             &CompassConfigurationField::Plugins,
         )?;
 
-        let mut plugins: Vec<Box<dyn OutputPlugin>> = Vec::new();
+        let mut plugins: Vec<Arc<dyn OutputPlugin>> = Vec::new();
         for plugin_json in output_plugins.into_iter() {
             let plugin_json_obj =
                 plugin_json

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -32,7 +32,7 @@ use crate::plugin::{
         output_plugin::OutputPlugin,
     },
 };
-use clap::builder::Str;
+
 use itertools::Itertools;
 use routee_compass_core::model::{
     frontier::{

--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
@@ -27,7 +27,7 @@ impl CostModelService {
     ) -> Result<CostModelService, CompassConfigurationError> {
         let vehicle_rates = vehicle_state_variable_rates
             .unwrap_or(CostModelService::default_vehicle_state_variable_rates());
-        let network_rates = network_state_variable_rates.unwrap_or(HashMap::new());
+        let network_rates = network_state_variable_rates.unwrap_or_default();
         let coefficients = match default_state_variable_coefficients {
             Some(coefficients) => {
                 if coefficients.is_empty() {

--- a/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_builder.rs
@@ -1,0 +1,81 @@
+use crate::app::compass::config::{
+    compass_configuration_error::CompassConfigurationError,
+    compass_configuration_field::CompassConfigurationField,
+    config_json_extension::ConfigJsonExtensions,
+};
+use itertools::Itertools;
+use routee_compass_core::model::frontier::{
+    frontier_model_builder::FrontierModelBuilder, frontier_model_error::FrontierModelError,
+    frontier_model_service::FrontierModelService,
+};
+use std::{collections::HashMap, rc::Rc, sync::Arc};
+
+use super::combined_service::CombinedFrontierService;
+
+pub struct CombinedBuilder {
+    pub builders: HashMap<String, Rc<dyn FrontierModelBuilder>>,
+}
+
+impl CombinedBuilder {
+    pub fn register_builder(
+        &self,
+        builder_key: String,
+        builder: Rc<dyn FrontierModelBuilder>,
+    ) -> Self {
+        let mut builders = self.builders.clone();
+        builders.insert(builder_key, builder);
+        CombinedBuilder { builders }
+    }
+    fn build_service(
+        &self,
+        config: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModelService>, CompassConfigurationError> {
+        let fm_type_obj =
+            config
+                .get("type")
+                .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
+                    CompassConfigurationField::Frontier.to_string(),
+                    String::from("type"),
+                ))?;
+        let fm_type: String = fm_type_obj
+            .as_str()
+            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
+                String::from("type"),
+                String::from("String"),
+            ))?
+            .into();
+        self.builders
+            .get(&fm_type)
+            .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
+                fm_type.clone(),
+                String::from("frontier"),
+                self.builders.keys().join(", "),
+            ))
+            .and_then(|b| {
+                b.build(config)
+                    .map_err(CompassConfigurationError::FrontierModelError)
+            })
+    }
+}
+
+impl FrontierModelBuilder for CombinedBuilder {
+    fn build(
+        &self,
+        parameters: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModelService>, FrontierModelError> {
+        let frontier_key = CompassConfigurationField::Frontier;
+        let params = parameters
+            .get_config_array(&"models", &frontier_key)
+            .map_err(|e| FrontierModelError::BuildError(e.to_string()))?;
+
+        let inner_services = params
+            .iter()
+            .map(|p| self.build_service(p))
+            .collect::<Result<Vec<Arc<dyn FrontierModelService>>, CompassConfigurationError>>()
+            .map_err(|e| FrontierModelError::BuildError(e.to_string()))?;
+
+        let service = CombinedFrontierService { inner_services };
+
+        Ok(Arc::new(service))
+    }
+}

--- a/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_model.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_model.rs
@@ -1,0 +1,28 @@
+use routee_compass_core::model::{
+    frontier::{frontier_model::FrontierModel, frontier_model_error::FrontierModelError},
+    property::edge::Edge,
+    traversal::state::traversal_state::TraversalState,
+};
+use std::sync::Arc;
+
+pub struct CombinedFrontierModel {
+    pub inner_models: Vec<Arc<dyn FrontierModel>>,
+}
+
+impl FrontierModel for CombinedFrontierModel {
+    fn valid_frontier(
+        &self,
+        edge: &Edge,
+        state: &TraversalState,
+        previous_edge: Option<&Edge>,
+    ) -> Result<bool, FrontierModelError> {
+        // If any of the inner models return an invalid frontier, it invalidates the whole set and we
+        // return an early false. We only return true if all the frontiers are valid.
+        for frontier_model in self.inner_models.iter() {
+            if !frontier_model.valid_frontier(edge, state, previous_edge)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+}

--- a/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_service.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_service.rs
@@ -1,0 +1,27 @@
+use routee_compass_core::model::frontier::{
+    frontier_model::FrontierModel, frontier_model_error::FrontierModelError,
+    frontier_model_service::FrontierModelService,
+};
+use std::sync::Arc;
+
+use super::combined_model::CombinedFrontierModel;
+
+#[derive(Clone)]
+pub struct CombinedFrontierService {
+    pub inner_services: Vec<Arc<dyn FrontierModelService>>,
+}
+
+impl FrontierModelService for CombinedFrontierService {
+    fn build(
+        &self,
+        query: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModel>, FrontierModelError> {
+        let inner_models = self
+            .inner_services
+            .iter()
+            .map(|s| s.build(query))
+            .collect::<Result<Vec<Arc<dyn FrontierModel>>, FrontierModelError>>()?;
+        let model = CombinedFrontierModel { inner_models };
+        Ok(Arc::new(model))
+    }
+}

--- a/rust/routee-compass/src/app/compass/config/frontier_model/combined/mod.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/combined/mod.rs
@@ -1,0 +1,3 @@
+pub mod combined_builder;
+pub mod combined_model;
+pub mod combined_service;

--- a/rust/routee-compass/src/app/compass/config/frontier_model/mod.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/mod.rs
@@ -1,2 +1,3 @@
 pub mod no_restriction_builder;
 pub mod road_class;
+pub mod turn_restrictions;

--- a/rust/routee-compass/src/app/compass/config/frontier_model/mod.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/mod.rs
@@ -1,3 +1,4 @@
+pub mod combined;
 pub mod no_restriction_builder;
 pub mod road_class;
 pub mod turn_restrictions;

--- a/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_model.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_model.rs
@@ -16,6 +16,7 @@ impl FrontierModel for RoadClassFrontierModel {
         &self,
         edge: &Edge,
         _state: &TraversalState,
+        _previous_edge: Option<&Edge>,
     ) -> Result<bool, FrontierModelError> {
         match &self.road_classes {
             None => Ok(true),

--- a/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/mod.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/mod.rs
@@ -1,0 +1,3 @@
+pub mod turn_restriction_builder;
+pub mod turn_restriction_model;
+pub mod turn_restriction_service;

--- a/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_builder.rs
@@ -1,0 +1,57 @@
+use crate::app::compass::config::{
+    compass_configuration_field::CompassConfigurationField,
+    config_json_extension::ConfigJsonExtensions,
+};
+use routee_compass_core::{
+    model::{
+        frontier::{
+            frontier_model_builder::FrontierModelBuilder, frontier_model_error::FrontierModelError,
+            frontier_model_service::FrontierModelService,
+        },
+        road_network::edge_id::EdgeId,
+    },
+    util::fs::read_utils,
+};
+use std::{collections::HashSet, sync::Arc};
+
+use super::turn_restriction_service::TurnRestrictionFrontierService;
+
+pub struct TurnRestrictionBuilder {}
+
+impl FrontierModelBuilder for TurnRestrictionBuilder {
+    fn build(
+        &self,
+        parameters: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModelService>, FrontierModelError> {
+        let frontier_key = CompassConfigurationField::Frontier.to_string();
+        let turn_restriction_file_key = String::from("turn_restriction_input_file");
+
+        let turn_restriction_file = parameters
+            .get_config_path(&turn_restriction_file_key, &frontier_key)
+            .map_err(|e| {
+                FrontierModelError::BuildError(format!(
+                    "configuration error due to {}: {}",
+                    turn_restriction_file_key.clone(),
+                    e
+                ))
+            })?;
+
+        let restricted_edges: HashSet<(EdgeId, EdgeId)> =
+            read_utils::from_csv(&turn_restriction_file, true, None)
+                .map_err(|e| {
+                    FrontierModelError::BuildError(format!(
+                        "configuration error due to {}: {}",
+                        turn_restriction_file_key.clone(),
+                        e
+                    ))
+                })?
+                .iter()
+                .cloned()
+                .collect();
+
+        let m: Arc<dyn FrontierModelService> = Arc::new(TurnRestrictionFrontierService {
+            restricted_edges: Arc::new(restricted_edges),
+        });
+        Ok(m)
+    }
+}

--- a/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_model.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_model.rs
@@ -5,7 +5,7 @@ use routee_compass_core::model::{
 };
 use std::sync::Arc;
 
-use super::turn_restriction_service::TurnRestrictionFrontierService;
+use super::turn_restriction_service::{RestrictedEdgePair, TurnRestrictionFrontierService};
 
 pub struct TurnRestrictionFrontierModel {
     pub service: Arc<TurnRestrictionFrontierService>,
@@ -21,8 +21,11 @@ impl FrontierModel for TurnRestrictionFrontierModel {
         match previous_edge {
             None => Ok(true),
             Some(previous_edge) => {
-                let edge_id_tuple = (previous_edge.edge_id, edge.edge_id);
-                if self.service.restricted_edges.contains(&edge_id_tuple) {
+                let edge_pair = RestrictedEdgePair {
+                    prev_edge_id: previous_edge.edge_id,
+                    next_edge_id: edge.edge_id,
+                };
+                if self.service.restricted_edge_pairs.contains(&edge_pair) {
                     return Ok(false);
                 }
                 Ok(true)

--- a/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_model.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_model.rs
@@ -1,0 +1,32 @@
+use routee_compass_core::model::{
+    frontier::{frontier_model::FrontierModel, frontier_model_error::FrontierModelError},
+    property::edge::Edge,
+    traversal::state::traversal_state::TraversalState,
+};
+use std::sync::Arc;
+
+use super::turn_restriction_service::TurnRestrictionFrontierService;
+
+pub struct TurnRestrictionFrontierModel {
+    pub service: Arc<TurnRestrictionFrontierService>,
+}
+
+impl FrontierModel for TurnRestrictionFrontierModel {
+    fn valid_frontier(
+        &self,
+        edge: &Edge,
+        _state: &TraversalState,
+        previous_edge: Option<&Edge>,
+    ) -> Result<bool, FrontierModelError> {
+        match previous_edge {
+            None => Ok(true),
+            Some(previous_edge) => {
+                let edge_id_tuple = (previous_edge.edge_id, edge.edge_id);
+                if self.service.restricted_edges.contains(&edge_id_tuple) {
+                    return Ok(false);
+                }
+                Ok(true)
+            }
+        }
+    }
+}

--- a/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_service.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_service.rs
@@ -1,0 +1,26 @@
+use routee_compass_core::model::{
+    frontier::{
+        frontier_model::FrontierModel, frontier_model_error::FrontierModelError,
+        frontier_model_service::FrontierModelService,
+    },
+    road_network::edge_id::EdgeId,
+};
+use std::{collections::HashSet, sync::Arc};
+
+use super::turn_restriction_model::TurnRestrictionFrontierModel;
+
+#[derive(Clone)]
+pub struct TurnRestrictionFrontierService {
+    pub restricted_edges: Arc<HashSet<(EdgeId, EdgeId)>>,
+}
+
+impl FrontierModelService for TurnRestrictionFrontierService {
+    fn build(
+        &self,
+        _query: &serde_json::Value,
+    ) -> Result<Arc<dyn FrontierModel>, FrontierModelError> {
+        let service: Arc<TurnRestrictionFrontierService> = Arc::new(self.clone());
+        let model = TurnRestrictionFrontierModel { service };
+        Ok(Arc::new(model))
+    }
+}

--- a/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_service.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/turn_restrictions/turn_restriction_service.rs
@@ -5,13 +5,20 @@ use routee_compass_core::model::{
     },
     road_network::edge_id::EdgeId,
 };
+use serde::Deserialize;
 use std::{collections::HashSet, sync::Arc};
 
 use super::turn_restriction_model::TurnRestrictionFrontierModel;
 
+#[derive(Eq, PartialEq, Hash, Deserialize, Clone)]
+pub struct RestrictedEdgePair {
+    pub prev_edge_id: EdgeId,
+    pub next_edge_id: EdgeId,
+}
+
 #[derive(Clone)]
 pub struct TurnRestrictionFrontierService {
-    pub restricted_edges: Arc<HashSet<(EdgeId, EdgeId)>>,
+    pub restricted_edge_pairs: Arc<HashSet<RestrictedEdgePair>>,
 }
 
 impl FrontierModelService for TurnRestrictionFrontierService {

--- a/rust/routee-compass/src/app/search/search_app.rs
+++ b/rust/routee-compass/src/app/search/search_app.rs
@@ -11,10 +11,7 @@ use routee_compass_core::{
     algorithm::search::{backtrack, search_algorithm::SearchAlgorithm},
     model::{
         cost::cost_model::CostModel,
-        frontier::{
-            frontier_model::FrontierModel, frontier_model_error::FrontierModelError,
-            frontier_model_service::FrontierModelService,
-        },
+        frontier::frontier_model_service::FrontierModelService,
         road_network::graph::Graph,
         termination::termination_model::TerminationModel,
         traversal::{

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::edge_rtree_input_plugin::EdgeRtreeInputPlugin;
 use crate::{
     app::compass::config::{
@@ -14,7 +16,7 @@ impl InputPluginBuilder for EdgeRtreeInputPluginBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("edge_rtree");
         let linestring_file = parameters.get_config_path(&"geometry_input_file", &parent_key)?;
         let road_class_file = parameters.get_config_path(&"road_class_input_file", &parent_key)?;
@@ -30,6 +32,6 @@ impl InputPluginBuilder for EdgeRtreeInputPluginBuilder {
             distance_tolerance_option,
             distance_unit_option,
         )?;
-        Ok(Box::new(plugin))
+        Ok(Arc::new(plugin))
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/grid_search/builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/grid_search/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     app::compass::config::{
         builders::InputPluginBuilder, compass_configuration_error::CompassConfigurationError,
@@ -13,7 +15,7 @@ impl InputPluginBuilder for GridSearchBuilder {
     fn build(
         &self,
         _parameters: &serde_json::Value,
-    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
-        Ok(Box::new(GridSearchPlugin {}))
+    ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError> {
+        Ok(Arc::new(GridSearchPlugin {}))
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/inject/inject_builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/inject_builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::inject_format::InjectFormat;
 use crate::{
     app::compass::config::{
@@ -13,12 +15,12 @@ impl InputPluginBuilder for InjectPluginBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError> {
         let key = parameters.get_config_string(&"key", &"inject")?;
         let value_string = parameters.get_config_string(&"value", &"inject")?;
         let format: InjectFormat = parameters.get_config_serde(&"format", &"inject")?;
         let value = format.to_json(&value_string)?;
         let plugin = InjectInputPlugin::new(key, value);
-        Ok(Box::new(plugin))
+        Ok(Arc::new(plugin))
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     app::compass::config::{
         builders::InputPluginBuilder, compass_configuration_error::CompassConfigurationError,
@@ -14,9 +16,9 @@ impl InputPluginBuilder for LoadBalancerBuilder {
     fn build(
         &self,
         params: &serde_json::Value,
-    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError> {
         let heuristic =
             params.get_config_serde::<WeightHeuristic>(&"weight_heuristic", &"load_balancer")?;
-        Ok(Box::new(LoadBalancerPlugin { heuristic }))
+        Ok(Arc::new(LoadBalancerPlugin { heuristic }))
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use routee_compass_core::model::unit::{Distance, DistanceUnit};
 
 use crate::{
@@ -16,7 +18,7 @@ impl InputPluginBuilder for VertexRTreeBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn InputPlugin>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("Vertex RTree Input Plugin");
         let vertex_path = parameters.get_config_path(&"vertices_input_file", &parent_key)?;
         let tolerance_distance =
@@ -25,7 +27,7 @@ impl InputPluginBuilder for VertexRTreeBuilder {
             parameters.get_config_serde_optional::<DistanceUnit>(&"distance_unit", &parent_key)?;
         let rtree = RTreePlugin::new(&vertex_path, tolerance_distance, distance_unit)
             .map_err(CompassConfigurationError::PluginError)?;
-        let m: Box<dyn InputPlugin> = Box::new(rtree);
+        let m: Arc<dyn InputPlugin> = Arc::new(rtree);
         Ok(m)
     }
 }

--- a/rust/routee-compass/src/plugin/output/default/edgeidlist/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/edgeidlist/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     app::compass::config::{
         builders::OutputPluginBuilder, compass_configuration_error::CompassConfigurationError,
@@ -13,7 +15,7 @@ impl OutputPluginBuilder for EdgeIdListOutputPluginBuilder {
     fn build(
         &self,
         _parameters: &serde_json::Value,
-    ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
-        Ok(Box::new(EdgeIdListOutputPlugin {}))
+    ) -> Result<Arc<dyn OutputPlugin>, CompassConfigurationError> {
+        Ok(Arc::new(EdgeIdListOutputPlugin {}))
     }
 }

--- a/rust/routee-compass/src/plugin/output/default/summary/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/summary/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     app::compass::config::{
         builders::OutputPluginBuilder, compass_configuration_error::CompassConfigurationError,
@@ -13,7 +15,7 @@ impl OutputPluginBuilder for SummaryOutputPluginBuilder {
     fn build(
         &self,
         _parameters: &serde_json::Value,
-    ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
-        Ok(Box::new(SummaryOutputPlugin {}))
+    ) -> Result<Arc<dyn OutputPlugin>, CompassConfigurationError> {
+        Ok(Arc::new(SummaryOutputPlugin {}))
     }
 }

--- a/rust/routee-compass/src/plugin/output/default/to_disk/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/to_disk/builder.rs
@@ -20,7 +20,7 @@ impl OutputPluginBuilder for ToDiskOutputPluginBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn OutputPlugin>, CompassConfigurationError> {
         let output_filename = parameters.get_config_string(&"output_file", &"output")?;
         let output_file_path = PathBuf::from(&output_filename);
 
@@ -46,6 +46,6 @@ impl OutputPluginBuilder for ToDiskOutputPluginBuilder {
             output_file_path,
             output_file,
         };
-        Ok(Box::new(to_disk_plugin))
+        Ok(Arc::new(to_disk_plugin))
     }
 }

--- a/rust/routee-compass/src/plugin/output/default/traversal/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::{plugin::TraversalPlugin, traversal_output_format::TraversalOutputFormat};
 use crate::{
     app::compass::config::{
@@ -38,7 +40,7 @@ impl OutputPluginBuilder for TraversalPluginBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn OutputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("traversal");
 
         let geometry_filename = parameters.get_config_path(&"geometry_input_file", &parent_key)?;
@@ -48,6 +50,6 @@ impl OutputPluginBuilder for TraversalPluginBuilder {
             parameters.get_config_serde_optional(&"tree", &parent_key)?;
 
         let geom_plugin = TraversalPlugin::from_file(&geometry_filename, route, tree)?;
-        Ok(Box::new(geom_plugin))
+        Ok(Arc::new(geom_plugin))
     }
 }

--- a/rust/routee-compass/src/plugin/output/default/uuid/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/uuid/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     app::compass::config::{
         builders::OutputPluginBuilder, compass_configuration_error::CompassConfigurationError,
@@ -14,11 +16,11 @@ impl OutputPluginBuilder for UUIDOutputPluginBuilder {
     fn build(
         &self,
         parameters: &serde_json::Value,
-    ) -> Result<Box<dyn OutputPlugin>, CompassConfigurationError> {
+    ) -> Result<Arc<dyn OutputPlugin>, CompassConfigurationError> {
         let uuid_filename = parameters.get_config_path(&"uuid_input_file", &"uuid")?;
 
         let uuid_plugin = UUIDOutputPlugin::from_file(&uuid_filename)
             .map_err(CompassConfigurationError::PluginError)?;
-        Ok(Box::new(uuid_plugin))
+        Ok(Arc::new(uuid_plugin))
     }
 }


### PR DESCRIPTION
Implements #94 by adding a new turn restriction frontier model which loads a set of edge id tuples that each represent a turn restriction. 

This also adds the ability for multiple frontier models to be provided and iterates over each model, excluding an edge from the search if any of the models result in an invalid frontier. 