### PR TITLE
Interpolate Predictor

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -49,62 +49,96 @@ factor = 0.50
 name = "2012_Ford_Focus"
 type = "ice"
 model_input_file = "models/2012_Ford_Focus.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2012_Ford_Fusion"
 type = "ice"
 model_input_file = "models/2012_Ford_Fusion.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_AUDI_A3_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_AUDI_A3_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_BMW_328d_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_BMW_328d_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_CHEVROLET_Malibu_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_CHEVROLET_Malibu_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_CHEVROLET_Spark_EV"
 type = "bev"
 model_input_file = "models/2016_CHEVROLET_Spark_EV.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -112,67 +146,109 @@ battery_capacity = 20
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_FORD_C-MAX_HEV"
 type = "ice"
 model_input_file = "models/2016_FORD_C-MAX_HEV.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_FORD_Escape_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_FORD_Escape_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_FORD_Explorer_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_FORD_Explorer_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_HYUNDAI_Elantra_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_HYUNDAI_Elantra_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_KIA_Optima_Hybrid"
 type = "ice"
 model_input_file = "models/2016_KIA_Optima_Hybrid.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_Leaf_24_kWh"
 type = "bev"
 model_input_file = "models/2016_Leaf_24_kWh.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -180,12 +256,19 @@ battery_capacity = 24
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_MITSUBISHI_i-MiEV"
 type = "bev"
 model_input_file = "models/2016_MITSUBISHI_i-MiEV.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -193,12 +276,19 @@ battery_capacity = 16
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_Nissan_Leaf_30_kWh"
 type = "bev"
 model_input_file = "models/2016_Nissan_Leaf_30_kWh.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -206,12 +296,19 @@ battery_capacity = 30
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_TESLA_Model_S60_2WD"
 type = "bev"
 model_input_file = "models/2016_TESLA_Model_S60_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -219,56 +316,99 @@ battery_capacity = 60
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_TOYOTA_Camry_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_TOYOTA_Camry_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_TOYOTA_Corolla_4cyl_2WD"
 type = "ice"
 model_input_file = "models/2016_TOYOTA_Corolla_4cyl_2WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_TOYOTA_Highlander_Hybrid"
 type = "ice"
 model_input_file = "models/2016_TOYOTA_Highlander_Hybrid.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2016_Toyota_Prius_Two_FWD"
 type = "ice"
 model_input_file = "models/2016_Toyota_Prius_Two_FWD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2017_CHEVROLET_Bolt"
 type = "bev"
 model_input_file = "models/2017_CHEVROLET_Bolt.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -276,89 +416,145 @@ battery_capacity = 60
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2017_Maruti_Dzire_VDI"
 type = "ice"
 model_input_file = "models/2017_Maruti_Dzire_VDI.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2017_Toyota_Highlander_3.5_L"
 type = "ice"
 model_input_file = "models/2017_Toyota_Highlander_3.5_L.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2020_Chevrolet_Colorado_2WD_Diesel"
 type = "ice"
 model_input_file = "models/2020_Chevrolet_Colorado_2WD_Diesel.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_diesel_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2020_VW_Golf_1.5TSI"
 type = "ice"
 model_input_file = "models/2020_VW_Golf_1.5TSI.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2020_VW_Golf_2.0TDI"
 type = "ice"
 model_input_file = "models/2020_VW_Golf_2.0TDI.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_diesel_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2021_Fiat_Panda_Mild_Hybrid"
 type = "ice"
 model_input_file = "models/2021_Fiat_Panda_Mild_Hybrid.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2021_Peugot_3008"
 type = "ice"
 model_input_file = "models/2021_Peugot_3008.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2022_Ford_F-150_Lightning_4WD"
 type = "bev"
 model_input_file = "models/2022_Ford_F-150_Lightning_4WD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -366,12 +562,19 @@ battery_capacity = 98
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2022_Renault_Zoe_ZE50_R135"
 type = "bev"
 model_input_file = "models/2022_Renault_Zoe_ZE50_R135.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -379,12 +582,19 @@ battery_capacity = 52
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2022_Tesla_Model_3_RWD"
 type = "bev"
 model_input_file = "models/2022_Tesla_Model_3_RWD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -392,12 +602,19 @@ battery_capacity = 60
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2022_Tesla_Model_Y_RWD"
 type = "bev"
 model_input_file = "models/2022_Tesla_Model_Y_RWD.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -405,23 +622,37 @@ battery_capacity = 62
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2022_Toyota_Yaris_Hybrid_Mid"
 type = "ice"
 model_input_file = "models/2022_Toyota_Yaris_Hybrid_Mid.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2022_Volvo_XC40_Recharge_twin"
 type = "bev"
 model_input_file = "models/2022_Volvo_XC40_Recharge_twin.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
@@ -429,17 +660,32 @@ battery_capacity = 78
 battery_capacity_unit = "kilowatt_hours"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 name = "2023_Mitsubishi_Pajero_Sport"
 type = "ice"
 model_input_file = "models/2023_Mitsubishi_Pajero_Sport.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02857143
 real_world_energy_adjustment = 1.166
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 type = "phev"
@@ -449,21 +695,35 @@ battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2016_BMW_i3_REx_PHEV_Charge_Depleting"
 model_input_file = "models/2016_BMW_i3_REx_PHEV_Charge_Depleting.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 [traversal.vehicles.charge_sustaining]
 name = "2016_BMW_i3_REx_PHEV_Charge_Sustaining"
 model_input_file = "models/2016_BMW_i3_REx_PHEV_Charge_Sustaining.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 type = "phev"
@@ -473,21 +733,35 @@ battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2016_CHEVROLET_Volt_Charge_Depleting"
 model_input_file = "models/2016_CHEVROLET_Volt_Charge_Depleting.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 [traversal.vehicles.charge_sustaining]
 name = "2016_CHEVROLET_Volt_Charge_Sustaining"
 model_input_file = "models/2016_CHEVROLET_Volt_Charge_Sustaining.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 type = "phev"
@@ -497,21 +771,35 @@ battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2016_FORD_C-MAX_(PHEV)_Charge_Depleting"
 model_input_file = "models/2016_FORD_C-MAX_(PHEV)_Charge_Depleting.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 [traversal.vehicles.charge_sustaining]
 name = "2016_FORD_C-MAX_(PHEV)_Charge_Sustaining"
 model_input_file = "models/2016_FORD_C-MAX_(PHEV)_Charge_Sustaining.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 type = "phev"
@@ -521,21 +809,35 @@ battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2016_HYUNDAI_Sonata_PHEV_Charge_Depleting"
 model_input_file = "models/2016_HYUNDAI_Sonata_PHEV_Charge_Depleting.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 [traversal.vehicles.charge_sustaining]
 name = "2016_HYUNDAI_Sonata_PHEV_Charge_Sustaining"
 model_input_file = "models/2016_HYUNDAI_Sonata_PHEV_Charge_Sustaining.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 
 [[traversal.vehicles]]
 type = "phev"
@@ -545,18 +847,32 @@ battery_capacity_unit = "kilowatt_hours"
 [traversal.vehicles.charge_depleting]
 name = "2017_Prius_Prime_Charge_Depleting"
 model_input_file = "models/2017_Prius_Prime_Charge_Depleting.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "kilowatt_hours_per_mile"
 ideal_energy_rate = 0.2
 real_world_energy_adjustment = 1.3958
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41
 [traversal.vehicles.charge_sustaining]
 name = "2017_Prius_Prime_Charge_Sustaining"
 model_input_file = "models/2017_Prius_Prime_Charge_Sustaining.bin"
-model_type = "smartcore"
 speed_unit = "miles_per_hour"
 grade_unit = "decimal"
 energy_rate_unit = "gallons_gasoline_per_mile"
 ideal_energy_rate = 0.02
 real_world_energy_adjustment = 1.1252
+[traversal.vehicles.model_type.interpolate]
+underlying_model_type = "smartcore"
+speed_lower_bound = 0
+speed_upper_bound = 100
+speed_bins = 101
+grade_lower_bound = -0.2
+grade_upper_bound = 0.2
+grade_bins = 41

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm_type.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm_type.rs
@@ -27,17 +27,14 @@ impl TryFrom<&serde_json::Value> for SearchAlgorithmType {
     /// and returns the SearchAlgorithmType, expected to be a string at the
     /// key "type" on this object.
     fn try_from(config: &serde_json::Value) -> Result<Self, Self::Error> {
-        let type_obj = config
-            .get("type")
-            .ok_or(SearchError::BuildError(String::from(
-                "algorithm config missing 'type' field",
-            )))?;
+        let type_obj = config.get("type").ok_or_else(|| {
+            SearchError::BuildError(String::from("algorithm config missing 'type' field"))
+        })?;
         let alg_string: String = type_obj
             .as_str()
-            .ok_or(SearchError::BuildError(format!(
-                "'type' must be string, found {:?}",
-                type_obj
-            )))?
+            .ok_or_else(|| {
+                SearchError::BuildError(format!("'type' must be string, found {:?}", type_obj))
+            })?
             .into();
         SearchAlgorithmType::from_str(&alg_string)
     }

--- a/rust/routee-compass-core/src/model/cost/cost_model.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_model.rs
@@ -171,11 +171,11 @@ impl CostModel {
             .map(move |(name, idx)| {
                 let state_var = state
                     .get(*idx)
-                    .ok_or(CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+                    .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
                 let rate = self
                     .vehicle_state_variable_rates
                     .get(name)
-                    .ok_or(CostError::StateVariableNotFound(name.clone()))?;
+                    .ok_or_else(|| CostError::StateVariableNotFound(name.clone()))?;
                 let cost = rate.map_value(*state_var);
                 Ok((name.clone(), cost))
             })

--- a/rust/routee-compass-core/src/model/cost/cost_ops.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_ops.rs
@@ -19,14 +19,14 @@ pub fn calculate_vehicle_costs<'a>(
         .map(|(name, idx)| {
             let prev_state_var = prev_state
                 .get(*idx)
-                .ok_or(CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+                .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
             let next_state_var = next_state
                 .get(*idx)
-                .ok_or(CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+                .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
             let delta: StateVar = *next_state_var - *prev_state_var;
             let mapping = rates
                 .get(name)
-                .ok_or(CostError::StateVariableNotFound(name.clone()))?;
+                .ok_or_else(|| CostError::StateVariableNotFound(name.clone()))?;
             let coefficient = state_variable_coefficients.get(name).unwrap_or(&1.0);
             let delta_cost = mapping.map_value(delta);
             let cost = delta_cost * coefficient;
@@ -51,10 +51,10 @@ pub fn calculate_network_traversal_costs<'a>(
             Some(m) => {
                 let prev_state_var = prev_state
                     .get(*idx)
-                    .ok_or(CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+                    .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
                 let next_state_var = next_state
                     .get(*idx)
-                    .ok_or(CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+                    .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
                 let coefficient = state_variable_coefficients.get(name).unwrap_or(&1.0);
                 let traversal_cost = m.traversal_cost(*prev_state_var, *next_state_var, edge)?;
                 let cost = traversal_cost * coefficient;
@@ -81,10 +81,10 @@ pub fn calculate_network_access_costs<'a>(
             Some(m) => {
                 let prev_state_var = prev_state
                     .get(*idx)
-                    .ok_or(CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+                    .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
                 let next_state_var = next_state
                     .get(*idx)
-                    .ok_or(CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+                    .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
                 let access_cost =
                     m.access_cost(*prev_state_var, *next_state_var, prev_edge, next_edge)?;
                 let coefficient = state_variable_coefficients.get(name).unwrap_or(&1.0);

--- a/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
@@ -157,13 +157,13 @@ fn get_time_from_state(state: &TraversalState) -> Time {
 
 /// look up a speed from the speed table
 pub fn get_speed(speed_table: &[Speed], edge_id: EdgeId) -> Result<Speed, TraversalModelError> {
-    let speed: &Speed = speed_table.get(edge_id.as_usize()).ok_or(
+    let speed: &Speed = speed_table.get(edge_id.as_usize()).ok_or_else(|| {
         TraversalModelError::MissingIdInTabularCostFunction(
             format!("{}", edge_id),
             String::from("EdgeId"),
             String::from("speed table"),
-        ),
-    )?;
+        )
+    })?;
     Ok(*speed)
 }
 

--- a/rust/routee-compass-core/src/util/cache_policy/float_cache_policy.rs
+++ b/rust/routee-compass-core/src/util/cache_policy/float_cache_policy.rs
@@ -56,9 +56,9 @@ pub struct FloatCachePolicy {
 
 impl FloatCachePolicy {
     pub fn from_config(config: FloatCachePolicyConfig) -> Result<Self, CacheError> {
-        let size = NonZeroUsize::new(config.cache_size).ok_or(CacheError::BuildError(
-            "maximum_cache_size must be greater than 0".to_string(),
-        ))?;
+        let size = NonZeroUsize::new(config.cache_size).ok_or_else(|| {
+            CacheError::BuildError("maximum_cache_size must be greater than 0".to_string())
+        })?;
         let cache = Mutex::new(LruCache::new(size));
         for precision in config.key_precisions.iter() {
             if (*precision > 10) || (*precision < -10) {

--- a/rust/routee-compass-core/src/util/conversion/duration_extension.rs
+++ b/rust/routee-compass-core/src/util/conversion/duration_extension.rs
@@ -8,10 +8,9 @@ pub trait DurationExtension {
 
 impl DurationExtension for serde_json::Value {
     fn as_duration(&self) -> Result<Duration, ConversionError> {
-        let d_str = self.as_str().ok_or(ConversionError::DecoderError(
-            format!("{:?}", self),
-            String::from("JSON"),
-        ))?;
+        let d_str = self.as_str().ok_or_else(|| {
+            ConversionError::DecoderError(format!("{:?}", self), String::from("JSON"))
+        })?;
 
         // regex lib recommends not building these within-the-loop, so this is not
         // good for performance to build here, but ran out of time exploring alternatives.

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_repr = "0.1"
 serde_json = { workspace = true }
+ordered-float = { workspace = true }
 ndarray = "0.15"
 ort = { version = "2.0.0-alpha.4", optional = true }
 rayon = { workspace = true }

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -22,7 +22,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_repr = "0.1"
 serde_json = { workspace = true }
 ndarray = "0.15"
-ort = { version = "2.0.0-alpha.2", optional = true }
+ort = { version = "2.0.0-alpha.4", optional = true }
 rayon = { workspace = true }
 
 [features]

--- a/rust/routee-compass-powertrain/src/routee/energy_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/energy_model_ops.rs
@@ -13,13 +13,13 @@ pub fn get_grade(
     match grade_table {
         None => Ok(Grade::ZERO),
         Some(gt) => {
-            let grade: &Grade = gt.get(edge_id.as_usize()).ok_or(
+            let grade: &Grade = gt.get(edge_id.as_usize()).ok_or_else(|| {
                 TraversalModelError::MissingIdInTabularCostFunction(
                     format!("{}", edge_id),
                     String::from("EdgeId"),
                     String::from("grade table"),
-                ),
-            )?;
+                )
+            })?;
             Ok(*grade)
         }
     }

--- a/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
@@ -142,13 +142,15 @@ impl TryFrom<(Arc<EnergyModelService>, &serde_json::Value)> for EnergyTraversalM
 
         let prediction_model_name = conf
             .get("model_name".to_string())
-            .ok_or(TraversalModelError::BuildError(
-                "No 'model_name' key provided in query".to_string(),
-            ))?
+            .ok_or_else(|| {
+                TraversalModelError::BuildError("No 'model_name' key provided in query".to_string())
+            })?
             .as_str()
-            .ok_or(TraversalModelError::BuildError(
-                "Expected 'model_name' value to be string".to_string(),
-            ))?
+            .ok_or_else(|| {
+                TraversalModelError::BuildError(
+                    "Expected 'model_name' value to be string".to_string(),
+                )
+            })?
             .to_string();
 
         let vehicle = match service.vehicle_library.get(&prediction_model_name) {

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/bilinear_interp.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/bilinear_interp.rs
@@ -1,0 +1,81 @@
+use ordered_float::OrderedFloat;
+
+use super::utils::find_nearest_index;
+
+pub struct BilinearInterp {
+    pub x: Vec<OrderedFloat<f64>>,
+    pub y: Vec<OrderedFloat<f64>>,
+    pub values: Vec<Vec<f64>>,
+}
+
+impl BilinearInterp {
+    pub fn new(x: Vec<f64>, y: Vec<f64>, values: Vec<Vec<f64>>) -> Result<Self, String> {
+        if x.len() != values.len() {
+            return Err("Supplied `x` must have same dimensionality as `values`".to_string());
+        }
+        if y.len() != values[0].len() {
+            return Err("Supplied `y` must have same dimensionality as `values`".to_string());
+        }
+        if !x.windows(2).all(|w| w[0] < w[1]) {
+            return Err("Supplied `x` coordinates must be sorted and non-repeating".to_string());
+        }
+        if !y.windows(2).all(|w| w[0] < w[1]) {
+            return Err("Supplied `y` coordinates must be sorted and non-repeating".to_string());
+        }
+        let x = x.into_iter().map(OrderedFloat::from).collect();
+        let y = y.into_iter().map(OrderedFloat::from).collect();
+        Ok(BilinearInterp { x, y, values })
+    }
+
+    pub fn interpolate(&self, x: f64, y: f64) -> Result<f64, &'static str> {
+        let x_index = find_nearest_index(&self.x, OrderedFloat(x));
+        let y_index = find_nearest_index(&self.y, OrderedFloat(y));
+
+        if x_index >= self.x.len() - 1 || y_index >= self.y.len() - 1 {
+            return Err("Cannot interpolate outside of grid bounds");
+        }
+        let x0 = self.x[x_index].into_inner();
+        let x1 = self.x[x_index + 1].into_inner();
+        let y0 = self.y[y_index].into_inner();
+        let y1 = self.y[y_index + 1].into_inner();
+
+        let q11 = self.values[x_index][y_index];
+        let q12 = self.values[x_index][y_index + 1];
+        let q21 = self.values[x_index + 1][y_index];
+        let q22 = self.values[x_index + 1][y_index + 1];
+
+        let fxy1 = (x1 - x) / (x1 - x0) * q11 + (x - x0) / (x1 - x0) * q21;
+        let fxy2 = (x1 - x) / (x1 - x0) * q12 + (x - x0) / (x1 - x0) * q22;
+
+        Ok((y1 - y) / (y1 - y0) * fxy1 + (y - y0) / (y1 - y0) * fxy2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::routee::prediction::interpolation::bilinear_interp::BilinearInterp;
+
+    // test targets found using https://www.omnicalculator.com/math/bilinear-interpolation
+    #[test]
+    fn test_multilinear_2d() {
+        let x = vec![0.0, 1.0, 2.0];
+        let y = vec![0.0, 1.0, 2.0];
+        let values = vec![
+            vec![0.0, 2.0, 1.9], // (x0, y0), (x0, y1), (x0, y2)
+            vec![2.0, 4.0, 3.1], // (x1, y0), (x1, y1), (x1, y2)
+            vec![5.0, 0.0, 1.4], // (x2, y0), (x2, y1), (x2, y2)
+        ];
+
+        let interp = BilinearInterp::new(x, y, values.clone()).unwrap();
+
+        assert_eq!(interp.interpolate(0.5, 0.5).unwrap(), 2.0);
+
+        assert_eq!(interp.interpolate(1.52, 0.36).unwrap(), 2.9696);
+
+        // returns value at (x2, y2)
+        assert_eq!(interp.interpolate(2.0, 2.0).unwrap(), values[2][2]);
+
+        // errors out for values greater than bounds
+        assert!(interp.interpolate(3.0, 3.0).is_err());
+    }
+}

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/bilinear_interp.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/bilinear_interp.rs
@@ -27,6 +27,18 @@ impl BilinearInterp {
         Ok(BilinearInterp { x, y, values })
     }
 
+    /// Interpolate a value at a given point (x, y) using bilinear interpolation
+    /// Based on https://en.wikipedia.org/wiki/Bilinear_interpolation
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - x coordinate to interpolate at
+    /// * `y` - y coordinate to interpolate at
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(f64)` - interpolated value
+    /// * `Err(&str)` - An error if the point is outside of the grid bounds
     pub fn interpolate(&self, x: f64, y: f64) -> Result<f64, &'static str> {
         let x_index = find_nearest_index(&self.x, OrderedFloat(x));
         let y_index = find_nearest_index(&self.y, OrderedFloat(y));

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
@@ -56,8 +56,9 @@ impl PredictionModel for InterpolationSpeedGradeModel {
 impl InterpolationSpeedGradeModel {
     #[allow(clippy::too_many_arguments)]
     pub fn new<P: AsRef<Path>>(
-        model_path: &P,
-        model_type: ModelType,
+        underlying_model_path: &P,
+        underlying_model_type: ModelType,
+        underlying_model_name: String,
         speed_unit: SpeedUnit,
         speed_bounds: (Speed, Speed),
         speed_bins: usize,
@@ -68,9 +69,9 @@ impl InterpolationSpeedGradeModel {
     ) -> Result<Self, TraversalModelError> {
         // load underlying model to build the interpolation grid
         let model = load_prediction_model(
-            "".to_string(),
-            model_path,
-            model_type,
+            underlying_model_name,
+            underlying_model_path,
+            underlying_model_type,
             speed_unit,
             grade_unit,
             energy_rate_unit,
@@ -141,6 +142,7 @@ mod test {
         let model = InterpolationSpeedGradeModel::new(
             &model_path,
             ModelType::Smartcore,
+            "Toyota Camry".to_string(),
             SpeedUnit::MilesPerHour,
             (Speed::new(0.0), Speed::new(100.0)),
             101,

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use crate::routee::prediction::prediction_model::PredictionModel;
+use routee_compass_core::{
+    model::traversal::traversal_model_error::TraversalModelError,
+    model::unit::{as_f64::AsF64, EnergyRate, EnergyRateUnit, Grade, GradeUnit, Speed, SpeedUnit},
+};
+use smartcore::{
+    ensemble::random_forest_regressor::RandomForestRegressor, linalg::basic::matrix::DenseMatrix,
+};
+
+pub struct InterpolationSpeedGradeModel {
+    rf: RandomForestRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>>,
+    speed_unit: SpeedUnit,
+    grade_unit: GradeUnit,
+    energy_rate_unit: EnergyRateUnit,
+}
+
+impl PredictionModel for InterpolationSpeedGradeModel {
+    fn predict(
+        &self,
+        speed: (Speed, SpeedUnit),
+        grade: (Grade, GradeUnit),
+    ) -> Result<(EnergyRate, EnergyRateUnit), TraversalModelError> {
+        let (speed, speed_unit) = speed;
+        let (grade, grade_unit) = grade;
+        let speed_value = speed_unit.convert(speed, self.speed_unit).as_f64();
+        let grade_value = grade_unit.convert(grade, self.grade_unit).as_f64();
+        let x = DenseMatrix::from_2d_vec(&vec![vec![speed_value, grade_value]]);
+        let y = self
+            .rf
+            .predict(&x)
+            .map_err(|e| TraversalModelError::PredictionModel(e.to_string()))?;
+
+        let energy_rate = EnergyRate::new(y[0]);
+        Ok((energy_rate, self.energy_rate_unit))
+    }
+}
+
+impl InterpolationSpeedGradeModel {
+    pub fn new<P: AsRef<Path>>(
+        routee_model_path: &P,
+        speed_unit: SpeedUnit,
+        grade_unit: GradeUnit,
+        energy_rate_unit: EnergyRateUnit,
+    ) -> Result<Self, TraversalModelError> {
+        // Load random forest binary file
+        let rf_binary = std::fs::read(routee_model_path).map_err(|e| {
+            TraversalModelError::FileReadError(
+                routee_model_path.as_ref().to_path_buf(),
+                e.to_string(),
+            )
+        })?;
+        let rf: RandomForestRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>> =
+            bincode::deserialize(&rf_binary).map_err(|e| {
+                TraversalModelError::FileReadError(
+                    routee_model_path.as_ref().to_path_buf(),
+                    e.to_string(),
+                )
+            })?;
+        Ok(InterpolationSpeedGradeModel {
+            rf,
+            speed_unit,
+            grade_unit,
+            energy_rate_unit,
+        })
+    }
+}

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::routee::prediction::prediction_model::PredictionModel;
-use ndarray::Array2;
+
 use routee_compass_core::{
     model::traversal::traversal_model_error::TraversalModelError,
     model::unit::{as_f64::AsF64, EnergyRate, EnergyRateUnit, Grade, GradeUnit, Speed, SpeedUnit},

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::routee::prediction::prediction_model::PredictionModel;
+use ndarray::Array2;
 use routee_compass_core::{
     model::traversal::traversal_model_error::TraversalModelError,
     model::unit::{as_f64::AsF64, EnergyRate, EnergyRateUnit, Grade, GradeUnit, Speed, SpeedUnit},
@@ -9,8 +10,10 @@ use smartcore::{
     ensemble::random_forest_regressor::RandomForestRegressor, linalg::basic::matrix::DenseMatrix,
 };
 
+use super::utils::{linspace, MultiLinearInterp};
+
 pub struct InterpolationSpeedGradeModel {
-    rf: RandomForestRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>>,
+    interpolator: MultiLinearInterp,
     speed_unit: SpeedUnit,
     grade_unit: GradeUnit,
     energy_rate_unit: EnergyRateUnit,
@@ -26,22 +29,32 @@ impl PredictionModel for InterpolationSpeedGradeModel {
         let (grade, grade_unit) = grade;
         let speed_value = speed_unit.convert(speed, self.speed_unit).as_f64();
         let grade_value = grade_unit.convert(grade, self.grade_unit).as_f64();
-        let x = DenseMatrix::from_2d_vec(&vec![vec![speed_value, grade_value]]);
-        let y = self
-            .rf
-            .predict(&x)
-            .map_err(|e| TraversalModelError::PredictionModel(e.to_string()))?;
 
-        let energy_rate = EnergyRate::new(y[0]);
+        let y = self
+            .interpolator
+            .interpolate(&[speed_value, grade_value])
+            .map_err(|e| {
+                TraversalModelError::PredictionModel(format!(
+                    "Failed to interpolate: {}",
+                    e
+                ))
+            })?;
+
+        let energy_rate = EnergyRate::new(y);
         Ok((energy_rate, self.energy_rate_unit))
     }
 }
 
 impl InterpolationSpeedGradeModel {
+    #[allow(clippy::too_many_arguments)]
     pub fn new<P: AsRef<Path>>(
         routee_model_path: &P,
         speed_unit: SpeedUnit,
+        speed_bounds: (Speed, Speed),
+        speed_bins: usize,
         grade_unit: GradeUnit,
+        grade_bounds: (Grade, Grade),
+        grade_bins: usize,
         energy_rate_unit: EnergyRateUnit,
     ) -> Result<Self, TraversalModelError> {
         // Load random forest binary file
@@ -51,6 +64,7 @@ impl InterpolationSpeedGradeModel {
                 e.to_string(),
             )
         })?;
+        // Load the random forest regressor so we can exercise it on a linear grid
         let rf: RandomForestRegressor<f64, f64, DenseMatrix<f64>, Vec<f64>> =
             bincode::deserialize(&rf_binary).map_err(|e| {
                 TraversalModelError::FileReadError(
@@ -58,8 +72,39 @@ impl InterpolationSpeedGradeModel {
                     e.to_string(),
                 )
             })?;
+
+        // Create a linear grid of speed and grade values
+        let speed_values = linspace(speed_bounds.0.as_f64(), speed_bounds.1.as_f64(), speed_bins);
+        let grade_values = linspace(grade_bounds.0.as_f64(), grade_bounds.1.as_f64(), grade_bins);
+        let grid = vec![speed_values.clone(), grade_values.clone()];
+
+        // Predict energy rate values across the whole grid
+        let mut values = Vec::new();
+        for speed_value in speed_values.clone().into_iter() {
+            let mut row: Vec<f64> = Vec::new();
+            for grade_value in grade_values.clone().into_iter() {
+                let x = DenseMatrix::from_2d_vec(&vec![vec![speed_value, grade_value]]);
+                let y = rf
+                    .predict(&x)
+                    .map_err(|e| TraversalModelError::PredictionModel(e.to_string()))?;
+                row.push(y[0]);
+            }
+            values.extend_from_slice(&row);
+        }
+
+        let arr = Array2::from_shape_vec((speed_bins, grade_bins), values).map_err(|e| {
+            TraversalModelError::PredictionModel(format!("Failed to create array: {}", e))
+        })?;
+
+        let interpolator = MultiLinearInterp::new(grid, arr.into_dyn()).map_err(|e| {
+            TraversalModelError::PredictionModel(format!(
+                "Failed to create interpolation model: {}",
+                e
+            ))
+        })?;
+
         Ok(InterpolationSpeedGradeModel {
-            rf,
+            interpolator,
             speed_unit,
             grade_unit,
             energy_rate_unit,

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/mod.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/mod.rs
@@ -1,0 +1,2 @@
+pub mod interpolation_speed_grade_model;
+pub mod utils;

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/mod.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/mod.rs
@@ -1,2 +1,3 @@
+pub mod bilinear_interp;
 pub mod interpolation_speed_grade_model;
 pub mod utils;

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -9,7 +9,7 @@ pub fn linspace(x0: f64, xend: f64, n: usize) -> Vec<f64> {
     x
 }
 
-fn find_nearest_index(arr: &[OrderedFloat<f64>], target: OrderedFloat<f64>) -> usize {
+pub fn find_nearest_index(arr: &[OrderedFloat<f64>], target: OrderedFloat<f64>) -> usize {
     let mut low = 0;
     let mut high = arr.len() - 1;
 
@@ -27,83 +27,5 @@ fn find_nearest_index(arr: &[OrderedFloat<f64>], target: OrderedFloat<f64>) -> u
         low - 1
     } else {
         low
-    }
-}
-
-pub struct BilinearInterp {
-    pub x: Vec<OrderedFloat<f64>>,
-    pub y: Vec<OrderedFloat<f64>>,
-    pub values: Vec<Vec<f64>>,
-}
-
-impl BilinearInterp {
-    pub fn new(x: Vec<f64>, y: Vec<f64>, values: Vec<Vec<f64>>) -> Result<Self, String> {
-        if x.len() != values.len() {
-            return Err("Supplied `x` must have same dimensionality as `values`".to_string());
-        }
-        if y.len() != values[0].len() {
-            return Err("Supplied `y` must have same dimensionality as `values`".to_string());
-        }
-        if !x.windows(2).all(|w| w[0] < w[1]) {
-            return Err("Supplied `x` coordinates must be sorted and non-repeating".to_string());
-        }
-        if !y.windows(2).all(|w| w[0] < w[1]) {
-            return Err("Supplied `y` coordinates must be sorted and non-repeating".to_string());
-        }
-        let x = x.into_iter().map(OrderedFloat::from).collect();
-        let y = y.into_iter().map(OrderedFloat::from).collect();
-        Ok(BilinearInterp { x, y, values })
-    }
-
-    pub fn interpolate(&self, x: f64, y: f64) -> Result<f64, &'static str> {
-        let x_index = find_nearest_index(&self.x, OrderedFloat(x));
-        let y_index = find_nearest_index(&self.y, OrderedFloat(y));
-
-        if x_index >= self.x.len() - 1 || y_index >= self.y.len() - 1 {
-            return Err("Cannot interpolate outside of grid bounds");
-        }
-        let x0 = self.x[x_index].into_inner();
-        let x1 = self.x[x_index + 1].into_inner();
-        let y0 = self.y[y_index].into_inner();
-        let y1 = self.y[y_index + 1].into_inner();
-
-        let q11 = self.values[x_index][y_index];
-        let q12 = self.values[x_index][y_index + 1];
-        let q21 = self.values[x_index + 1][y_index];
-        let q22 = self.values[x_index + 1][y_index + 1];
-
-        let fxy1 = (x1 - x) / (x1 - x0) * q11 + (x - x0) / (x1 - x0) * q21;
-        let fxy2 = (x1 - x) / (x1 - x0) * q12 + (x - x0) / (x1 - x0) * q22;
-
-        Ok((y1 - y) / (y1 - y0) * fxy1 + (y - y0) / (y1 - y0) * fxy2)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // test targets found using https://www.omnicalculator.com/math/bilinear-interpolation
-    #[test]
-    fn test_multilinear_2d() {
-        let x = vec![0.0, 1.0, 2.0];
-        let y = vec![0.0, 1.0, 2.0];
-        let values = vec![
-            vec![0.0, 2.0, 1.9], // (x0, y0), (x0, y1), (x0, y2)
-            vec![2.0, 4.0, 3.1], // (x1, y0), (x1, y1), (x1, y2)
-            vec![5.0, 0.0, 1.4], // (x2, y0), (x2, y1), (x2, y2)
-        ];
-
-        let interp = BilinearInterp::new(x, y, values.clone()).unwrap();
-
-        assert_eq!(interp.interpolate(0.5, 0.5).unwrap(), 2.0);
-
-        assert_eq!(interp.interpolate(1.52, 0.36).unwrap(), 2.9696);
-
-        // returns value at (x2, y2)
-        assert_eq!(interp.interpolate(2.0, 2.0).unwrap(), values[2][2]);
-
-        // errors out for values greater than bounds
-        assert!(interp.interpolate(3.0, 3.0).is_err());
     }
 }

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -105,8 +105,7 @@ mod tests {
         // returns value at (x2, y2)
         assert_eq!(interp.interpolate(2.0, 2.0).unwrap(), values[2][2]);
 
-        // errors out for values greater than bounds 
+        // errors out for values greater than bounds
         assert!(interp.interpolate(3.0, 3.0).is_err());
-        
     }
 }

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -44,6 +44,15 @@ pub fn get_binary_indeces(n: usize) -> Vec<Vec<usize>> {
     indeces
 }
 
+pub fn linspace(x0: f64, xend: f64, n: usize) -> Vec<f64> {
+    let dx = (xend - x0) / ((n - 1) as f64);
+    let mut x = vec![x0; n];
+    for i in 1..n {
+        x[i] = x[i - 1] + dx;
+    }
+    x
+}
+
 pub struct MultiLinearInterp {
     grid: Vec<Vec<f64>>,
     values: ArrayD<f64>,

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -1,0 +1,297 @@
+use ndarray::*;
+
+/// Get all possible indeces of an array of length 2 in `n` dimensions. Result will have shape (2<sup>n</sup>, n).
+///
+/// # Arguments:
+/// * `n` - dimensionality
+///
+/// # Example:
+/// ```rust
+/// use multilinear::get_binary_indeces;
+/// assert_eq!(
+///     get_binary_indeces(2),
+///     vec![
+///         vec![0, 0],
+///         vec![0, 1],
+///         vec![1, 0],
+///         vec![1, 1],
+///     ]
+/// );
+/// assert_eq!(
+///     get_binary_indeces(3),
+///     vec![
+///         vec![0, 0, 0],
+///         vec![0, 0, 1],
+///         vec![0, 1, 0],
+///         vec![0, 1, 1],
+///         vec![1, 0, 0],
+///         vec![1, 0, 1],
+///         vec![1, 1, 0],
+///         vec![1, 1, 1],
+///     ]
+/// );
+/// ```
+pub fn get_binary_indeces(n: usize) -> Vec<Vec<usize>> {
+    let len = 2_usize.pow(n as u32);
+    let mut indeces = Vec::with_capacity(len);
+    for i in 0..len {
+        let mut index = Vec::with_capacity(n);
+        for j in (0..n).rev() {
+            index.push(((i >> j) & 1));
+        }
+        indeces.push(index);
+    }
+    indeces
+}
+
+pub struct MultiLinearInterp {
+    grid: Vec<Vec<f64>>,
+    values: ArrayD<f64>,
+}
+
+impl MultiLinearInterp {
+    pub fn new(grid: Vec<Vec<f64>>, values: ArrayD<f64>) -> Result<Self, String> {
+        // Dimensionality
+        let n = values.ndim();
+
+        // Validate inputs
+        if grid.len() != n {
+            return Err("Supplied `grid` must have same dimensionality as `values`".to_string());
+        }
+        for i in 0..n {
+            if grid[i].len() <= 1 {
+                return Err(format!(
+                    "Supplied `grid` length must be > 1 for dimension {}",
+                    i
+                ));
+            }
+            if grid[i].len() != values.shape()[i] {
+                return Err(format!("Supplied `grid` and `values` are not compatible shapes: dimension {}, lengths {} != {}", i, grid[i].len(), values.shape()[i]));
+            }
+            if !grid[i].windows(2).all(|w| w[0] < w[1]) {
+                return Err(format!("Supplied `grid` coordinates must be sorted and non-repeating: dimension {}, {:?}", i, grid[i]));
+            }
+        }
+        Ok(MultiLinearInterp { grid, values })
+    }
+
+    pub fn interpolate(&self, point: &[f64]) -> Result<f64, String> {
+        let mut n = self.values.ndim();
+        if point.len() != n {
+            return Err(format!("Length of supplied `point` must be same as `values` dimensionality: {point:?} is not {n}-dimensional"));
+        }
+        let mut values = self.values.view();
+
+        if values.len() == 1 {
+            // Supplied point is coincident with a grid point, so just return the value
+            let first_value: f64 = match values.first() {
+                Some(v) => *v,
+                None => return Err("Could not find first value from array".to_string()),
+            };
+            return Ok(first_value);
+        }
+
+        // Point can share up to N values of a grid point, which reduces the problem dimensionality
+        // i.e. the point shares one of three values of a 3-D grid point, then the interpolation becomes 2-D at that slice
+        // or   if the point shares two of three values of a 3-D grid point, then the interpolation becomes 1-D
+        let mut grid: Vec<&Vec<f64>> = self.grid.iter().collect();
+        let mut point: Vec<f64> = point.to_vec();
+        for dim in (0..n).rev() {
+            // Range is reversed so that removal doesn't affect indexing
+            if let Some(pos) = grid[dim]
+                .iter()
+                .position(|&grid_point| grid_point == point[dim])
+            {
+                point.remove(dim);
+                grid.remove(dim);
+                values.index_axis_inplace(Axis(dim), pos);
+            }
+        }
+        // Simplified dimensionality
+        n = values.ndim();
+
+        // Extract the lower and upper indices for each dimension,
+        // as well as the fraction of how far the supplied point is between the surrounding grid points
+        let mut indeces_lower = Vec::with_capacity(n);
+        let mut indeces_upper = Vec::with_capacity(n);
+        let mut interp_diffs = Vec::with_capacity(n);
+        for dim in 0..n {
+            let lower_idx = match grid[dim]
+                .windows(2)
+                .position(|w| w[0] < point[dim] && point[dim] < w[1]) {
+                    Some(idx) => idx,
+                    None => return Err(format!(
+                            "Supplied `point` is outside of `grid` bounds: {point:?} is not between {grid:?}",
+                            point = point,
+                            grid = grid
+                    )),
+                };
+            let upper_idx = lower_idx + 1;
+            let interp_diff =
+                (point[dim] - grid[dim][lower_idx]) / (grid[dim][upper_idx] - grid[dim][lower_idx]);
+            indeces_lower.push(lower_idx);
+            indeces_upper.push(upper_idx);
+            interp_diffs.push(interp_diff);
+        }
+        // `interp_vals` contains all values surrounding the point of interest, starting with shape (2, 2, ...) in N dimensions
+        // this gets mutated and reduces in dimension each iteration, filling with the next values to interpolate with
+        // this ends up as a 0-dimensional array containing only the final interpolated value
+        let mut interp_vals = values
+            .slice_each_axis(|ax| Slice::from(indeces_lower[ax.axis.0]..=indeces_upper[ax.axis.0]))
+            .to_owned();
+        // Binary is handy as there are 2 surrounding values to index in each dimension: lower and upper
+        let mut binary_idxs = get_binary_indeces(n);
+        // This loop interpolates in each dimension sequentially
+        // each outer loop iteration the dimensionality reduces by 1
+        // `interp_vals` ends up as a 0-dimensional array containing only the final interpolated value
+        for dim in 0..n {
+            let diff = interp_diffs[dim];
+            let next_dim = n - 1 - dim;
+            // Indeces used for saving results of this dimensions interpolation results
+            // assigned to `binary_idxs` at end of loop to be used for indexing in next iteration
+            let next_idxs = get_binary_indeces(next_dim);
+            let mut intermediate_arr = Array::default(vec![2; next_dim]);
+            for i in 0..next_idxs.len() {
+                // `next_idxs` is always half the length of `binary_idxs`
+                let l = binary_idxs[i].as_slice();
+                let u = binary_idxs[next_idxs.len() + i].as_slice();
+                if dim == 0 && (interp_vals[l].is_nan() || interp_vals[u].is_nan()) {
+                    return Err(format!(
+                            "Surrounding value(s) cannot be NaN:\npoint = {point:?},\ngrid = {grid:?},\nvalues = {values:?}"
+                    ));
+                }
+                // This calculation happens 2^(n-1) times in the first iteration of the outer loop,
+                // 2^(n-2) times in the second iteration, etc.
+                intermediate_arr[next_idxs[i].as_slice()] =
+                    interp_vals[l] * (1.0 - diff) + interp_vals[u] * diff;
+            }
+            binary_idxs = next_idxs;
+            interp_vals = intermediate_arr;
+        }
+
+        // return the only value contained within the 0-dimensional array
+        let val: f64 = match interp_vals.first() {
+            Some(v) => *v,
+            None => return Err("Could not find first value from array".to_string()),
+        };
+        Ok(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multilinear_1d() {
+        let grid = vec![vec![0.0, 1.0, 4.0]];
+        let values = array![0.0, 2.0, 4.45].into_dyn();
+
+        let interp = MultiLinearInterp::new(grid, values.clone()).unwrap();
+
+        let point_a = [0.82];
+        assert_eq!(interp.interpolate(&point_a).unwrap(), 1.64);
+
+        let point_b = [2.98];
+        assert_eq!(interp.interpolate(&point_b).unwrap(), 3.617);
+
+        // returns value at x2
+        let point_c = [4.0];
+        assert_eq!(interp.interpolate(&point_c).unwrap(), values[2]);
+    }
+
+    // test targets found using https://www.omnicalculator.com/math/bilinear-interpolation
+    #[test]
+    fn test_multilinear_2d() {
+        let grid = vec![
+            vec![0.0, 1.0, 2.0], // x0, x1, x2
+            vec![0.0, 1.0, 2.0], // y0, y1, y2
+        ];
+        let values = array![
+            [0.0, 2.0, 1.9], // (x0, y0), (x0, y1), (x0, y2)
+            [2.0, 4.0, 3.1], // (x1, y0), (x1, y1), (x1, y2)
+            [5.0, 0.0, 1.4], // (x2, y0), (x2, y1), (x2, y2)
+        ]
+        .into_dyn();
+
+        let interp = MultiLinearInterp::new(grid, values.clone()).unwrap();
+
+        let point_a = [0.5, 0.5];
+        assert_eq!(interp.interpolate(&point_a).unwrap(), 2.0);
+
+        let point_b = [1.52, 0.36];
+        assert_eq!(interp.interpolate(&point_b).unwrap(), 2.9696);
+
+        // returns value at (x2, y2)
+        let point_c = [2.0, 2.0];
+        assert_eq!(interp.interpolate(&point_c).unwrap(), values[[2, 2]]);
+    }
+
+    #[test]
+    fn test_multilinear_3d() {
+        let grid = vec![
+            vec![0.0, 1.0, 2.0], // x0, x1, x2
+            vec![0.0, 1.0, 2.0], // y0, y1, y2
+            vec![0.0, 1.0, 2.0], // z0, z1, z2
+        ];
+        let values = array![
+            [
+                [0.0, 1.5, 3.0], // (x0, y0, z0), (x0, y0, z1), (x0, y0, z2)
+                [2.0, 0.5, 1.4], // (x0, y1, z0), (x0, y1, z1), (x0, y1, z2)
+                [1.9, 5.3, 2.2], // (x0, y2, z0), (x0, y0, z1), (x0, y2, z2)
+            ],
+            [
+                [2.0, 5.1, 1.1], // (x1, y0, z0), (x1, y0, z1), (x1, y0, z2)
+                [4.0, 1.0, 0.5], // (x1, y1, z0), (x1, y1, z1), (x1, y1, z2)
+                [3.1, 0.9, 1.2], // (x1, y2, z0), (x1, y2, z1), (x1, y2, z2)
+            ],
+            [
+                [5.0, 0.2, 5.1], // (x2, y0, z0), (x2, y0, z1), (x2, y0, z2)
+                [0.7, 0.1, 3.2], // (x2, y1, z0), (x2, y1, z1), (x2, y1, z2)
+                [1.4, 1.1, 0.0], // (x2, y2, z0), (x2, y2, z1), (x2, y2, z2)
+            ],
+        ]
+        .into_dyn();
+
+        let interp = MultiLinearInterp::new(grid, values.clone()).unwrap();
+
+        let point_a = [0.5, 0.5, 0.5];
+        assert_eq!(interp.interpolate(&point_a).unwrap(), 2.0125);
+
+        let point_b = [1.52, 0.36, 0.5];
+        assert_eq!(interp.interpolate(&point_b).unwrap(), 2.46272);
+
+        // returns value at (x2, y1, z0)
+        let point_c = [2.0, 1.0, 0.0];
+        assert_eq!(interp.interpolate(&point_c).unwrap(), values[[2, 1, 0]]);
+    }
+
+    #[test]
+    fn test_multilinear_with_nans() {
+        let grid = vec![
+            vec![0.0, 1.0, 2.0, 3.0, 4.0], // x0, x1, x2, x3, x4
+            vec![0.0, 1.0, 2.0, 3.0],      // y0, y1, y2, y3
+        ];
+        let values = array![
+            [0.000000, 2.000000, 1.900000, 4.200000], // (x0, y0), (x0, y1), (x0, y2), (x0, y3)
+            [2.000000, 4.000000, 3.100000, 6.100000], // (x1, y0), (x1, y1), (x1, y2), (x1, y3)
+            [f64::NAN, 0.000000, 1.400000, 1.100000], // (x2, y0), (x2, y1), (x2, y2), (x2, y3)
+            [f64::NAN, 0.000000, f64::NAN, f64::NAN], // (x3, y0), (x3, y1), (x3, y2), (x3, y3)
+            [f64::NAN, f64::NAN, f64::NAN, f64::NAN], // (x4, y0), (x4, y1), (x4, y2), (x4, y3)
+        ];
+
+        let interp = MultiLinearInterp::new(grid, values.into_dyn()).unwrap();
+
+        let point_a = [0.51, 0.36];
+        assert_eq!(interp.interpolate(&point_a).unwrap(), 1.74);
+
+        let point_b = [1.5, 2.5];
+        assert_eq!(interp.interpolate(&point_b).unwrap(), 2.925);
+
+        let point_c = [1.5, 0.5];
+        assert!(interp.interpolate(&point_c).is_err());
+
+        let point_d = [3.5, 2.5];
+        assert!(interp.interpolate(&point_d).is_err());
+    }
+}

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+
 
 use ordered_float::OrderedFloat;
 

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -1,48 +1,6 @@
-use ndarray::*;
+use std::cmp::Ordering;
 
-/// Get all possible indeces of an array of length 2 in `n` dimensions. Result will have shape (2<sup>n</sup>, n).
-///
-/// # Arguments:
-/// * `n` - dimensionality
-///
-/// # Example:
-/// ```rust
-/// use multilinear::get_binary_indeces;
-/// assert_eq!(
-///     get_binary_indeces(2),
-///     vec![
-///         vec![0, 0],
-///         vec![0, 1],
-///         vec![1, 0],
-///         vec![1, 1],
-///     ]
-/// );
-/// assert_eq!(
-///     get_binary_indeces(3),
-///     vec![
-///         vec![0, 0, 0],
-///         vec![0, 0, 1],
-///         vec![0, 1, 0],
-///         vec![0, 1, 1],
-///         vec![1, 0, 0],
-///         vec![1, 0, 1],
-///         vec![1, 1, 0],
-///         vec![1, 1, 1],
-///     ]
-/// );
-/// ```
-pub fn get_binary_indeces(n: usize) -> Vec<Vec<usize>> {
-    let len = 2_usize.pow(n as u32);
-    let mut indeces = Vec::with_capacity(len);
-    for i in 0..len {
-        let mut index = Vec::with_capacity(n);
-        for j in (0..n).rev() {
-            index.push(((i >> j) & 1));
-        }
-        indeces.push(index);
-    }
-    indeces
-}
+use ordered_float::OrderedFloat;
 
 pub fn linspace(x0: f64, xend: f64, n: usize) -> Vec<f64> {
     let dx = (xend - x0) / ((n - 1) as f64);
@@ -53,137 +11,73 @@ pub fn linspace(x0: f64, xend: f64, n: usize) -> Vec<f64> {
     x
 }
 
-pub struct MultiLinearInterp {
-    grid: Vec<Vec<f64>>,
-    values: ArrayD<f64>,
-}
+fn find_nearest_index(arr: &[OrderedFloat<f64>], target: OrderedFloat<f64>) -> usize {
+    let mut low = 0;
+    let mut high = arr.len() - 1;
 
-impl MultiLinearInterp {
-    pub fn new(grid: Vec<Vec<f64>>, values: ArrayD<f64>) -> Result<Self, String> {
-        // Dimensionality
-        let n = values.ndim();
+    while low < high {
+        let mid = low + (high - low) / 2;
 
-        // Validate inputs
-        if grid.len() != n {
-            return Err("Supplied `grid` must have same dimensionality as `values`".to_string());
+        if arr[mid] >= target {
+            high = mid;
+        } else {
+            low = mid + 1;
         }
-        for i in 0..n {
-            if grid[i].len() <= 1 {
-                return Err(format!(
-                    "Supplied `grid` length must be > 1 for dimension {}",
-                    i
-                ));
-            }
-            if grid[i].len() != values.shape()[i] {
-                return Err(format!("Supplied `grid` and `values` are not compatible shapes: dimension {}, lengths {} != {}", i, grid[i].len(), values.shape()[i]));
-            }
-            if !grid[i].windows(2).all(|w| w[0] < w[1]) {
-                return Err(format!("Supplied `grid` coordinates must be sorted and non-repeating: dimension {}, {:?}", i, grid[i]));
-            }
-        }
-        Ok(MultiLinearInterp { grid, values })
     }
 
-    pub fn interpolate(&self, point: &[f64]) -> Result<f64, String> {
-        let mut n = self.values.ndim();
-        if point.len() != n {
-            return Err(format!("Length of supplied `point` must be same as `values` dimensionality: {point:?} is not {n}-dimensional"));
-        }
-        let mut values = self.values.view();
+    if low > 0 && arr[low] >= target {
+        low - 1
+    } else {
+        low
+    }
+}
 
-        if values.len() == 1 {
-            // Supplied point is coincident with a grid point, so just return the value
-            let first_value: f64 = match values.first() {
-                Some(v) => *v,
-                None => return Err("Could not find first value from array".to_string()),
-            };
-            return Ok(first_value);
-        }
+pub struct BilinearInterp {
+    pub x: Vec<OrderedFloat<f64>>,
+    pub y: Vec<OrderedFloat<f64>>,
+    pub values: Vec<Vec<f64>>,
+}
 
-        // Point can share up to N values of a grid point, which reduces the problem dimensionality
-        // i.e. the point shares one of three values of a 3-D grid point, then the interpolation becomes 2-D at that slice
-        // or   if the point shares two of three values of a 3-D grid point, then the interpolation becomes 1-D
-        let mut grid: Vec<&Vec<f64>> = self.grid.iter().collect();
-        let mut point: Vec<f64> = point.to_vec();
-        for dim in (0..n).rev() {
-            // Range is reversed so that removal doesn't affect indexing
-            if let Some(pos) = grid[dim]
-                .iter()
-                .position(|&grid_point| grid_point == point[dim])
-            {
-                point.remove(dim);
-                grid.remove(dim);
-                values.index_axis_inplace(Axis(dim), pos);
-            }
+impl BilinearInterp {
+    pub fn new(x: Vec<f64>, y: Vec<f64>, values: Vec<Vec<f64>>) -> Result<Self, String> {
+        if x.len() != values.len() {
+            return Err("Supplied `x` must have same dimensionality as `values`".to_string());
         }
-        // Simplified dimensionality
-        n = values.ndim();
+        if y.len() != values[0].len() {
+            return Err("Supplied `y` must have same dimensionality as `values`".to_string());
+        }
+        if !x.windows(2).all(|w| w[0] < w[1]) {
+            return Err("Supplied `x` coordinates must be sorted and non-repeating".to_string());
+        }
+        if !y.windows(2).all(|w| w[0] < w[1]) {
+            return Err("Supplied `y` coordinates must be sorted and non-repeating".to_string());
+        }
+        let x = x.into_iter().map(OrderedFloat::from).collect();
+        let y = y.into_iter().map(OrderedFloat::from).collect();
+        Ok(BilinearInterp { x, y, values })
+    }
 
-        // Extract the lower and upper indices for each dimension,
-        // as well as the fraction of how far the supplied point is between the surrounding grid points
-        let mut indeces_lower = Vec::with_capacity(n);
-        let mut indeces_upper = Vec::with_capacity(n);
-        let mut interp_diffs = Vec::with_capacity(n);
-        for dim in 0..n {
-            let lower_idx = match grid[dim]
-                .windows(2)
-                .position(|w| w[0] < point[dim] && point[dim] < w[1]) {
-                    Some(idx) => idx,
-                    None => return Err(format!(
-                            "Supplied `point` is outside of `grid` bounds: {point:?} is not between {grid:?}",
-                            point = point,
-                            grid = grid
-                    )),
-                };
-            let upper_idx = lower_idx + 1;
-            let interp_diff =
-                (point[dim] - grid[dim][lower_idx]) / (grid[dim][upper_idx] - grid[dim][lower_idx]);
-            indeces_lower.push(lower_idx);
-            indeces_upper.push(upper_idx);
-            interp_diffs.push(interp_diff);
-        }
-        // `interp_vals` contains all values surrounding the point of interest, starting with shape (2, 2, ...) in N dimensions
-        // this gets mutated and reduces in dimension each iteration, filling with the next values to interpolate with
-        // this ends up as a 0-dimensional array containing only the final interpolated value
-        let mut interp_vals = values
-            .slice_each_axis(|ax| Slice::from(indeces_lower[ax.axis.0]..=indeces_upper[ax.axis.0]))
-            .to_owned();
-        // Binary is handy as there are 2 surrounding values to index in each dimension: lower and upper
-        let mut binary_idxs = get_binary_indeces(n);
-        // This loop interpolates in each dimension sequentially
-        // each outer loop iteration the dimensionality reduces by 1
-        // `interp_vals` ends up as a 0-dimensional array containing only the final interpolated value
-        for dim in 0..n {
-            let diff = interp_diffs[dim];
-            let next_dim = n - 1 - dim;
-            // Indeces used for saving results of this dimensions interpolation results
-            // assigned to `binary_idxs` at end of loop to be used for indexing in next iteration
-            let next_idxs = get_binary_indeces(next_dim);
-            let mut intermediate_arr = Array::default(vec![2; next_dim]);
-            for i in 0..next_idxs.len() {
-                // `next_idxs` is always half the length of `binary_idxs`
-                let l = binary_idxs[i].as_slice();
-                let u = binary_idxs[next_idxs.len() + i].as_slice();
-                if dim == 0 && (interp_vals[l].is_nan() || interp_vals[u].is_nan()) {
-                    return Err(format!(
-                            "Surrounding value(s) cannot be NaN:\npoint = {point:?},\ngrid = {grid:?},\nvalues = {values:?}"
-                    ));
-                }
-                // This calculation happens 2^(n-1) times in the first iteration of the outer loop,
-                // 2^(n-2) times in the second iteration, etc.
-                intermediate_arr[next_idxs[i].as_slice()] =
-                    interp_vals[l] * (1.0 - diff) + interp_vals[u] * diff;
-            }
-            binary_idxs = next_idxs;
-            interp_vals = intermediate_arr;
-        }
+    pub fn interpolate(&self, x: f64, y: f64) -> Result<f64, &'static str> {
+        let x_index = find_nearest_index(&self.x, OrderedFloat(x));
+        let y_index = find_nearest_index(&self.y, OrderedFloat(y));
 
-        // return the only value contained within the 0-dimensional array
-        let val: f64 = match interp_vals.first() {
-            Some(v) => *v,
-            None => return Err("Could not find first value from array".to_string()),
-        };
-        Ok(val)
+        if x_index >= self.x.len() - 1 || y_index >= self.y.len() - 1 {
+            return Err("Cannot interpolate outside of grid bounds");
+        }
+        let x0 = self.x[x_index].into_inner();
+        let x1 = self.x[x_index + 1].into_inner();
+        let y0 = self.y[y_index].into_inner();
+        let y1 = self.y[y_index + 1].into_inner();
+
+        let q11 = self.values[x_index][y_index];
+        let q12 = self.values[x_index][y_index + 1];
+        let q21 = self.values[x_index + 1][y_index];
+        let q22 = self.values[x_index + 1][y_index + 1];
+
+        let fxy1 = (x1 - x) / (x1 - x0) * q11 + (x - x0) / (x1 - x0) * q21;
+        let fxy2 = (x1 - x) / (x1 - x0) * q12 + (x - x0) / (x1 - x0) * q22;
+
+        Ok((y1 - y) / (y1 - y0) * fxy1 + (y - y0) / (y1 - y0) * fxy2)
     }
 }
 
@@ -191,116 +85,28 @@ impl MultiLinearInterp {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_multilinear_1d() {
-        let grid = vec![vec![0.0, 1.0, 4.0]];
-        let values = array![0.0, 2.0, 4.45].into_dyn();
-
-        let interp = MultiLinearInterp::new(grid, values.clone()).unwrap();
-
-        let point_a = [0.82];
-        assert_eq!(interp.interpolate(&point_a).unwrap(), 1.64);
-
-        let point_b = [2.98];
-        assert_eq!(interp.interpolate(&point_b).unwrap(), 3.617);
-
-        // returns value at x2
-        let point_c = [4.0];
-        assert_eq!(interp.interpolate(&point_c).unwrap(), values[2]);
-    }
-
     // test targets found using https://www.omnicalculator.com/math/bilinear-interpolation
     #[test]
     fn test_multilinear_2d() {
-        let grid = vec![
-            vec![0.0, 1.0, 2.0], // x0, x1, x2
-            vec![0.0, 1.0, 2.0], // y0, y1, y2
+        let x = vec![0.0, 1.0, 2.0];
+        let y = vec![0.0, 1.0, 2.0];
+        let values = vec![
+            vec![0.0, 2.0, 1.9], // (x0, y0), (x0, y1), (x0, y2)
+            vec![2.0, 4.0, 3.1], // (x1, y0), (x1, y1), (x1, y2)
+            vec![5.0, 0.0, 1.4], // (x2, y0), (x2, y1), (x2, y2)
         ];
-        let values = array![
-            [0.0, 2.0, 1.9], // (x0, y0), (x0, y1), (x0, y2)
-            [2.0, 4.0, 3.1], // (x1, y0), (x1, y1), (x1, y2)
-            [5.0, 0.0, 1.4], // (x2, y0), (x2, y1), (x2, y2)
-        ]
-        .into_dyn();
 
-        let interp = MultiLinearInterp::new(grid, values.clone()).unwrap();
+        let interp = BilinearInterp::new(x, y, values.clone()).unwrap();
 
-        let point_a = [0.5, 0.5];
-        assert_eq!(interp.interpolate(&point_a).unwrap(), 2.0);
+        assert_eq!(interp.interpolate(0.5, 0.5).unwrap(), 2.0);
 
-        let point_b = [1.52, 0.36];
-        assert_eq!(interp.interpolate(&point_b).unwrap(), 2.9696);
+        assert_eq!(interp.interpolate(1.52, 0.36).unwrap(), 2.9696);
 
         // returns value at (x2, y2)
-        let point_c = [2.0, 2.0];
-        assert_eq!(interp.interpolate(&point_c).unwrap(), values[[2, 2]]);
-    }
+        assert_eq!(interp.interpolate(2.0, 2.0).unwrap(), values[2][2]);
 
-    #[test]
-    fn test_multilinear_3d() {
-        let grid = vec![
-            vec![0.0, 1.0, 2.0], // x0, x1, x2
-            vec![0.0, 1.0, 2.0], // y0, y1, y2
-            vec![0.0, 1.0, 2.0], // z0, z1, z2
-        ];
-        let values = array![
-            [
-                [0.0, 1.5, 3.0], // (x0, y0, z0), (x0, y0, z1), (x0, y0, z2)
-                [2.0, 0.5, 1.4], // (x0, y1, z0), (x0, y1, z1), (x0, y1, z2)
-                [1.9, 5.3, 2.2], // (x0, y2, z0), (x0, y0, z1), (x0, y2, z2)
-            ],
-            [
-                [2.0, 5.1, 1.1], // (x1, y0, z0), (x1, y0, z1), (x1, y0, z2)
-                [4.0, 1.0, 0.5], // (x1, y1, z0), (x1, y1, z1), (x1, y1, z2)
-                [3.1, 0.9, 1.2], // (x1, y2, z0), (x1, y2, z1), (x1, y2, z2)
-            ],
-            [
-                [5.0, 0.2, 5.1], // (x2, y0, z0), (x2, y0, z1), (x2, y0, z2)
-                [0.7, 0.1, 3.2], // (x2, y1, z0), (x2, y1, z1), (x2, y1, z2)
-                [1.4, 1.1, 0.0], // (x2, y2, z0), (x2, y2, z1), (x2, y2, z2)
-            ],
-        ]
-        .into_dyn();
-
-        let interp = MultiLinearInterp::new(grid, values.clone()).unwrap();
-
-        let point_a = [0.5, 0.5, 0.5];
-        assert_eq!(interp.interpolate(&point_a).unwrap(), 2.0125);
-
-        let point_b = [1.52, 0.36, 0.5];
-        assert_eq!(interp.interpolate(&point_b).unwrap(), 2.46272);
-
-        // returns value at (x2, y1, z0)
-        let point_c = [2.0, 1.0, 0.0];
-        assert_eq!(interp.interpolate(&point_c).unwrap(), values[[2, 1, 0]]);
-    }
-
-    #[test]
-    fn test_multilinear_with_nans() {
-        let grid = vec![
-            vec![0.0, 1.0, 2.0, 3.0, 4.0], // x0, x1, x2, x3, x4
-            vec![0.0, 1.0, 2.0, 3.0],      // y0, y1, y2, y3
-        ];
-        let values = array![
-            [0.000000, 2.000000, 1.900000, 4.200000], // (x0, y0), (x0, y1), (x0, y2), (x0, y3)
-            [2.000000, 4.000000, 3.100000, 6.100000], // (x1, y0), (x1, y1), (x1, y2), (x1, y3)
-            [f64::NAN, 0.000000, 1.400000, 1.100000], // (x2, y0), (x2, y1), (x2, y2), (x2, y3)
-            [f64::NAN, 0.000000, f64::NAN, f64::NAN], // (x3, y0), (x3, y1), (x3, y2), (x3, y3)
-            [f64::NAN, f64::NAN, f64::NAN, f64::NAN], // (x4, y0), (x4, y1), (x4, y2), (x4, y3)
-        ];
-
-        let interp = MultiLinearInterp::new(grid, values.into_dyn()).unwrap();
-
-        let point_a = [0.51, 0.36];
-        assert_eq!(interp.interpolate(&point_a).unwrap(), 1.74);
-
-        let point_b = [1.5, 2.5];
-        assert_eq!(interp.interpolate(&point_b).unwrap(), 2.925);
-
-        let point_c = [1.5, 0.5];
-        assert!(interp.interpolate(&point_c).is_err());
-
-        let point_d = [3.5, 2.5];
-        assert!(interp.interpolate(&point_d).is_err());
+        // errors out for values greater than bounds 
+        assert!(interp.interpolate(3.0, 3.0).is_err());
+        
     }
 }

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -1,5 +1,6 @@
 use ordered_float::OrderedFloat;
 
+// based on https://stackoverflow.com/a/70840233
 pub fn linspace(x0: f64, xend: f64, n: usize) -> Vec<f64> {
     let dx = (xend - x0) / ((n - 1) as f64);
     let mut x = vec![x0; n];

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/utils.rs
@@ -1,5 +1,3 @@
-
-
 use ordered_float::OrderedFloat;
 
 pub fn linspace(x0: f64, xend: f64, n: usize) -> Vec<f64> {

--- a/rust/routee-compass-powertrain/src/routee/prediction/mod.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/mod.rs
@@ -1,3 +1,4 @@
+pub mod interpolation;
 pub mod model_type;
 pub mod prediction_model;
 pub mod prediction_model_ops;

--- a/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
@@ -7,6 +7,7 @@ pub enum ModelType {
     Smartcore,
     Onnx,
     Interpolate {
+        underlying_model: Box<ModelType>,
         speed_lower_bound: Speed,
         speed_upper_bound: Speed,
         speed_bins: usize,

--- a/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
@@ -1,4 +1,4 @@
-use routee_compass_core::model::unit::{Speed, Grade};
+use routee_compass_core::model::unit::{Grade, Speed};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
@@ -7,7 +7,7 @@ pub enum ModelType {
     Smartcore,
     Onnx,
     Interpolate {
-        underlying_model: Box<ModelType>,
+        underlying_model_type: Box<ModelType>,
         speed_lower_bound: Speed,
         speed_upper_bound: Speed,
         speed_bins: usize,

--- a/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/model_type.rs
@@ -1,64 +1,24 @@
-use super::{
-    prediction_model::PredictionModel,
-    smartcore::smartcore_speed_grade_model::SmartcoreSpeedGradeModel,
-};
-use routee_compass_core::{
-    model::traversal::traversal_model_error::TraversalModelError,
-    model::unit::{EnergyRateUnit, GradeUnit, SpeedUnit},
-};
+use routee_compass_core::model::unit::{Speed, Grade};
 use serde::{Deserialize, Serialize};
-use std::{path::Path, sync::Arc};
-
-#[cfg(feature = "onnx")]
-use super::onnx::onnx_speed_grade_model::OnnxSpeedGradeModel;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelType {
     Smartcore,
     Onnx,
+    Interpolate {
+        speed_lower_bound: Speed,
+        speed_upper_bound: Speed,
+        speed_bins: usize,
+        grade_lower_bound: Grade,
+        grade_upper_bound: Grade,
+        grade_bins: usize,
+    },
 }
 
 impl std::fmt::Display for ModelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = serde_json::to_string(self).map_err(|_| std::fmt::Error)?;
         write!(f, "{}", s)
-    }
-}
-
-impl ModelType {
-    /// builds a speed grade energy prediction model
-    pub fn build<P: AsRef<Path>>(
-        &self,
-        energy_model_path: &P,
-        energy_model_speed_unit: SpeedUnit,
-        energy_model_grade_unit: GradeUnit,
-        energy_model_energy_rate_unit: EnergyRateUnit,
-    ) -> Result<Arc<dyn PredictionModel>, TraversalModelError> {
-        // Load random forest binary file
-        let model: Arc<dyn PredictionModel> = match self {
-            ModelType::Smartcore => Arc::new(SmartcoreSpeedGradeModel::new(
-                energy_model_path,
-                energy_model_speed_unit,
-                energy_model_grade_unit,
-                energy_model_energy_rate_unit,
-            )?),
-            ModelType::Onnx => {
-                #[cfg(feature = "onnx")]
-                {
-                    Arc::new(OnnxSpeedGradeModel::new(
-                        energy_model_path,
-                        energy_model_speed_unit,
-                        energy_model_grade_unit,
-                        energy_model_energy_rate_unit,
-                    )?)
-                }
-                #[cfg(not(feature = "onnx"))]
-                {
-                    return Err(TraversalModelError::BuildError("Cannot build Onnx model without `onnx` feature enabled for compass-powertrain".to_string()));
-                }
-            }
-        };
-        Ok(model)
     }
 }

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
@@ -7,6 +7,7 @@ use routee_compass_core::{
 };
 
 use super::{
+    interpolation::interpolation_speed_grade_model::InterpolationSpeedGradeModel,
     model_type::ModelType, smartcore::smartcore_speed_grade_model::SmartcoreSpeedGradeModel,
     PredictionModel, PredictionModelRecord,
 };
@@ -50,6 +51,26 @@ pub fn load_prediction_model<P: AsRef<Path>>(
                         .to_string(),
                 ));
             }
+        }
+        ModelType::Interpolate {
+            speed_lower_bound,
+            speed_upper_bound,
+            speed_bins: speed_bin_size,
+            grade_lower_bound,
+            grade_upper_bound,
+            grade_bins: grade_bin_size,
+        } => {
+            let model = InterpolationSpeedGradeModel::new(
+                model_path,
+                speed_unit,
+                (speed_lower_bound, speed_upper_bound),
+                speed_bin_size,
+                grade_unit,
+                (grade_lower_bound, grade_upper_bound),
+                grade_bin_size,
+                energy_rate_unit,
+            )?;
+            Arc::new(model)
         }
     };
     let ideal_energy_rate = match ideal_energy_rate_option {

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
@@ -27,7 +27,7 @@ pub fn load_prediction_model<P: AsRef<Path>>(
     real_world_energy_adjustment_option: Option<f64>,
     cache: Option<FloatCachePolicy>,
 ) -> Result<PredictionModelRecord, TraversalModelError> {
-    let prediction_model: Arc<dyn PredictionModel> = match model_type {
+    let prediction_model: Arc<dyn PredictionModel> = match model_type.clone() {
         ModelType::Smartcore => {
             let model = SmartcoreSpeedGradeModel::new(
                 model_path,
@@ -53,6 +53,7 @@ pub fn load_prediction_model<P: AsRef<Path>>(
             }
         }
         ModelType::Interpolate {
+            underlying_model,
             speed_lower_bound,
             speed_upper_bound,
             speed_bins: speed_bin_size,
@@ -62,6 +63,7 @@ pub fn load_prediction_model<P: AsRef<Path>>(
         } => {
             let model = InterpolationSpeedGradeModel::new(
                 model_path,
+                *underlying_model,
                 speed_unit,
                 (speed_lower_bound, speed_upper_bound),
                 speed_bin_size,

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
@@ -64,6 +64,7 @@ pub fn load_prediction_model<P: AsRef<Path>>(
             let model = InterpolationSpeedGradeModel::new(
                 model_path,
                 *underlying_model,
+                name.clone(),
                 speed_unit,
                 (speed_lower_bound, speed_upper_bound),
                 speed_bin_size,

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_ops.rs
@@ -53,7 +53,7 @@ pub fn load_prediction_model<P: AsRef<Path>>(
             }
         }
         ModelType::Interpolate {
-            underlying_model,
+            underlying_model_type: underlying_model,
             speed_lower_bound,
             speed_upper_bound,
             speed_bins: speed_bin_size,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -218,7 +218,14 @@ mod tests {
         let model_record = load_prediction_model(
             "Chevy Bolt".to_string(),
             &model_file_path,
-            ModelType::Smartcore,
+            ModelType::Interpolate {
+                speed_lower_bound: Speed::new(0.0),
+                speed_upper_bound: Speed::new(100.0),
+                speed_bins: 101,
+                grade_lower_bound: Grade::new(-0.20),
+                grade_upper_bound: Grade::new(0.20),
+                grade_bins: 41,
+            },
             SpeedUnit::MilesPerHour,
             GradeUnit::Decimal,
             EnergyRateUnit::KilowattHoursPerMile,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -221,7 +221,7 @@ mod tests {
             "Chevy Bolt".to_string(),
             &model_file_path,
             ModelType::Interpolate {
-                underlying_model: Box::new(ModelType::Smartcore),
+                underlying_model_type: Box::new(ModelType::Smartcore),
                 speed_lower_bound: Speed::new(0.0),
                 speed_upper_bound: Speed::new(100.0),
                 speed_bins: 101,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -221,6 +221,7 @@ mod tests {
             "Chevy Bolt".to_string(),
             &model_file_path,
             ModelType::Interpolate {
+                underlying_model: Box::new(ModelType::Smartcore),
                 speed_lower_bound: Speed::new(0.0),
                 speed_upper_bound: Speed::new(100.0),
                 speed_bins: 101,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -129,9 +129,11 @@ impl VehicleType for BEV {
         query: &serde_json::Value,
     ) -> Result<Arc<dyn VehicleType>, TraversalModelError> {
         let starting_soc_percent = match query.get("starting_soc_percent".to_string()) {
-            Some(soc_string) => soc_string.as_f64().ok_or(TraversalModelError::BuildError(
-                "Expected 'starting_soc_percent' value to be numeric".to_string(),
-            ))?,
+            Some(soc_string) => soc_string.as_f64().ok_or_else(|| {
+                TraversalModelError::BuildError(
+                    "Expected 'starting_soc_percent' value to be numeric".to_string(),
+                )
+            })?,
             None => 100.0,
         };
         if !(0.0..=100.0).contains(&starting_soc_percent) {

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
@@ -167,13 +167,17 @@ impl VehicleType for PHEV {
     ) -> Result<Arc<dyn VehicleType>, TraversalModelError> {
         let starting_soc_percent = query
             .get("starting_soc_percent".to_string())
-            .ok_or(TraversalModelError::BuildError(
-                "No 'starting_soc_percent' key provided in query".to_string(),
-            ))?
+            .ok_or_else(|| {
+                TraversalModelError::BuildError(
+                    "No 'starting_soc_percent' key provided in query".to_string(),
+                )
+            })?
             .as_f64()
-            .ok_or(TraversalModelError::BuildError(
-                "Expected 'starting_soc_percent' value to be numeric".to_string(),
-            ))?;
+            .ok_or_else(|| {
+                TraversalModelError::BuildError(
+                    "Expected 'starting_soc_percent' value to be numeric".to_string(),
+                )
+            })?;
         if !(0.0..=100.0).contains(&starting_soc_percent) {
             return Err(TraversalModelError::BuildError(
                 "Expected 'starting_soc_percent' value to be between 0 and 100".to_string(),

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
@@ -319,7 +319,7 @@ mod tests {
             .join("test")
             .join("2016_CHEVROLET_Volt_Charge_Depleting.bin");
         let model_type = ModelType::Interpolate {
-            underlying_model: Box::new(ModelType::Smartcore),
+            underlying_model_type: Box::new(ModelType::Smartcore),
             speed_lower_bound: Speed::new(0.0),
             speed_upper_bound: Speed::new(100.0),
             speed_bins: 101,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
@@ -314,11 +314,19 @@ mod tests {
             .join("routee")
             .join("test")
             .join("2016_CHEVROLET_Volt_Charge_Depleting.bin");
+        let model_type = ModelType::Interpolate {
+            speed_lower_bound: Speed::new(0.0),
+            speed_upper_bound: Speed::new(100.0),
+            speed_bins: 101,
+            grade_lower_bound: Grade::new(-0.20),
+            grade_upper_bound: Grade::new(0.20),
+            grade_bins: 41,
+        };
 
         let charge_sustain_model_record = load_prediction_model(
             "Chevy_Volt_Charge_Sustaining".to_string(),
             &charge_sustain_model_file_path,
-            ModelType::Smartcore,
+            model_type.clone(),
             SpeedUnit::MilesPerHour,
             GradeUnit::Decimal,
             EnergyRateUnit::GallonsGasolinePerMile,
@@ -330,7 +338,7 @@ mod tests {
         let charge_depleting_model_record = load_prediction_model(
             "Chevy_Volt_Charge_Depleting".to_string(),
             &charge_depleting_model_file_path,
-            ModelType::Smartcore,
+            model_type.clone(),
             SpeedUnit::MilesPerHour,
             GradeUnit::Decimal,
             EnergyRateUnit::KilowattHoursPerMile,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
@@ -319,6 +319,7 @@ mod tests {
             .join("test")
             .join("2016_CHEVROLET_Volt_Charge_Depleting.bin");
         let model_type = ModelType::Interpolate {
+            underlying_model: Box::new(ModelType::Smartcore),
             speed_lower_bound: Speed::new(0.0),
             speed_upper_bound: Speed::new(100.0),
             speed_bins: 101,

--- a/rust/routee-compass/src/app/compass/compass_app_ops.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_ops.rs
@@ -24,9 +24,9 @@ pub fn read_config_from_file(config_path: &Path) -> Result<Config, CompassAppErr
     // was found so we can use it later to resolve relative paths
     let conf_file_string = config_path
         .to_str()
-        .ok_or(CompassAppError::InternalError(
-            "Could not parse incoming config file path".to_string(),
-        ))?
+        .ok_or_else(|| {
+            CompassAppError::InternalError("Could not parse incoming config file path".to_string())
+        })?
         .to_string();
 
     let config = Config::builder()
@@ -117,9 +117,9 @@ fn min_bin(bins: &[f64]) -> Result<usize, PluginError> {
         .enumerate()
         .min_by_key(|(_i, w)| OrderedFloat(**w))
         .map(|(i, _w)| i)
-        .ok_or(PluginError::InternalError(String::from(
-            "cannot find min bin of empty slice",
-        )))
+        .ok_or_else(|| {
+            PluginError::InternalError(String::from("cannot find min bin of empty slice"))
+        })
 }
 
 #[cfg(test)]

--- a/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_app_builder.rs
@@ -189,28 +189,31 @@ impl CompassAppBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<Arc<dyn TraversalModelService>, CompassConfigurationError> {
-        let tm_type_obj =
-            config
-                .get("type")
-                .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::Traversal.to_string(),
-                    String::from("type"),
-                ))?;
+        let tm_type_obj = config.get("type").ok_or_else(|| {
+            CompassConfigurationError::ExpectedFieldForComponent(
+                CompassConfigurationField::Traversal.to_string(),
+                String::from("type"),
+            )
+        })?;
         let tm_type: String = tm_type_obj
             .as_str()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from("type"),
-                String::from("String"),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from("type"),
+                    String::from("String"),
+                )
+            })?
             .into();
         let result = self
             .traversal_model_builders
             .get(&tm_type)
-            .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
-                tm_type.clone(),
-                String::from("traversal"),
-                self.traversal_model_builders.keys().join(", "),
-            ))
+            .ok_or_else(|| {
+                CompassConfigurationError::UnknownModelNameForComponent(
+                    tm_type.clone(),
+                    String::from("traversal"),
+                    self.traversal_model_builders.keys().join(", "),
+                )
+            })
             .and_then(|b| {
                 b.build(config)
                     .map_err(CompassConfigurationError::TraversalModelError)
@@ -224,27 +227,30 @@ impl CompassAppBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<Arc<dyn FrontierModelService>, CompassConfigurationError> {
-        let fm_type_obj =
-            config
-                .get("type")
-                .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::Frontier.to_string(),
-                    String::from("type"),
-                ))?;
+        let fm_type_obj = config.get("type").ok_or_else(|| {
+            CompassConfigurationError::ExpectedFieldForComponent(
+                CompassConfigurationField::Frontier.to_string(),
+                String::from("type"),
+            )
+        })?;
         let fm_type: String = fm_type_obj
             .as_str()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from("type"),
-                String::from("String"),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from("type"),
+                    String::from("String"),
+                )
+            })?
             .into();
         self.frontier_builders
             .get(&fm_type)
-            .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
-                fm_type.clone(),
-                String::from("frontier"),
-                self.frontier_builders.keys().join(", "),
-            ))
+            .ok_or_else(|| {
+                CompassConfigurationError::UnknownModelNameForComponent(
+                    fm_type.clone(),
+                    String::from("frontier"),
+                    self.frontier_builders.keys().join(", "),
+                )
+            })
             .and_then(|b| {
                 b.build(config)
                     .map_err(CompassConfigurationError::FrontierModelError)
@@ -262,32 +268,38 @@ impl CompassAppBuilder {
 
         let mut plugins: Vec<Arc<dyn InputPlugin>> = Vec::new();
         for plugin_json in input_plugins.into_iter() {
-            let plugin_type_obj =
-                plugin_json
-                    .as_object()
-                    .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                        String::from("type"),
-                        String::from("Json Object"),
-                    ))?;
+            let plugin_type_obj = plugin_json.as_object().ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from("type"),
+                    String::from("Json Object"),
+                )
+            })?;
             let plugin_type: String = plugin_type_obj
                 .get("type")
-                .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::InputPlugins.to_string(),
-                    String::from("type"),
-                ))?
+                .ok_or_else(|| {
+                    CompassConfigurationError::ExpectedFieldForComponent(
+                        CompassConfigurationField::InputPlugins.to_string(),
+                        String::from("type"),
+                    )
+                })?
                 .as_str()
-                .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                    String::from("type"),
-                    String::from("String"),
-                ))?
+                .ok_or_else(|| {
+                    CompassConfigurationError::ExpectedFieldWithType(
+                        String::from("type"),
+                        String::from("String"),
+                    )
+                })?
                 .into();
-            let builder = self.input_plugin_builders.get(&plugin_type).ok_or(
-                CompassConfigurationError::UnknownModelNameForComponent(
-                    plugin_type.clone(),
-                    String::from("Input Plugin"),
-                    self.input_plugin_builders.keys().join(", "),
-                ),
-            )?;
+            let builder = self
+                .input_plugin_builders
+                .get(&plugin_type)
+                .ok_or_else(|| {
+                    CompassConfigurationError::UnknownModelNameForComponent(
+                        plugin_type.clone(),
+                        String::from("Input Plugin"),
+                        self.input_plugin_builders.keys().join(", "),
+                    )
+                })?;
             let input_plugin = builder.build(&plugin_json)?;
             plugins.push(input_plugin);
         }
@@ -305,32 +317,38 @@ impl CompassAppBuilder {
 
         let mut plugins: Vec<Arc<dyn OutputPlugin>> = Vec::new();
         for plugin_json in output_plugins.into_iter() {
-            let plugin_json_obj =
-                plugin_json
-                    .as_object()
-                    .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                        String::from("output_plugins"),
-                        String::from("Json Object"),
-                    ))?;
+            let plugin_json_obj = plugin_json.as_object().ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from("output_plugins"),
+                    String::from("Json Object"),
+                )
+            })?;
             let plugin_type: String = plugin_json_obj
                 .get("type")
-                .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::OutputPlugins.to_string(),
-                    String::from("type"),
-                ))?
+                .ok_or_else(|| {
+                    CompassConfigurationError::ExpectedFieldForComponent(
+                        CompassConfigurationField::OutputPlugins.to_string(),
+                        String::from("type"),
+                    )
+                })?
                 .as_str()
-                .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                    String::from("type"),
-                    String::from("String"),
-                ))?
+                .ok_or_else(|| {
+                    CompassConfigurationError::ExpectedFieldWithType(
+                        String::from("type"),
+                        String::from("String"),
+                    )
+                })?
                 .into();
-            let builder = self.output_plugin_builders.get(&plugin_type).ok_or(
-                CompassConfigurationError::UnknownModelNameForComponent(
-                    plugin_type.clone(),
-                    String::from("Output Plugin"),
-                    self.output_plugin_builders.keys().join(", "),
-                ),
-            )?;
+            let builder = self
+                .output_plugin_builders
+                .get(&plugin_type)
+                .ok_or_else(|| {
+                    CompassConfigurationError::UnknownModelNameForComponent(
+                        plugin_type.clone(),
+                        String::from("Output Plugin"),
+                        self.output_plugin_builders.keys().join(", "),
+                    )
+                })?;
             let output_plugin = builder.build(&plugin_json)?;
             plugins.push(output_plugin);
         }

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -72,10 +72,12 @@ impl ConfigJsonExtensions for serde_json::Value {
     ) -> Result<serde_json::Value, CompassConfigurationError> {
         let section = self
             .get(section.to_str())
-            .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                section.to_string(),
-                String::from(""),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldForComponent(
+                    section.to_string(),
+                    String::from(""),
+                )
+            })?
             .clone();
 
         Ok(section)
@@ -120,16 +122,20 @@ impl ConfigJsonExtensions for serde_json::Value {
     ) -> Result<String, CompassConfigurationError> {
         let value = self
             .get(key.as_ref())
-            .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                String::from(key.as_ref()),
-                String::from(parent_key.as_ref()),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldForComponent(
+                    String::from(key.as_ref()),
+                    String::from(parent_key.as_ref()),
+                )
+            })?
             .as_str()
             .map(String::from)
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from(key.as_ref()),
-                String::from("String"),
-            ))?;
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from(key.as_ref()),
+                    String::from("String"),
+                )
+            })?;
         Ok(value)
     }
 
@@ -140,15 +146,19 @@ impl ConfigJsonExtensions for serde_json::Value {
     ) -> Result<Vec<serde_json::Value>, CompassConfigurationError> {
         let array = self
             .get(key.as_ref())
-            .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                String::from(key.as_ref()),
-                String::from(parent_key.as_ref()),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldForComponent(
+                    String::from(key.as_ref()),
+                    String::from(parent_key.as_ref()),
+                )
+            })?
             .as_array()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from(key.as_ref()),
-                String::from("Array"),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from(key.as_ref()),
+                    String::from("Array"),
+                )
+            })?
             .to_owned();
         Ok(array)
     }
@@ -160,15 +170,19 @@ impl ConfigJsonExtensions for serde_json::Value {
     ) -> Result<i64, CompassConfigurationError> {
         let value = self
             .get(key.as_ref())
-            .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                String::from(key.as_ref()),
-                String::from(parent_key.as_ref()),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldForComponent(
+                    String::from(key.as_ref()),
+                    String::from(parent_key.as_ref()),
+                )
+            })?
             .as_i64()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from(key.as_ref()),
-                String::from("64-bit signed integer"),
-            ))?;
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from(key.as_ref()),
+                    String::from("64-bit signed integer"),
+                )
+            })?;
         Ok(value)
     }
 
@@ -179,15 +193,19 @@ impl ConfigJsonExtensions for serde_json::Value {
     ) -> Result<f64, CompassConfigurationError> {
         let value = self
             .get(key.as_ref())
-            .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                String::from(key.as_ref()),
-                String::from(parent_key.as_ref()),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldForComponent(
+                    String::from(key.as_ref()),
+                    String::from(parent_key.as_ref()),
+                )
+            })?
             .as_f64()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from(key.as_ref()),
-                String::from("64-bit floating point"),
-            ))?;
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from(key.as_ref()),
+                    String::from("64-bit floating point"),
+                )
+            })?;
         Ok(value)
     }
 
@@ -198,15 +216,19 @@ impl ConfigJsonExtensions for serde_json::Value {
     ) -> Result<T, CompassConfigurationError> {
         let value = self
             .get(key.as_ref())
-            .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                String::from(key.as_ref()),
-                String::from(parent_key.as_ref()),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldForComponent(
+                    String::from(key.as_ref()),
+                    String::from(parent_key.as_ref()),
+                )
+            })?
             .as_str()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from(key.as_ref()),
-                String::from("string-parseable"),
-            ))?;
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from(key.as_ref()),
+                    String::from("string-parseable"),
+                )
+            })?;
         let result = T::from_str(value).map_err(|_| {
             CompassConfigurationError::ExpectedFieldWithType(
                 String::from(key.as_ref()),
@@ -223,10 +245,12 @@ impl ConfigJsonExtensions for serde_json::Value {
     ) -> Result<T, CompassConfigurationError> {
         let value = self
             .get(key.as_ref())
-            .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                String::from(key.as_ref()),
-                String::from(parent_key.as_ref()),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldForComponent(
+                    String::from(key.as_ref()),
+                    String::from(parent_key.as_ref()),
+                )
+            })?
             .to_owned();
 
         let result: T = serde_json::from_value(value)
@@ -287,9 +311,9 @@ impl ConfigJsonExtensions for serde_json::Value {
                     let new_path = root_config_parent.join(path);
                     let new_path_string = new_path
                         .to_str()
-                        .ok_or(CompassConfigurationError::FileNormalizationError(
-                            path_string.clone(),
-                        ))?
+                        .ok_or_else(|| {
+                            CompassConfigurationError::FileNormalizationError(path_string.clone())
+                        })?
                         .to_string();
                     if new_path.is_file() {
                         Ok(serde_json::Value::String(new_path_string))

--- a/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/combined/combined_builder.rs
@@ -30,27 +30,30 @@ impl CombinedBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<Arc<dyn FrontierModelService>, CompassConfigurationError> {
-        let fm_type_obj =
-            config
-                .get("type")
-                .ok_or(CompassConfigurationError::ExpectedFieldForComponent(
-                    CompassConfigurationField::Frontier.to_string(),
-                    String::from("type"),
-                ))?;
+        let fm_type_obj = config.get("type").ok_or_else(|| {
+            CompassConfigurationError::ExpectedFieldForComponent(
+                CompassConfigurationField::Frontier.to_string(),
+                String::from("type"),
+            )
+        })?;
         let fm_type: String = fm_type_obj
             .as_str()
-            .ok_or(CompassConfigurationError::ExpectedFieldWithType(
-                String::from("type"),
-                String::from("String"),
-            ))?
+            .ok_or_else(|| {
+                CompassConfigurationError::ExpectedFieldWithType(
+                    String::from("type"),
+                    String::from("String"),
+                )
+            })?
             .into();
         self.builders
             .get(&fm_type)
-            .ok_or(CompassConfigurationError::UnknownModelNameForComponent(
-                fm_type.clone(),
-                String::from("frontier"),
-                self.builders.keys().join(", "),
-            ))
+            .ok_or_else(|| {
+                CompassConfigurationError::UnknownModelNameForComponent(
+                    fm_type.clone(),
+                    String::from("frontier"),
+                    self.builders.keys().join(", "),
+                )
+            })
             .and_then(|b| {
                 b.build(config)
                     .map_err(CompassConfigurationError::FrontierModelError)

--- a/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_model.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_model.rs
@@ -24,10 +24,7 @@ impl FrontierModel for RoadClassFrontierModel {
                 .service
                 .road_class_lookup
                 .get(edge.edge_id.0)
-                .ok_or(FrontierModelError::MissingIndex(format!(
-                    "{}",
-                    edge.edge_id
-                )))
+                .ok_or_else(|| FrontierModelError::MissingIndex(format!("{}", edge.edge_id)))
                 .map(|road_class| road_classes.contains(road_class)),
         }
     }

--- a/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/termination_model_builder.rs
@@ -21,12 +21,12 @@ impl TerminationModelBuilder {
 
         let result = match term_type.to_lowercase().as_str() {
             "query_runtime" => {
-                let dur_val = config.get("limit").ok_or(
+                let dur_val = config.get("limit").ok_or_else(|| {
                     CompassConfigurationError::ExpectedFieldForComponent(
                         local_scope.clone(),
                         String::from("limit"),
-                    ),
-                )?;
+                    )
+                })?;
                 let dur = dur_val.as_duration()?;
                 let freq = config.get_config_i64(&"frequency", &local_scope)? as u64;
                 Ok(T::QueryRuntimeLimit {

--- a/rust/routee-compass/src/app/geom/geom_app.rs
+++ b/rust/routee-compass/src/app/geom/geom_app.rs
@@ -72,7 +72,7 @@ impl GeomApp {
             let edge_idx = row
                 .parse::<usize>()
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-            let result = self.geoms.get(edge_idx).cloned().ok_or({
+            let result = self.geoms.get(edge_idx).cloned().ok_or_else(|| {
                 std::io::Error::new(
                     ErrorKind::InvalidData,
                     format!("EdgeId {} is out of bounds, should be in range [0, )", idx),

--- a/rust/routee-compass/src/main.rs
+++ b/rust/routee-compass/src/main.rs
@@ -14,9 +14,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // build CompassApp from config
     let args = CompassAppArgs::parse();
 
-    let conf_file = args.config.ok_or(CompassAppError::NoInputFile(
-        "No configuration file specified".to_string(),
-    ))?;
+    let conf_file = args.config.ok_or_else(|| {
+        CompassAppError::NoInputFile("No configuration file specified".to_string())
+    })?;
 
     let compass_app = match CompassApp::try_from(conf_file.as_path()) {
         Ok(app) => app,

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
@@ -39,12 +39,12 @@ impl InputPlugin for EdgeRtreeInputPlugin {
         let dst_coord_option = query.get_destination_coordinate()?;
 
         let source_edge_id = search(&self.rtree, src_coord, &road_classes, self.tolerance)
-            .ok_or(matching_error(&src_coord, self.tolerance))?;
+            .ok_or_else(|| matching_error(&src_coord, self.tolerance))?;
         let destination_edge_id_option = match dst_coord_option {
             None => Ok(None),
             Some(dst_coord) => search(&self.rtree, dst_coord, &road_classes, self.tolerance)
                 .map(Some)
-                .ok_or(matching_error(&dst_coord, self.tolerance)),
+                .ok_or_else(|| matching_error(&dst_coord, self.tolerance)),
         }?;
 
         let mut updated = query.clone();

--- a/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
@@ -23,13 +23,9 @@ impl InputPlugin for GridSearchPlugin {
                     )));
                 }
 
-                let map =
-                    grid_search_input
-                        .as_object()
-                        .ok_or(PluginError::UnexpectedQueryStructure(format!(
-                            "{:?}",
-                            input
-                        )))?;
+                let map = grid_search_input
+                    .as_object()
+                    .ok_or_else(|| PluginError::UnexpectedQueryStructure(format!("{:?}", input)))?;
                 let mut keys: Vec<String> = vec![];
                 let mut multiset_input: Vec<Vec<serde_json::Value>> = vec![];
                 let mut multiset_indices: Vec<Vec<usize>> = vec![];
@@ -46,10 +42,7 @@ impl InputPlugin for GridSearchPlugin {
                 // let remove_key = InputField::GridSearch.to_str();
                 let mut initial_map = input
                     .as_object()
-                    .ok_or(PluginError::UnexpectedQueryStructure(format!(
-                        "{:?}",
-                        input
-                    )))?
+                    .ok_or_else(|| PluginError::UnexpectedQueryStructure(format!("{:?}", input)))?
                     .clone();
                 initial_map.remove(InputField::GridSearch.to_str());
                 let initial = serde_json::json!(initial_map);

--- a/rust/routee-compass/src/plugin/input/default/inject/inject_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/inject_plugin.rs
@@ -16,12 +16,12 @@ impl InjectInputPlugin {
 impl InputPlugin for InjectInputPlugin {
     fn process(&self, input: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
         let mut updated_obj = input.clone();
-        let updated = updated_obj
-            .as_object_mut()
-            .ok_or(PluginError::InternalError(format!(
+        let updated = updated_obj.as_object_mut().ok_or_else(|| {
+            PluginError::InternalError(format!(
                 "expected input JSON to be an object, found {}",
                 input
-            )))?;
+            ))
+        })?;
         updated.insert(self.key.clone(), self.value.clone());
         Ok(vec![json!(updated)])
     }

--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/plugin.rs
@@ -141,13 +141,12 @@ impl InputPlugin for RTreePlugin {
         let src_coord = query.get_origin_coordinate()?;
         let dst_coord_option = query.get_destination_coordinate()?;
 
-        let src_vertex =
-            self.vertex_rtree
-                .nearest_vertex(src_coord)
-                .ok_or(PluginError::PluginFailed(format!(
-                    "nearest vertex not found for origin coordinate {:?}",
-                    src_coord
-                )))?;
+        let src_vertex = self.vertex_rtree.nearest_vertex(src_coord).ok_or_else(|| {
+            PluginError::PluginFailed(format!(
+                "nearest vertex not found for origin coordinate {:?}",
+                src_coord
+            ))
+        })?;
 
         validate_tolerance(src_coord, src_vertex.coordinate, &self.tolerance)?;
         updated.add_origin_vertex(src_vertex.vertex_id)?;
@@ -155,12 +154,12 @@ impl InputPlugin for RTreePlugin {
         match dst_coord_option {
             None => {}
             Some(dst_coord) => {
-                let dst_vertex = self.vertex_rtree.nearest_vertex(dst_coord).ok_or(
+                let dst_vertex = self.vertex_rtree.nearest_vertex(dst_coord).ok_or_else(|| {
                     PluginError::PluginFailed(format!(
                         "nearest vertex not found for destination coordinate {:?}",
                         dst_coord
-                    )),
-                )?;
+                    ))
+                })?;
                 validate_tolerance(dst_coord, dst_vertex.coordinate, &self.tolerance)?;
                 updated.add_destination_vertex(dst_vertex.vertex_id)?;
             }

--- a/rust/routee-compass/src/plugin/input/input_json_extensions.rs
+++ b/rust/routee-compass/src/plugin/input/input_json_extensions.rs
@@ -24,20 +24,18 @@ impl InputJsonExtensions for serde_json::Value {
     fn get_origin_coordinate(&self) -> Result<geo::Coord<f64>, PluginError> {
         let origin_x = self
             .get(InputField::OriginX.to_string())
-            .ok_or(PluginError::MissingField(InputField::OriginX.to_string()))?
+            .ok_or_else(|| PluginError::MissingField(InputField::OriginX.to_string()))?
             .as_f64()
-            .ok_or(PluginError::ParseError(
-                InputField::OriginX.to_string(),
-                String::from("f64"),
-            ))?;
+            .ok_or_else(|| {
+                PluginError::ParseError(InputField::OriginX.to_string(), String::from("f64"))
+            })?;
         let origin_y = self
             .get(InputField::OriginY.to_string())
-            .ok_or(PluginError::MissingField(InputField::OriginY.to_string()))?
+            .ok_or_else(|| PluginError::MissingField(InputField::OriginY.to_string()))?
             .as_f64()
-            .ok_or(PluginError::ParseError(
-                InputField::OriginY.to_string(),
-                String::from("f64"),
-            ))?;
+            .ok_or_else(|| {
+                PluginError::ParseError(InputField::OriginY.to_string(), String::from("f64"))
+            })?;
         Ok(geo::Coord::from((origin_x, origin_y)))
     }
     fn get_destination_coordinate(&self) -> Result<Option<geo::Coord<f64>>, PluginError> {
@@ -56,14 +54,12 @@ impl InputJsonExtensions for serde_json::Value {
                 &x_field, &y_field
             ))),
             (Some(x_json), Some(y_json)) => {
-                let x = x_json.as_f64().ok_or(PluginError::ParseError(
-                    x_field.clone(),
-                    String::from("f64"),
-                ))?;
-                let y = y_json.as_f64().ok_or(PluginError::ParseError(
-                    y_field.clone(),
-                    String::from("f64"),
-                ))?;
+                let x = x_json
+                    .as_f64()
+                    .ok_or_else(|| PluginError::ParseError(x_field.clone(), String::from("f64")))?;
+                let y = y_json
+                    .as_f64()
+                    .ok_or_else(|| PluginError::ParseError(y_field.clone(), String::from("f64")))?;
                 Ok(Some(geo::Coord::from((x, y))))
             }
         }
@@ -99,54 +95,45 @@ impl InputJsonExtensions for serde_json::Value {
 
     fn get_origin_vertex(&self) -> Result<VertexId, PluginError> {
         self.get(InputField::OriginVertex.to_string())
-            .ok_or(PluginError::MissingField(
-                InputField::OriginVertex.to_string(),
-            ))?
+            .ok_or_else(|| PluginError::MissingField(InputField::OriginVertex.to_string()))?
             .as_u64()
             .map(|v| VertexId(v as usize))
-            .ok_or(PluginError::ParseError(
-                InputField::OriginVertex.to_string(),
-                String::from("u64"),
-            ))
+            .ok_or_else(|| {
+                PluginError::ParseError(InputField::OriginVertex.to_string(), String::from("u64"))
+            })
     }
 
     fn get_destination_vertex(&self) -> Result<Option<VertexId>, PluginError> {
         match self.get(InputField::DestinationVertex.to_string()) {
             None => Ok(None),
-            Some(v) => {
-                v.as_u64()
-                    .map(|v| Some(VertexId(v as usize)))
-                    .ok_or(PluginError::ParseError(
+            Some(v) => v
+                .as_u64()
+                .map(|v| Some(VertexId(v as usize)))
+                .ok_or_else(|| {
+                    PluginError::ParseError(
                         InputField::DestinationVertex.to_string(),
                         String::from("u64"),
-                    ))
-            }
+                    )
+                }),
         }
     }
 
     fn get_origin_edge(&self) -> Result<EdgeId, PluginError> {
         self.get(InputField::OriginEdge.to_string())
-            .ok_or(PluginError::MissingField(
-                InputField::OriginEdge.to_string(),
-            ))?
+            .ok_or_else(|| PluginError::MissingField(InputField::OriginEdge.to_string()))?
             .as_u64()
             .map(|v| EdgeId(v as usize))
-            .ok_or(PluginError::ParseError(
-                InputField::OriginEdge.to_string(),
-                String::from("u64"),
-            ))
+            .ok_or_else(|| {
+                PluginError::ParseError(InputField::OriginEdge.to_string(), String::from("u64"))
+            })
     }
 
     fn get_destination_edge(&self) -> Result<Option<EdgeId>, PluginError> {
         match self.get(InputField::DestinationEdge.to_string()) {
             None => Ok(None),
-            Some(v) => v
-                .as_u64()
-                .map(|v| Some(EdgeId(v as usize)))
-                .ok_or(PluginError::ParseError(
-                    InputField::OriginEdge.to_string(),
-                    String::from("u64"),
-                )),
+            Some(v) => v.as_u64().map(|v| Some(EdgeId(v as usize))).ok_or_else(|| {
+                PluginError::ParseError(InputField::OriginEdge.to_string(), String::from("u64"))
+            }),
         }
     }
     fn get_grid_search(&self) -> Option<&serde_json::Value> {
@@ -198,10 +185,12 @@ impl InputJsonExtensions for serde_json::Value {
     fn get_query_weight_estimate(&self) -> Result<Option<f64>, PluginError> {
         match self.get(InputField::QueryWeightEstimate.to_string()) {
             None => Ok(None),
-            Some(v) => v.as_f64().map(Some).ok_or(PluginError::ParseError(
-                InputField::QueryWeightEstimate.to_string(),
-                String::from("f64"),
-            )),
+            Some(v) => v.as_f64().map(Some).ok_or_else(|| {
+                PluginError::ParseError(
+                    InputField::QueryWeightEstimate.to_string(),
+                    String::from("f64"),
+                )
+            }),
         }
     }
 }
@@ -216,12 +205,12 @@ impl InputJsonExtensions for serde_json::Value {
 //     let at_field = value.get(field.to_string());
 //     match at_field {
 //         None => Err(PluginError::MissingField(field.to_string())),
-//         Some(v) => op(v).ok_or(PluginError::ParseError(field.to_string(), ())),
+//         Some(v) => op(v).ok_or_else( ||PluginError::ParseError(field.to_string(), ())),
 //     };
 // }
 
 // fn get_f64(v: &serde_json::Value) -> Result<f64, PluginError> {
 
 //     get_from_json(v, field, |v| v.as_f64())
-//     v.as_f64().ok_or(PluginError::ParseError((), ())
+//     v.as_f64().ok_or_else( ||PluginError::ParseError((), ())
 // }

--- a/rust/routee-compass/src/plugin/output/default/edgeidlist/json_extensions.rs
+++ b/rust/routee-compass/src/plugin/output/default/edgeidlist/json_extensions.rs
@@ -60,20 +60,19 @@ impl EdgeListJsonExtensions for serde_json::Value {
                 let edge_id_list_field = EdgeListField::EdgeIdList.into_str();
                 let edge_id_list_json = map
                     .get(edge_id_list_field)
-                    .ok_or(PluginError::MissingField(String::from(edge_id_list_field)))?;
-                let json_list = edge_id_list_json.as_array().ok_or(PluginError::ParseError(
-                    format!("{:?}", edge_id_list_json),
-                    String::from("JSON Array"),
-                ))?;
+                    .ok_or_else(|| PluginError::MissingField(String::from(edge_id_list_field)))?;
+                let json_list = edge_id_list_json.as_array().ok_or_else(|| {
+                    PluginError::ParseError(
+                        format!("{:?}", edge_id_list_json),
+                        String::from("JSON Array"),
+                    )
+                })?;
                 let result: Result<Vec<EdgeId>, PluginError> = json_list
                     .iter()
                     .map(|v| {
-                        v.as_u64()
-                            .map(|u| EdgeId(u as usize))
-                            .ok_or(PluginError::ParseError(
-                                format!("{}", v),
-                                String::from("u64"),
-                            ))
+                        v.as_u64().map(|u| EdgeId(u as usize)).ok_or_else(|| {
+                            PluginError::ParseError(format!("{}", v), String::from("u64"))
+                        })
                     })
                     .collect();
 

--- a/rust/routee-compass/src/plugin/output/default/summary/json_extensions.rs
+++ b/rust/routee-compass/src/plugin/output/default/summary/json_extensions.rs
@@ -51,9 +51,9 @@ impl SummaryJsonExtensions for serde_json::Value {
         match self {
             serde_json::Value::Object(map) => {
                 let cost_f64: f64 = cost.into();
-                let cost_json = serde_json::Number::from_f64(cost_f64).ok_or(
-                    PluginError::ParseError(String::from("Cost"), String::from("f64")),
-                )?;
+                let cost_json = serde_json::Number::from_f64(cost_f64).ok_or_else(|| {
+                    PluginError::ParseError(String::from("Cost"), String::from("f64"))
+                })?;
                 map.insert(
                     SummaryField::Cost.to_string(),
                     serde_json::Value::Number(cost_json),
@@ -72,11 +72,10 @@ impl SummaryJsonExtensions for serde_json::Value {
                 let cost_field = SummaryField::Cost.to_string();
                 let cost_json = map
                     .get(&cost_field)
-                    .ok_or(PluginError::MissingField(cost_field))?;
-                let cost_f64 = cost_json.as_f64().ok_or(PluginError::ParseError(
-                    String::from("Cost"),
-                    String::from("f64"),
-                ))?;
+                    .ok_or_else(|| PluginError::MissingField(cost_field))?;
+                let cost_f64 = cost_json.as_f64().ok_or_else(|| {
+                    PluginError::ParseError(String::from("Cost"), String::from("f64"))
+                })?;
                 let cost = Cost::from(cost_f64);
                 Ok(cost)
             }
@@ -92,11 +91,10 @@ impl SummaryJsonExtensions for serde_json::Value {
                 let distance_field = SummaryField::Distance.to_string();
                 let distance_json = map
                     .get(&distance_field)
-                    .ok_or(PluginError::MissingField(distance_field))?;
-                let distance_f64 = distance_json.as_f64().ok_or(PluginError::ParseError(
-                    String::from("Distance"),
-                    String::from("f64"),
-                ))?;
+                    .ok_or_else(|| PluginError::MissingField(distance_field))?;
+                let distance_f64 = distance_json.as_f64().ok_or_else(|| {
+                    PluginError::ParseError(String::from("Distance"), String::from("f64"))
+                })?;
                 Ok(distance_f64)
             }
             _ => Err(PluginError::InputError(String::from(
@@ -108,9 +106,9 @@ impl SummaryJsonExtensions for serde_json::Value {
     fn add_distance(&mut self, distance: f64) -> Result<(), PluginError> {
         match self {
             serde_json::Value::Object(map) => {
-                let distance_json = serde_json::Number::from_f64(distance).ok_or(
-                    PluginError::ParseError(String::from("Distance"), String::from("f64")),
-                )?;
+                let distance_json = serde_json::Number::from_f64(distance).ok_or_else(|| {
+                    PluginError::ParseError(String::from("Distance"), String::from("f64"))
+                })?;
                 let json_string = serde_json::Value::Number(distance_json);
                 map.insert(SummaryField::Distance.to_string(), json_string);
                 Ok(())

--- a/rust/routee-compass/src/plugin/output/default/traversal/json_extensions.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/json_extensions.rs
@@ -30,14 +30,14 @@ impl TraversalJsonExtensions for serde_json::Value {
     fn get_route_geometry_wkt(&self) -> Result<String, PluginError> {
         let geometry = self
             .get(TraversalJsonField::RouteOutput.as_str())
-            .ok_or(PluginError::MissingField(
-                TraversalJsonField::RouteOutput.to_string(),
-            ))?
+            .ok_or_else(|| PluginError::MissingField(TraversalJsonField::RouteOutput.to_string()))?
             .as_str()
-            .ok_or(PluginError::ParseError(
-                TraversalJsonField::RouteOutput.to_string(),
-                String::from("string"),
-            ))?
+            .ok_or_else(|| {
+                PluginError::ParseError(
+                    TraversalJsonField::RouteOutput.to_string(),
+                    String::from("string"),
+                )
+            })?
             .to_string();
         Ok(geometry)
     }

--- a/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
@@ -57,12 +57,12 @@ impl OutputPlugin for TraversalPlugin {
             Err(_) => Ok(vec![output.clone()]),
             Ok(result) => {
                 let mut output_mut = output.clone();
-                let updated = output_mut
-                    .as_object_mut()
-                    .ok_or(PluginError::InternalError(format!(
+                let updated = output_mut.as_object_mut().ok_or_else(|| {
+                    PluginError::InternalError(format!(
                         "expected output JSON to be an object, found {}",
                         output
-                    )))?;
+                    ))
+                })?;
 
                 match self.route {
                     None => {}

--- a/rust/routee-compass/src/plugin/output/default/traversal/traversal_ops.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/traversal_ops.rs
@@ -19,7 +19,7 @@ pub fn create_tree_geojson(
             let row_result = geoms
                 .get(t.edge_traversal.edge_id.0)
                 .cloned()
-                .ok_or(PluginError::EdgeGeometryMissing(t.edge_traversal.edge_id))
+                .ok_or_else(|| PluginError::EdgeGeometryMissing(t.edge_traversal.edge_id))
                 .and_then(|g| create_geojson_feature(&t.edge_traversal, g));
 
             row_result
@@ -45,7 +45,7 @@ pub fn create_route_geojson(
             let row_result = geoms
                 .get(t.edge_id.0)
                 .cloned()
-                .ok_or(PluginError::EdgeGeometryMissing(t.edge_id))
+                .ok_or_else(|| PluginError::EdgeGeometryMissing(t.edge_id))
                 .and_then(|g| create_geojson_feature(t, g));
 
             row_result
@@ -90,7 +90,7 @@ pub fn create_edge_geometry(
     geoms
         .get(edge.edge_id.0)
         .cloned()
-        .ok_or(PluginError::EdgeGeometryMissing(edge.edge_id))
+        .ok_or_else(|| PluginError::EdgeGeometryMissing(edge.edge_id))
 }
 
 pub fn create_branch_geometry(
@@ -114,7 +114,7 @@ pub fn create_route_linestring(
         .map(|eid| {
             let geom = geoms
                 .get(eid.0)
-                .ok_or(PluginError::EdgeGeometryMissing(*eid));
+                .ok_or_else(|| PluginError::EdgeGeometryMissing(*eid));
             geom
         })
         .collect::<Result<Vec<&LineString>, PluginError>>()?;
@@ -136,7 +136,7 @@ pub fn create_tree_multilinestring(
         .map(|eid| {
             let geom = geoms
                 .get(eid.0)
-                .ok_or(PluginError::EdgeGeometryMissing(*eid));
+                .ok_or_else(|| PluginError::EdgeGeometryMissing(*eid));
             geom.cloned()
         })
         .collect::<Result<Vec<LineString>, PluginError>>()?;
@@ -158,12 +158,14 @@ pub fn create_tree_multipoint(
         .map(|eid| {
             let geom = geoms
                 .get(eid.0)
-                .ok_or(PluginError::EdgeGeometryMissing(*eid))
+                .ok_or_else(|| PluginError::EdgeGeometryMissing(*eid))
                 .map(|l| {
-                    l.points().last().ok_or(PluginError::InputError(format!(
-                        "linestring is invalid for edge_id {}",
-                        eid
-                    )))
+                    l.points().last().ok_or_else(|| {
+                        PluginError::InputError(format!(
+                            "linestring is invalid for edge_id {}",
+                            eid
+                        ))
+                    })
                 });
             match geom {
                 // rough "result flatten"

--- a/rust/routee-compass/src/plugin/output/default/uuid/json_extensions.rs
+++ b/rust/routee-compass/src/plugin/output/default/uuid/json_extensions.rs
@@ -43,35 +43,37 @@ impl UUIDJsonExtensions for serde_json::Value {
     fn get_od_vertex_ids(&self) -> Result<(VertexId, VertexId), PluginError> {
         let request = self
             .get(UUIDJsonField::Request.as_str())
-            .ok_or(PluginError::MissingField(
-                UUIDJsonField::Request.to_string(),
-            ))?
+            .ok_or_else(|| PluginError::MissingField(UUIDJsonField::Request.to_string()))?
             .as_object()
-            .ok_or(PluginError::ParseError(
-                UUIDJsonField::Request.to_string(),
-                String::from("json object"),
-            ))?;
+            .ok_or_else(|| {
+                PluginError::ParseError(
+                    UUIDJsonField::Request.to_string(),
+                    String::from("json object"),
+                )
+            })?;
 
         let origin_vertex_id = request
             .get(&UUIDJsonField::OriginVertexId.to_string())
-            .ok_or(PluginError::MissingField(
-                UUIDJsonField::OriginVertexId.to_string(),
-            ))?
+            .ok_or_else(|| PluginError::MissingField(UUIDJsonField::OriginVertexId.to_string()))?
             .as_u64()
-            .ok_or(PluginError::ParseError(
-                UUIDJsonField::OriginVertexId.to_string(),
-                String::from("u64"),
-            ))?;
+            .ok_or_else(|| {
+                PluginError::ParseError(
+                    UUIDJsonField::OriginVertexId.to_string(),
+                    String::from("u64"),
+                )
+            })?;
         let destination_vertex_id = request
             .get(&UUIDJsonField::DestinationVertexId.to_string())
-            .ok_or(PluginError::MissingField(
-                UUIDJsonField::DestinationVertexId.to_string(),
-            ))?
+            .ok_or_else(|| {
+                PluginError::MissingField(UUIDJsonField::DestinationVertexId.to_string())
+            })?
             .as_u64()
-            .ok_or(PluginError::ParseError(
-                UUIDJsonField::DestinationVertexId.to_string(),
-                String::from("u64"),
-            ))?;
+            .ok_or_else(|| {
+                PluginError::ParseError(
+                    UUIDJsonField::DestinationVertexId.to_string(),
+                    String::from("u64"),
+                )
+            })?;
         Ok((
             VertexId(origin_vertex_id as usize),
             VertexId(destination_vertex_id as usize),
@@ -84,14 +86,14 @@ impl UUIDJsonExtensions for serde_json::Value {
     ) -> Result<(), PluginError> {
         let request = self
             .get_mut(UUIDJsonField::Request.as_str())
-            .ok_or(PluginError::MissingField(
-                UUIDJsonField::Request.to_string(),
-            ))?
+            .ok_or_else(|| PluginError::MissingField(UUIDJsonField::Request.to_string()))?
             .as_object_mut()
-            .ok_or(PluginError::ParseError(
-                UUIDJsonField::Request.to_string(),
-                String::from("json object"),
-            ))?;
+            .ok_or_else(|| {
+                PluginError::ParseError(
+                    UUIDJsonField::Request.to_string(),
+                    String::from("json object"),
+                )
+            })?;
 
         request.insert(
             UUIDJsonField::OriginVertexUUID.to_string(),

--- a/rust/routee-compass/src/plugin/output/default/uuid/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/uuid/plugin.rs
@@ -48,11 +48,11 @@ impl OutputPlugin for UUIDOutputPlugin {
         let origin_uuid = self
             .uuids
             .get(origin_vertex_id.0)
-            .ok_or(PluginError::UUIDMissing(origin_vertex_id.0))?;
+            .ok_or_else(|| PluginError::UUIDMissing(origin_vertex_id.0))?;
         let destination_uuid = self
             .uuids
             .get(destination_vertex_id.0)
-            .ok_or(PluginError::UUIDMissing(destination_vertex_id.0))?;
+            .ok_or_else(|| PluginError::UUIDMissing(destination_vertex_id.0))?;
 
         updated_output.add_od_uuids(origin_uuid.clone(), destination_uuid.clone())?;
 


### PR DESCRIPTION
Adds a new `InterpolationSpeedGradeModel` that operates by:
 - loading in an existing routee powertrain model 
 - exercising the model over a structured grid of model inputs
 - at predict time, perform a bilinear interpolation to get model outputs

I tested this approach over the training and test set for the data that were used to train the existing random forest models and only observed a link RMSE bump of around 0.00001 relative to the pure random forest model.

The benefit of this model is that it decreases the runtime cost of predicting energy on a link. When testing this over a few Denver metro scenarios (with the addition of some other small performance updates like using `.ok_or_else` instead of `ok_or` to delay string formatting until an error occurs), I'm seeing runtimes improve close to 10x.  