### PR TITLE
Version 0.6.1

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -47,7 +47,7 @@ name = "2012_Ford_Focus"
 type = "single_fuel"
 # the file for the routee-powertrain model
 model_input_file = "models/2012_Ford_Focus.bin"
-# what underlying machine learn framework to use [smartcore | interpolate]
+# what underlying machine learn framework to use [smartcore | interpolate | onnx]
 model_type = "smartcore"
 # the units of what the routee-powertrain model expects speed to be in
 speed_unit = "miles_per_hour"
@@ -158,7 +158,7 @@ name = "2012_Ford_Focus"
 type = "single_fuel"
 # the file for the routee-powertrain model
 model_input_file = "models/2012_Ford_Focus.bin"
-# what underlying machine learn framework to use [smartcore | interpolate]
+# what underlying machine learn framework to use [smartcore | interpolate | onnx]
 model_type = "smartcore"
 # the units of what the routee-powertrain model expects speed to be in
 speed_unit = "miles_per_hour"

--- a/docs/config.md
+++ b/docs/config.md
@@ -47,7 +47,7 @@ name = "2012_Ford_Focus"
 type = "single_fuel"
 # the file for the routee-powertrain model
 model_input_file = "models/2012_Ford_Focus.bin"
-# what underlying machine learn framework to use [smartcore | onnx]
+# what underlying machine learn framework to use [smartcore | interpolate]
 model_type = "smartcore"
 # the units of what the routee-powertrain model expects speed to be in
 speed_unit = "miles_per_hour"
@@ -158,7 +158,7 @@ name = "2012_Ford_Focus"
 type = "single_fuel"
 # the file for the routee-powertrain model
 model_input_file = "models/2012_Ford_Focus.bin"
-# what underlying machine learn framework to use [smartcore | onnx]
+# what underlying machine learn framework to use [smartcore | interpolate]
 model_type = "smartcore"
 # the units of what the routee-powertrain model expects speed to be in
 speed_unit = "miles_per_hour"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nrel.routee.compass"
-version = "0.6.0"
+version = "0.6.1"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"
 documentation = "nrel.github.io/routee-compass"

--- a/rust/routee-compass-core/Cargo.toml
+++ b/rust/routee-compass-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 exclude = ["test/"]
 readme = "README.md"

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-powertrain"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/routee-compass"
 
 
 [dependencies]
-routee-compass-core = { path = "../routee-compass-core", version = "0.6.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.6.1" }
 smartcore = { version = "0.3.1", features = ["serde"] }                      # random forest
 thiserror = { workspace = true }
 log = { workspace = true }
@@ -27,5 +27,5 @@ ort = { version = "2.0.0-alpha.4", optional = true }
 rayon = { workspace = true }
 
 [features]
-default = ["onnx"]
+default = []
 onnx = ["ort"]

--- a/rust/routee-compass-powertrain/README.md
+++ b/rust/routee-compass-powertrain/README.md
@@ -12,7 +12,7 @@ To install as a library in Rust, add routee-compass-powertrain to your Cargo.tom
 
 ```toml
 [dependencies]
-routee-compass-powertrain = { version = "0.6.0" }
+routee-compass-powertrain = { version = "0.6.1" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass-powertrain/latest/routee_compass_powertrain/) for usage.

--- a/rust/routee-compass-py/Cargo.toml
+++ b/rust/routee-compass-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-py"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -10,8 +10,8 @@ repository = "https://github.com/NREL/routee-compass"
 documentation = "https://docs.rs/routee-compass"
 
 [dependencies]
-routee-compass = { path = "../routee-compass", version = "0.6.0" }
-routee-compass-core = { path = "../routee-compass-core", version = "0.6.0" }
+routee-compass = { path = "../routee-compass", version = "0.6.1" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.6.1" }
 pyo3 = { version = "0.20.0", features = ["extension-module"] }
 serde_json = { workspace = true }
 config = { workspace = true }

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -18,8 +18,8 @@ keywords = [
 categories = ["science", "science::geo"]
 
 [dependencies]
-routee-compass-core = { path = "../routee-compass-core", version = "0.6.0" }
-routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.6.0", features=["onnx"]}
+routee-compass-core = { path = "../routee-compass-core", version = "0.6.1" }
+routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.6.1"}
 thiserror = { workspace = true }
 flate2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
After running into [yet another set of build errors](https://github.com/conda-forge/nrel.routee.compass-feedstock/pull/7/checks?check_run_id=20433194404) with the onnx runtime, I'm proposing that we omit it from our default build for the time being since we're not actually using it. We can come back to this and re-visit if we decide that it's valuable to have. 