### PR TITLE
Ndr/rtree mem fix

### DIFF
--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
@@ -9,7 +9,7 @@ use crate::{
         plugin_error::PluginError,
     },
 };
-use geo_types::{Coord, LineString};
+use geo_types::Coord;
 use routee_compass_core::{
     model::road_network::edge_id::EdgeId,
     model::unit::{as_f64::AsF64, Distance, DistanceUnit, BASE_DISTANCE_UNIT},
@@ -68,8 +68,7 @@ impl EdgeRtreeInputPlugin {
         distance_unit: Option<DistanceUnit>,
     ) -> Result<Self, CompassConfigurationError> {
         let road_class_lookup: Vec<String> =
-            read_utils::read_raw_file(road_class_file, read_decoders::string, None)?
-            .into_vec();
+            read_utils::read_raw_file(road_class_file, read_decoders::string, None)?.into_vec();
         let geometries = read_linestring_text_file(linestring_file)
             .map_err(CompassConfigurationError::IoError)?
             .into_vec();
@@ -84,14 +83,11 @@ impl EdgeRtreeInputPlugin {
             return Err(CompassConfigurationError::UserConfigurationError(msg));
         }
 
-
         let records: Vec<EdgeRtreeRecord> = geometries
             .into_iter()
             .enumerate()
             .zip(road_class_lookup)
-            .map(|((idx, geom), rc)| {
-                EdgeRtreeRecord::new(EdgeId(idx), geom, rc)
-            })
+            .map(|((idx, geom), rc)| EdgeRtreeRecord::new(EdgeId(idx), geom, rc))
             .collect();
 
         let rtree = RTree::bulk_load(records);


### PR DESCRIPTION
When running some simple performance tests I noticed that the app was failing when loading the edge rtree plugin. This is just a simple fix to not clone the geometry and road class strings when building the plugin but rather pass ownership directly to the rtree.