### PR TITLE
Ndr/cost model performance

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -465,8 +465,7 @@ mod tests {
                     )])),
                     Arc::new(HashMap::new()),
                     CostAggregation::Sum,
-                )
-                .unwrap();
+                )?;
                 let fm_inner = Arc::new(NoRestriction {});
                 let rm_inner = Arc::new(driver_rm.read_only());
                 run_a_star(o, Some(d), dg_inner, dist_tm, dist_um, fm_inner, rm_inner)

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -465,7 +465,8 @@ mod tests {
                     )])),
                     Arc::new(HashMap::new()),
                     CostAggregation::Sum,
-                );
+                )
+                .unwrap();
                 let fm_inner = Arc::new(NoRestriction {});
                 let rm_inner = Arc::new(driver_rm.read_only());
                 run_a_star(o, Some(d), dg_inner, dist_tm, dist_um, fm_inner, rm_inner)

--- a/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
@@ -1,6 +1,8 @@
 use crate::model::unit::{as_f64::AsF64, Cost};
 use serde::{Deserialize, Serialize};
 
+use super::cost_error::CostError;
+
 #[derive(Deserialize, Serialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum CostAggregation {
@@ -20,6 +22,35 @@ impl CostAggregation {
                         Cost::new(acc.as_f64() * c.as_f64())
                     })
                 }
+            }
+        }
+    }
+
+    pub fn agg_iter<'a>(
+        &self,
+        costs: impl Iterator<Item = Result<(&'a String, Cost), CostError>>,
+    ) -> Result<Cost, CostError> {
+        match self {
+            CostAggregation::Sum => {
+                let mut sum = Cost::ZERO;
+                for cost in costs {
+                    let (_, cost) = cost?;
+                    sum = sum + cost;
+                }
+                Ok(sum)
+            }
+            CostAggregation::Mul => {
+                // test if the iterator is empty
+                let mut costs = costs.peekable();
+                if costs.peek().is_none() {
+                    return Ok(Cost::ZERO);
+                }
+                let mut product = Cost::ONE;
+                for cost in costs {
+                    let (_, cost) = cost?;
+                    product = Cost::new(product.as_f64() * cost.as_f64());
+                }
+                Ok(product)
             }
         }
     }

--- a/rust/routee-compass-core/src/model/cost/cost_error.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_error.rs
@@ -9,4 +9,6 @@ pub enum CostError {
     StateVariableNotFound(String),
     #[error("index {0} for state variable {1} out of bounds, not found in traversal state")]
     StateIndexOutOfBounds(usize, String),
+    #[error("invalid cost variables, sum of state variable coefficients must be non-zero")]
+    InvalidCostVariables,
 }

--- a/rust/routee-compass-core/src/model/cost/cost_model.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_model.rs
@@ -51,6 +51,9 @@ impl CostModel {
                 .unwrap_or_default();
             network_state_variable_rates[*idx] = rate.clone();
         }
+        if state_variable_coefficients.iter().sum::<f64>() == 0.0 {
+            return Err(CostError::InvalidCostVariables);
+        }
         Ok(CostModel {
             state_variable_indices,
             state_variable_coefficients,

--- a/rust/routee-compass-core/src/model/cost/cost_ops.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_ops.rs
@@ -1,52 +1,49 @@
 use super::{
+    cost_aggregation::CostAggregation, cost_error::CostError,
     network::network_cost_rate::NetworkCostRate, vehicle::vehicle_cost_rate::VehicleCostRate,
 };
-use crate::model::{
-    cost::cost_error::CostError, property::edge::Edge, traversal::state::state_variable::StateVar,
-    unit::Cost,
-};
-use std::{collections::HashMap, sync::Arc};
+use crate::model::{property::edge::Edge, traversal::state::state_variable::StateVar, unit::Cost};
 
-pub fn calculate_vehicle_costs<'a>(
-    prev_state: &'a [StateVar],
-    next_state: &'a [StateVar],
-    state_variable_indices: &'a [(String, usize)],
-    state_variable_coefficients: Arc<HashMap<String, f64>>,
-    rates: Arc<HashMap<String, VehicleCostRate>>,
-) -> Result<Vec<(&'a String, Cost)>, CostError> {
-    let costs = state_variable_indices
-        .iter()
-        .map(|(name, idx)| {
-            let prev_state_var = prev_state
-                .get(*idx)
-                .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
-            let next_state_var = next_state
-                .get(*idx)
-                .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
-            let delta: StateVar = *next_state_var - *prev_state_var;
-            let mapping = rates
-                .get(name)
-                .ok_or_else(|| CostError::StateVariableNotFound(name.clone()))?;
-            let coefficient = state_variable_coefficients.get(name).unwrap_or(&1.0);
-            let delta_cost = mapping.map_value(delta);
-            let cost = delta_cost * coefficient;
-            Ok((name, cost))
-        })
-        .collect::<Result<Vec<_>, CostError>>()?;
-    Ok(costs)
+pub fn calculate_vehicle_costs(
+    prev_state: &[StateVar],
+    next_state: &[StateVar],
+    state_variable_indices: &[(String, usize)],
+    state_variable_coefficients: &[f64],
+    rates: &[VehicleCostRate],
+    cost_aggregation: &CostAggregation,
+) -> Result<Cost, CostError> {
+    let costs = state_variable_indices.iter().map(|(name, idx)| {
+        let prev_state_var = prev_state
+            .get(*idx)
+            .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+        let next_state_var = next_state
+            .get(*idx)
+            .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
+        let delta: StateVar = *next_state_var - *prev_state_var;
+        let mapping = rates
+            .get(*idx)
+            .ok_or_else(|| CostError::StateVariableNotFound(name.clone()))?;
+        let coefficient = state_variable_coefficients.get(*idx).unwrap_or(&1.0);
+        let delta_cost = mapping.map_value(delta);
+        let cost = delta_cost * coefficient;
+        Ok((name, cost))
+    });
+    let cost = cost_aggregation.agg_iter(costs);
+    cost
 }
 
-pub fn calculate_network_traversal_costs<'a>(
-    prev_state: &'a [StateVar],
-    next_state: &'a [StateVar],
-    edge: &'a Edge,
-    state_variable_indices: &'a [(String, usize)],
-    state_variable_coefficients: Arc<HashMap<String, f64>>,
-    rates: Arc<HashMap<String, NetworkCostRate>>,
-) -> Result<Vec<(&'a String, Cost)>, CostError> {
+pub fn calculate_network_traversal_costs(
+    prev_state: &[StateVar],
+    next_state: &[StateVar],
+    edge: &Edge,
+    state_variable_indices: &[(String, usize)],
+    state_variable_coefficients: &[f64],
+    rates: &[NetworkCostRate],
+    cost_aggregation: &CostAggregation,
+) -> Result<Cost, CostError> {
     let costs = state_variable_indices
         .iter()
-        .map(|(name, idx)| match rates.get(name) {
+        .map(|(name, idx)| match rates.get(*idx) {
             None => Ok((name, Cost::ZERO)),
             Some(m) => {
                 let prev_state_var = prev_state
@@ -55,28 +52,29 @@ pub fn calculate_network_traversal_costs<'a>(
                 let next_state_var = next_state
                     .get(*idx)
                     .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
-                let coefficient = state_variable_coefficients.get(name).unwrap_or(&1.0);
+                let coefficient = state_variable_coefficients.get(*idx).unwrap_or(&1.0);
                 let traversal_cost = m.traversal_cost(*prev_state_var, *next_state_var, edge)?;
                 let cost = traversal_cost * coefficient;
                 Ok((name, cost))
             }
-        })
-        .collect::<Result<Vec<_>, CostError>>()?;
-    Ok(costs)
+        });
+    let cost = cost_aggregation.agg_iter(costs);
+    cost
 }
 
-pub fn calculate_network_access_costs<'a>(
-    prev_state: &'a [StateVar],
-    next_state: &'a [StateVar],
-    prev_edge: &'a Edge,
-    next_edge: &'a Edge,
-    state_variable_indices: &'a [(String, usize)],
-    state_variable_coefficients: Arc<HashMap<String, f64>>,
-    rates: Arc<HashMap<String, NetworkCostRate>>,
-) -> Result<Vec<(&'a String, Cost)>, CostError> {
+pub fn calculate_network_access_costs(
+    prev_state: &[StateVar],
+    next_state: &[StateVar],
+    prev_edge: &Edge,
+    next_edge: &Edge,
+    state_variable_indices: &[(String, usize)],
+    state_variable_coefficients: &[f64],
+    rates: &[NetworkCostRate],
+    cost_aggregation: &CostAggregation,
+) -> Result<Cost, CostError> {
     let costs = state_variable_indices
         .iter()
-        .map(|(name, idx)| match rates.get(name) {
+        .map(|(name, idx)| match rates.get(*idx) {
             None => Ok((name, Cost::ZERO)),
             Some(m) => {
                 let prev_state_var = prev_state
@@ -87,11 +85,11 @@ pub fn calculate_network_access_costs<'a>(
                     .ok_or_else(|| CostError::StateIndexOutOfBounds(*idx, name.clone()))?;
                 let access_cost =
                     m.access_cost(*prev_state_var, *next_state_var, prev_edge, next_edge)?;
-                let coefficient = state_variable_coefficients.get(name).unwrap_or(&1.0);
+                let coefficient = state_variable_coefficients.get(*idx).unwrap_or(&1.0);
                 let cost = access_cost * coefficient;
                 Ok((name, cost))
             }
-        })
-        .collect::<Result<Vec<_>, CostError>>()?;
-    Ok(costs)
+        });
+    let cost = cost_aggregation.agg_iter(costs);
+    cost
 }

--- a/rust/routee-compass-core/src/model/cost/cost_ops.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_ops.rs
@@ -28,8 +28,8 @@ pub fn calculate_vehicle_costs(
         let cost = delta_cost * coefficient;
         Ok((name, cost))
     });
-    let cost = cost_aggregation.agg_iter(costs);
-    cost
+
+    cost_aggregation.agg_iter(costs)
 }
 
 pub fn calculate_network_traversal_costs(
@@ -58,8 +58,8 @@ pub fn calculate_network_traversal_costs(
                 Ok((name, cost))
             }
         });
-    let cost = cost_aggregation.agg_iter(costs);
-    cost
+
+    cost_aggregation.agg_iter(costs)
 }
 
 pub fn calculate_network_access_costs(
@@ -90,6 +90,6 @@ pub fn calculate_network_access_costs(
                 Ok((name, cost))
             }
         });
-    let cost = cost_aggregation.agg_iter(costs);
-    cost
+
+    cost_aggregation.agg_iter(costs)
 }

--- a/rust/routee-compass-core/src/model/cost/network/network_cost_rate.rs
+++ b/rust/routee-compass-core/src/model/cost/network/network_cost_rate.rs
@@ -10,9 +10,11 @@ use std::collections::HashMap;
 ///
 /// when multiple mappings are specified they are applied sequentially (in user-defined order)
 /// to the state value.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum NetworkCostRate {
+    #[default]
+    Zero,
     EdgeLookup {
         lookup: HashMap<EdgeId, Cost>,
     },
@@ -30,6 +32,7 @@ impl NetworkCostRate {
         edge: &Edge,
     ) -> Result<Cost, CostError> {
         match self {
+            NetworkCostRate::Zero => Ok(Cost::ZERO),
             NetworkCostRate::EdgeEdgeLookup { lookup: _ } => Ok(Cost::ZERO),
             NetworkCostRate::EdgeLookup { lookup } => {
                 let cost = lookup.get(&edge.edge_id).unwrap_or(&Cost::ZERO).to_owned();
@@ -68,6 +71,7 @@ impl NetworkCostRate {
         next_edge: &Edge,
     ) -> Result<Cost, CostError> {
         match self {
+            NetworkCostRate::Zero => Ok(Cost::ZERO),
             NetworkCostRate::EdgeLookup { lookup: _ } => Ok(Cost::ZERO),
             NetworkCostRate::EdgeEdgeLookup { lookup } => {
                 let result = lookup

--- a/rust/routee-compass-core/src/model/cost/vehicle/vehicle_cost_rate.rs
+++ b/rust/routee-compass-core/src/model/cost/vehicle/vehicle_cost_rate.rs
@@ -5,10 +5,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// when multiple mappings are specified they are applied sequentially (in user-defined order)
 /// to the state value.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum VehicleCostRate {
     /// use a value directly as a cost
+    #[default]
     Raw,
     /// multiply a value by a factor to become a cost
     Factor {

--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
@@ -153,7 +153,13 @@ impl CostModelService {
             vehicle_rates,
             self.network_state_variable_rates.clone(),
             cost_aggregation,
-        );
+        )
+        .map_err(|e| {
+            CompassConfigurationError::UserConfigurationError(format!(
+                "failed to build cost model: {}",
+                e
+            ))
+        })?;
 
         Ok(model)
     }


### PR DESCRIPTION
Applies some minor modifications to the cost model to use iterators instead of allocating a vector for the cost model aggregation.

Also flattens the state variable coefficients, vehicle rates and network rates into a fixed size vector for index based lookup.