### PR TITLE
Rjf/cost model invariants

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_distance.toml
+++ b/python/nrel/routee/compass/resources/osm_default_distance.toml
@@ -14,6 +14,8 @@ distance_unit = "miles"
 [cost.vehicle_state_variable_rates.distance]
 type = "factor"
 factor = 0.655
+[cost.state_variable_coefficients]
+distance = 1
 
 [plugin]
 input_plugins = [

--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -37,6 +37,12 @@ factor = 3.120
 type = "factor"
 factor = 0.50
 
+[cost.state_variable_coefficients]
+distance = 1
+time = 1
+energy_liquid = 1
+energy_electric = 1
+
 [traversal]
 type = "energy_model"
 speed_table_input_file = "edges-posted-speed-enumerated.txt.gz"

--- a/python/nrel/routee/compass/resources/osm_default_speed.toml
+++ b/python/nrel/routee/compass/resources/osm_default_speed.toml
@@ -23,6 +23,10 @@ factor = 0.655
 type = "factor"
 factor = 0.333336
 
+[cost.state_variable_coefficients]
+distance = 1
+time = 1
+
 [plugin]
 input_plugins = [
     { type = "vertex_rtree", distance_tolerance = 0.2, distance_unit = "kilometers", vertices_input_file = "vertices-compass.csv.gz" },

--- a/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use super::cost_error::CostError;
 
-#[derive(Deserialize, Serialize, Clone, Copy)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum CostAggregation {
     Sum,

--- a/rust/routee-compass-core/src/model/cost/cost_error.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_error.rs
@@ -5,8 +5,10 @@ pub enum CostError {
         #[from]
         source: csv::Error,
     },
-    #[error("expected state variable name {0} not found in cost rate table")]
-    StateVariableNotFound(String),
+    #[error("invalid cost model configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error("expected state variable name {0} not found in {1} table")]
+    StateVariableNotFound(String, String),
     #[error("index {0} for state variable {1} out of bounds, not found in traversal state")]
     StateIndexOutOfBounds(usize, String),
     #[error("invalid cost variables, sum of state variable coefficients must be non-zero")]

--- a/rust/routee-compass-core/src/model/cost/network/network_cost_rate.rs
+++ b/rust/routee-compass-core/src/model/cost/network/network_cost_rate.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 ///
 /// when multiple mappings are specified they are applied sequentially (in user-defined order)
 /// to the state value.
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum NetworkCostRate {
     #[default]

--- a/rust/routee-compass-core/src/model/cost/vehicle/vehicle_cost_rate.rs
+++ b/rust/routee-compass-core/src/model/cost/vehicle/vehicle_cost_rate.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// when multiple mappings are specified they are applied sequentially (in user-defined order)
 /// to the state value.
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum VehicleCostRate {
     /// use a value directly as a cost

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -537,29 +537,7 @@ pub fn apply_output_processing(
                 "error": e.to_string()
             })]
         }
-        Ok(json) => {
-            json
-            // let output_plugin_runtime = chrono::Local::now() - start_time;
-            // let output_plugin_runtime_str = output_plugin_runtime
-            //     .to_std()
-            //     .unwrap_or(time::Duration::ZERO)
-            //     .hhmmss();
-            // json.iter()
-            //     .map(|j| {
-            //         let mut mj = j.clone();
-            //         match mj.as_object_mut().ok_or(PluginError::JsonError) {
-            //             Ok(map) => {
-            //                 map.insert(
-            //                     String::from("output_plugin_runtime"),
-            //                     serde_json::json!(output_plugin_runtime_str),
-            //                 );
-            //                 serde_json::json!(map)
-            //             }
-            //             Err(_) => j.clone(),
-            //         }
-            //     })
-            //     .collect::<Vec<_>>()
-        }
+        Ok(json) => json,
     }
 }
 

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -10,9 +10,7 @@ use crate::{
             config::{
                 compass_configuration_field::CompassConfigurationField,
                 config_json_extension::ConfigJsonExtensions,
-                cost_model::{
-                    cost_model_builder::CostModelBuilder,
-                },
+                cost_model::cost_model_builder::CostModelBuilder,
                 graph_builder::DefaultGraphBuilder,
                 termination_model_builder::TerminationModelBuilder,
             },

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -11,7 +11,7 @@ use crate::{
                 compass_configuration_field::CompassConfigurationField,
                 config_json_extension::ConfigJsonExtensions,
                 cost_model::{
-                    cost_model_builder::CostModelBuilder, cost_model_service::CostModelService,
+                    cost_model_builder::CostModelBuilder,
                 },
                 graph_builder::DefaultGraphBuilder,
                 termination_model_builder::TerminationModelBuilder,

--- a/rust/routee-compass/src/app/compass/config.default.toml
+++ b/rust/routee-compass/src/app/compass/config.default.toml
@@ -13,22 +13,10 @@ distance_unit = "kilometers"
 
 [cost]
 cost_aggregation = "sum"
-
-[cost.state_variable_coefficients]
-distance = 1
-time = 1
-energy = 1
-energy_liquid = 1
-energy_electric = 1
-
-[cost.vehicle_state_variable_rates.distance]
-type = "raw"
-[cost.vehicle_state_variable_rates.time]
-type = "raw"
-[cost.vehicle_state_variable_rates.energy_liquid]
-type = "raw"
-[cost.vehicle_state_variable_rates.energy_electric]
-type = "raw"
+network_state_variable_rates = {}
+# cost.state_variable_coefficients = { distance = 1 }
+# [cost.vehicle_state_variable_rates.distance]
+# type = "raw"
 
 [frontier]
 type = "no_restriction"

--- a/rust/routee-compass/src/app/compass/config.default.toml
+++ b/rust/routee-compass/src/app/compass/config.default.toml
@@ -14,9 +14,6 @@ distance_unit = "kilometers"
 [cost]
 cost_aggregation = "sum"
 network_state_variable_rates = {}
-# cost.state_variable_coefficients = { distance = 1 }
-# [cost.vehicle_state_variable_rates.distance]
-# type = "raw"
 
 [frontier]
 type = "no_restriction"

--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
@@ -8,7 +8,7 @@ use routee_compass_core::model::cost::{
     cost_aggregation::CostAggregation, network::network_cost_rate::NetworkCostRate,
     vehicle::vehicle_cost_rate::VehicleCostRate,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 pub struct CostModelBuilder {}
 
@@ -18,22 +18,22 @@ impl CostModelBuilder {
         config: &serde_json::Value,
     ) -> Result<CostModelService, CompassConfigurationError> {
         let parent_key = CompassConfigurationField::Cost.to_string();
-        let vehicle_state_variable_rates: Option<HashMap<String, VehicleCostRate>> =
-            config.get_config_serde_optional(&"vehicle_state_variable_rates", &parent_key)?;
-        let network_state_variable_rates: Option<HashMap<String, NetworkCostRate>> =
-            config.get_config_serde_optional(&"network_state_variable_rates", &parent_key)?;
+        let vehicle_rates: HashMap<String, VehicleCostRate> =
+            config.get_config_serde(&"vehicle_state_variable_rates", &parent_key)?;
+        let network_rates: HashMap<String, NetworkCostRate> =
+            config.get_config_serde(&"network_state_variable_rates", &parent_key)?;
 
-        let default_state_variable_coefficients: Option<HashMap<String, f64>> =
-            config.get_config_serde_optional(&"state_variable_coefficients", &parent_key)?;
-        let default_cost_aggregation: Option<CostAggregation> =
-            config.get_config_serde_optional(&"cost_aggregation", &parent_key)?;
+        let coefficients: HashMap<String, f64> =
+            config.get_config_serde(&"state_variable_coefficients", &parent_key)?;
+        let cost_aggregation: CostAggregation =
+            config.get_config_serde(&"cost_aggregation", &parent_key)?;
 
-        let model = CostModelService::new(
-            vehicle_state_variable_rates,
-            network_state_variable_rates,
-            default_state_variable_coefficients,
-            default_cost_aggregation,
-        )?;
+        let model = CostModelService {
+            vehicle_state_variable_rates: Arc::new(vehicle_rates),
+            network_state_variable_rates: Arc::new(network_rates),
+            state_variable_coefficients: Arc::new(coefficients),
+            cost_aggregation,
+        };
         Ok(model)
     }
 }

--- a/rust/routee-compass/src/app/compass/test/speeds_test/speeds_debug.toml
+++ b/rust/routee-compass/src/app/compass/test/speeds_test/speeds_debug.toml
@@ -22,6 +22,8 @@ distance = 0
 time = 1
 [cost.vehicle_state_variable_rates.time]
 type = "raw"
+[cost.vehicle_state_variable_rates.distance]
+type = "raw"
 
 [plugin]
 input_plugins = []

--- a/rust/routee-compass/src/app/compass/test/speeds_test/speeds_test.toml
+++ b/rust/routee-compass/src/app/compass/test/speeds_test/speeds_test.toml
@@ -22,6 +22,8 @@ distance = 0
 time = 1
 [cost.vehicle_state_variable_rates.time]
 type = "raw"
+[cost.vehicle_state_variable_rates.distance]
+type = "raw"
 
 [plugin]
 input_plugins = []

--- a/rust/routee-compass/src/app/search/search_app.rs
+++ b/rust/routee-compass/src/app/search/search_app.rs
@@ -123,10 +123,10 @@ impl SearchApp {
                 Ok(SearchAppResult {
                     route,
                     tree,
-                    search_start_time: search_start_time.to_rfc3339(),
-                    search_runtime,
+                    search_executed_time: search_start_time.to_rfc3339(),
+                    algorithm_runtime: search_runtime,
                     route_runtime,
-                    total_runtime: search_runtime + route_runtime,
+                    search_app_runtime: search_runtime + route_runtime,
                 })
             })
             .map_err(CompassAppError::SearchError)
@@ -201,10 +201,10 @@ impl SearchApp {
                 Ok(SearchAppResult {
                     route,
                     tree,
-                    search_start_time: search_start_time.to_rfc3339(),
-                    search_runtime,
+                    search_executed_time: search_start_time.to_rfc3339(),
+                    algorithm_runtime: search_runtime,
                     route_runtime,
-                    total_runtime: search_runtime + route_runtime,
+                    search_app_runtime: search_runtime + route_runtime,
                 })
             })
             .map_err(CompassAppError::SearchError)

--- a/rust/routee-compass/src/app/search/search_app_result.rs
+++ b/rust/routee-compass/src/app/search/search_app_result.rs
@@ -9,8 +9,8 @@ use std::{collections::HashMap, time::Duration};
 pub struct SearchAppResult {
     pub route: Vec<EdgeTraversal>,
     pub tree: HashMap<VertexId, SearchTreeBranch>,
-    pub search_start_time: String,
-    pub search_runtime: Duration,
+    pub search_executed_time: String,
+    pub algorithm_runtime: Duration,
     pub route_runtime: Duration,
-    pub total_runtime: Duration,
+    pub search_app_runtime: Duration,
 }

--- a/rust/routee-compass/src/plugin/output/default/summary/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/summary/plugin.rs
@@ -30,17 +30,17 @@ impl OutputPlugin for SummaryOutputPlugin {
 
                 updated.insert(
                     "search_executed_time".to_string(),
-                    result.search_start_time.clone().into(),
+                    result.search_executed_time.clone().into(),
                 );
 
                 updated.insert(
-                    "search_runtime".to_string(),
-                    result.search_runtime.hhmmss().into(),
+                    "algorithm_runtime".to_string(),
+                    result.algorithm_runtime.hhmmss().into(),
                 );
 
                 updated.insert(
-                    "total_runtime".to_string(),
-                    result.total_runtime.hhmmss().into(),
+                    "search_app_runtime".to_string(),
+                    result.search_app_runtime.hhmmss().into(),
                 );
 
                 updated.insert("route_edge_count".to_string(), result.route.len().into());

--- a/rust/routee-compass/src/plugin/output/default/to_disk/builder.rs
+++ b/rust/routee-compass/src/plugin/output/default/to_disk/builder.rs
@@ -29,7 +29,6 @@ impl OutputPluginBuilder for ToDiskOutputPluginBuilder {
 
         // open the file with the option to append to it
         let file = OpenOptions::new()
-            .write(true)
             .append(true)
             .open(&output_file_path)
             .map_err(|e| {

--- a/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
@@ -147,10 +147,10 @@ mod tests {
         let search_result = SearchAppResult {
             route,
             tree: HashMap::new(),
-            search_start_time: Local::now().to_rfc3339(),
-            search_runtime: Duration::ZERO,
+            search_executed_time: Local::now().to_rfc3339(),
+            algorithm_runtime: Duration::ZERO,
             route_runtime: Duration::ZERO,
-            total_runtime: Duration::ZERO,
+            search_app_runtime: Duration::ZERO,
         };
         let filename = mock_geometry_file();
         let _route_geometry = true;

--- a/rust/routee-compass/src/plugin/output/default/traversal/traversal_output_format.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/traversal_output_format.rs
@@ -108,10 +108,10 @@ mod test {
         let result = SearchAppResult {
             route,
             tree: HashMap::new(),
-            search_start_time: Local::now().to_rfc3339(),
-            search_runtime: Duration::ZERO,
+            search_executed_time: Local::now().to_rfc3339(),
+            algorithm_runtime: Duration::ZERO,
             route_runtime: Duration::ZERO,
-            total_runtime: Duration::ZERO,
+            search_app_runtime: Duration::ZERO,
         };
 
         let geoms = vec![


### PR DESCRIPTION
this PR fixes some logic errors in the cost model.

##### state indices vs cost model indices

we're looking a lot of stuff by index now which gets ambiguous in the cost model because there are _two kinds of indices_ at play there. the thing i'm calling a _state index_ is the index of a particular state variable in a state vector. the other, maybe worth calling a _model index_ is a position in one of the vectors stored on the CostModel instance, such as the vehicle rate parameter vector. it turns out these were mixed up.

##### empty defaults

i got confused a bunch by unexpected behavior surrounding cost model defaults. i basically ripped out any defaults to make the user more responsible for properly set the cost model values and so they won't waste an hour looking around in the repo for an explanation of why certain things were happening. i _think_ this doesn't mess with any of our capabilities we wanted.

##### reporting runtimes

i made some changes to the runtime reporting. i wanted to focus on output processing, and so now there's a runtime for creating the tree and route outputs. i wanted also to have one for the output plugin processing, but i stopped short of it since the to_disk plugin dumps an output row before we get to the outer scope of running the output plugins. future work to set that up.

Closes #119.