### PR TITLE
Rjf/output json mutable

### DIFF
--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -31,14 +31,13 @@ class CompassApp:
 
     @classmethod
     def from_config_file(
-        cls, config_file: Union[str, Path], output_file: Optional[str] = None
+        cls, config_file: Union[str, Path]  # , output_file: Optional[str] = None
     ) -> CompassApp:
         """
         Build a CompassApp from a config file
 
         Args:
             config_file (Union[str, Path]): Path to the config file
-            output_file (Optional[str]): Path to the output file. This overrides whatever is in the config file
 
         Returns:
             CompassApp: A CompassApp object
@@ -53,19 +52,31 @@ class CompassApp:
         with open(config_path) as f:
             toml_config = toml.load(f)
 
-        # inject the output file override into the to_disk plugin config
-        if output_file is not None:
-            toml_config = inject_to_disk_plugin(output_file, toml_config)
+        return CompassApp.from_dict(toml_config, config_path)
 
-        toml_string = toml.dumps(toml_config)
-        config_path_string = str(config_path.absolute())
+    @classmethod
+    def from_dict(cls, config: Dict, working_dir: Optional[Path] = None) -> CompassApp:
+        """
+        Build a CompassApp from a configuration object
 
-        app = CompassAppWrapper._from_config_toml_string(
-            toml_string, config_path_string
-        )
+        Args:
+            config (Dict): Configuration dictionary
+            working_dir (Path): optional path to working directory
+
+        Returns:
+            CompassApp: a CompassApp object
+
+        Example:
+            >>> from nrel.routee.compass import CompassApp
+            >>> conf = { parallelism: 2 }
+            >>> app = CompassApp.from_config(conf)
+        """
+        path_str = str(working_dir.absolute()) if working_dir is not None else ""
+        toml_string = toml.dumps(config)
+        app = CompassAppWrapper._from_config_toml_string(toml_string, path_str)
         return cls(app)
 
-    def run(self, query: Union[Query, List[Query]]) -> Result:
+    def run(self, query: Union[Query, List[Query]], config: Optional[Dict]) -> Result:
         """
         Run a query (or multiple queries) against the CompassApp
 
@@ -101,9 +112,10 @@ class CompassApp:
                 f"Query must be a dict or list of dicts, not {type(query)}"
             )
 
-        queries_json = list(map(json.dumps, queries))
+        queries_str = list(map(json.dumps, queries))
+        config_str = json.dumps(config) if config is not None else None
 
-        results_json: List[str] = self._app._run_queries(queries_json)
+        results_json: List[str] = self._app._run_queries(queries_str, config_str)
 
         results = list(map(json.loads, results_json))
         if single_query and len(results) == 1:
@@ -174,36 +186,36 @@ class CompassApp:
         return self._app.graph_get_in_edge_ids(vertex_id)
 
 
-def inject_to_disk_plugin(output_file: str, toml_config: dict) -> dict:
-    """
-    Inject or override the to_disk plugin in the config dictionary
+# def inject_to_disk_plugin(output_file: str, toml_config: dict) -> dict:
+#     """
+#     Inject or override the to_disk plugin in the config dictionary
 
-    Args:
-        output_file (str): Path to the output file
-        toml_config (dict): The existing config dictionary
+#     Args:
+#         output_file (str): Path to the output file
+#         toml_config (dict): The existing config dictionary
 
-    Returns:
-        dict: A dictionary with the to_disk plugin injected or overriden
-    """
-    plugins = toml_config.get("plugin")
-    if plugins is None:
-        # inject a whole plugin section with the to_disk output plugin
-        toml_config["plugin"] = {
-            "output_plugins": [{"type": "to_disk", "output_file": output_file}]
-        }
-    else:
-        output_plugins = plugins.get("output_plugins")
-        if output_plugins is None:
-            # inject the to_disk output plugin into the existing plugin section
-            plugins["output_plugins"] = [
-                {"type": "to_disk", "output_file": output_file}
-            ]
-        else:
-            to_disk_exists = False
-            for plugin in output_plugins:
-                if plugin.get("type") == "to_disk":
-                    to_disk_exists = True
-                    plugin["output_file"] = output_file
-            if not to_disk_exists:
-                output_plugins.append({"type": "to_disk", "output_file": output_file})
-    return toml_config
+#     Returns:
+#         dict: A dictionary with the to_disk plugin injected or overriden
+#     """
+#     plugins = toml_config.get("plugin")
+#     if plugins is None:
+#         # inject a whole plugin section with the to_disk output plugin
+#         toml_config["plugin"] = {
+#             "output_plugins": [{"type": "to_disk", "output_file": output_file}]
+#         }
+#     else:
+#         output_plugins = plugins.get("output_plugins")
+#         if output_plugins is None:
+#             # inject the to_disk output plugin into the existing plugin section
+#             plugins["output_plugins"] = [
+#                 {"type": "to_disk", "output_file": output_file}
+#             ]
+#         else:
+#             to_disk_exists = False
+#             for plugin in output_plugins:
+#                 if plugin.get("type") == "to_disk":
+#                     to_disk_exists = True
+#                     plugin["output_file"] = output_file
+#             if not to_disk_exists:
+#                 output_plugins.append({"type": "to_disk", "output_file": output_file})
+#     return toml_config

--- a/rust/routee-compass-py/Cargo.toml
+++ b/rust/routee-compass-py/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/routee-compass"
 [dependencies]
 routee-compass = { path = "../routee-compass", version = "0.6.1" }
 routee-compass-core = { path = "../routee-compass-core", version = "0.6.1" }
-pyo3 = { version = "0.20.0", features = ["extension-module"] }
+pyo3 = { version = "0.20.0", features = ["extension-module", "serde"] }
 serde_json = { workspace = true }
 config = { workspace = true }
 

--- a/rust/routee-compass-py/src/app_wrapper.rs
+++ b/rust/routee-compass-py/src/app_wrapper.rs
@@ -1,15 +1,10 @@
-use std::path::Path;
-
 use crate::app_graph_ops as ops;
-use pyo3::{
-    exceptions::PyException,
-    prelude::*,
-    types::{PyDict, PyFloat, PyType},
-};
+use pyo3::{exceptions::PyException, prelude::*, types::PyType};
 use routee_compass::app::compass::{
     compass_app::CompassApp, compass_app_ops::read_config_from_string,
     config::compass_app_builder::CompassAppBuilder,
 };
+use std::path::Path;
 
 #[pyclass]
 pub struct CompassAppWrapper {

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -36,7 +36,6 @@ use serde_json::Value;
 use std::{
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
-    time,
 };
 
 /// Instance of RouteE Compass as an application.

--- a/rust/routee-compass/src/app/compass/compass_app_args.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_args.rs
@@ -8,4 +8,6 @@ pub struct CompassAppArgs {
     pub query_file: PathBuf,
     #[arg(short, long, value_name = "FILE")]
     pub config: Option<PathBuf>,
+    #[arg(short, long, value_name = "RUN_CONFIGURATION")]
+    pub run_config: Option<PathBuf>,
 }

--- a/rust/routee-compass/src/app/compass/config.default.toml
+++ b/rust/routee-compass/src/app/compass/config.default.toml
@@ -1,5 +1,11 @@
 parallelism = 2
 search_orientation = "vertex"
+response_persistence_policy = "persist_response_in_memory"
+
+[response_output_policy]
+type = "run_batch_file_sink"
+filename = "output.json"
+format = { type = "json", newline_delimited = true }
 
 [graph]
 verbose = true
@@ -20,7 +26,7 @@ type = "no_restriction"
 
 [termination]
 type = "query_runtime"
-limit = "00:02:00"
+limit = "00:10:00"
 frequency = 100_000
 
 [plugin]

--- a/rust/routee-compass/src/app/compass/config.default.toml
+++ b/rust/routee-compass/src/app/compass/config.default.toml
@@ -1,11 +1,15 @@
 parallelism = 2
 search_orientation = "vertex"
 response_persistence_policy = "persist_response_in_memory"
-
 [response_output_policy]
-type = "run_batch_file_sink"
-filename = "output.json"
-format = { type = "json", newline_delimited = true }
+type = "no_output"
+
+# # example file output policy
+# response_persistence_policy = "discard_response_from_memory"
+# [response_output_policy]
+# type = "run_batch_file_sink"
+# filename = "output.json"
+# format = { type = "json", newline_delimited = true }
 
 [graph]
 verbose = true

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
@@ -17,7 +17,8 @@ pub enum CompassConfigurationField {
     ChargeDepleting,
     ChargeSustaining,
     SearchOrientation,
-    ReturnResponses,
+    ResponsePersistencePolicy,
+    ResponseOutputPolicy,
 }
 
 impl CompassConfigurationField {
@@ -38,7 +39,8 @@ impl CompassConfigurationField {
             CompassConfigurationField::ChargeDepleting => "charge_depleting",
             CompassConfigurationField::ChargeSustaining => "charge_sustaining",
             CompassConfigurationField::SearchOrientation => "search_orientation",
-            CompassConfigurationField::ReturnResponses => "return_responses",
+            CompassConfigurationField::ResponsePersistencePolicy => "response_persistence_policy",
+            CompassConfigurationField::ResponseOutputPolicy => "response_output_policy",
         }
     }
 }

--- a/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
+++ b/rust/routee-compass/src/app/compass/config/compass_configuration_field.rs
@@ -17,6 +17,7 @@ pub enum CompassConfigurationField {
     ChargeDepleting,
     ChargeSustaining,
     SearchOrientation,
+    ReturnResponses,
 }
 
 impl CompassConfigurationField {
@@ -37,6 +38,7 @@ impl CompassConfigurationField {
             CompassConfigurationField::ChargeDepleting => "charge_depleting",
             CompassConfigurationField::ChargeSustaining => "charge_sustaining",
             CompassConfigurationField::SearchOrientation => "search_orientation",
+            CompassConfigurationField::ReturnResponses => "return_responses",
         }
     }
 }

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -5,5 +5,5 @@ pub mod compass_app_ops;
 pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod config;
-pub mod response_persistence_policy;
+pub mod response;
 pub mod search_orientation;

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -5,4 +5,5 @@ pub mod compass_app_ops;
 pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod config;
+pub mod response_memory_persistence;
 pub mod search_orientation;

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -5,5 +5,5 @@ pub mod compass_app_ops;
 pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod config;
-pub mod response_memory_persistence;
+pub mod response_persistence_policy;
 pub mod search_orientation;

--- a/rust/routee-compass/src/app/compass/response/mod.rs
+++ b/rust/routee-compass/src/app/compass/response/mod.rs
@@ -1,0 +1,5 @@
+pub mod response_output_format;
+pub mod response_output_format_json;
+pub mod response_output_policy;
+pub mod response_persistence_policy;
+pub mod response_writer;

--- a/rust/routee-compass/src/app/compass/response/response_output_format.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_format.rs
@@ -1,0 +1,43 @@
+use super::response_output_format_json as json_ops;
+use crate::app::compass::compass_app_error::CompassAppError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum ResponseOutputFormat {
+    Json { newline_delimited: bool },
+}
+
+impl ResponseOutputFormat {
+    pub fn initial_file_contents(&self) -> Option<String> {
+        match self {
+            ResponseOutputFormat::Json { newline_delimited } => {
+                json_ops::initial_file_contents(*newline_delimited)
+            }
+        }
+    }
+
+    pub fn final_file_contents(&self) -> Option<String> {
+        match self {
+            ResponseOutputFormat::Json { newline_delimited } => {
+                json_ops::final_file_contents(*newline_delimited)
+            }
+        }
+    }
+
+    pub fn format_response(&self, response: &serde_json::Value) -> Result<String, CompassAppError> {
+        match self {
+            ResponseOutputFormat::Json { newline_delimited } => {
+                json_ops::format_response(response, *newline_delimited)
+            }
+        }
+    }
+
+    pub fn delimiter(&self) -> Option<String> {
+        match self {
+            ResponseOutputFormat::Json { newline_delimited } => {
+                json_ops::delimiter(*newline_delimited)
+            }
+        }
+    }
+}

--- a/rust/routee-compass/src/app/compass/response/response_output_format_json.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_format_json.rs
@@ -1,0 +1,37 @@
+use crate::app::compass::compass_app_error::CompassAppError;
+
+pub fn initial_file_contents(newline_delimited: bool) -> Option<String> {
+    if newline_delimited {
+        None
+    } else {
+        Some(String::from("[\n"))
+    }
+}
+
+pub fn final_file_contents(newline_delimited: bool) -> Option<String> {
+    if newline_delimited {
+        None
+    } else {
+        Some(String::from("\n]"))
+    }
+}
+
+pub fn format_response(
+    response: &serde_json::Value,
+    newline_delimited: bool,
+) -> Result<String, CompassAppError> {
+    if newline_delimited {
+        serde_json::to_string(response).map_err(CompassAppError::CodecError)
+    } else {
+        let row = serde_json::to_string_pretty(response).map_err(CompassAppError::CodecError)?;
+        Ok(row)
+    }
+}
+
+pub fn delimiter(newline_delimited: bool) -> Option<String> {
+    if newline_delimited {
+        None
+    } else {
+        Some(String::from(",\n"))
+    }
+}

--- a/rust/routee-compass/src/app/compass/response/response_output_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_policy.rs
@@ -10,6 +10,7 @@ use std::{
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ResponseOutputPolicy {
+    NoOutput,
     RunBatchFileSink {
         filename: String,
         format: ResponseOutputFormat,
@@ -22,6 +23,7 @@ impl ResponseOutputPolicy {
     /// such as a file header.
     pub fn build(&self) -> Result<ResponseWriter, CompassAppError> {
         match self {
+            ResponseOutputPolicy::NoOutput => Ok(ResponseWriter::NoOutputWriter),
             ResponseOutputPolicy::RunBatchFileSink { filename, format } => {
                 let output_file_path = PathBuf::from(filename);
 

--- a/rust/routee-compass/src/app/compass/response/response_output_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_policy.rs
@@ -1,0 +1,49 @@
+use super::{response_output_format::ResponseOutputFormat, response_writer::ResponseWriter};
+use crate::app::compass::compass_app_error::CompassAppError;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::OpenOptions,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum ResponseOutputPolicy {
+    RunBatchFileSink {
+        filename: String,
+        format: ResponseOutputFormat,
+    },
+}
+
+impl ResponseOutputPolicy {
+    /// creates an instance of a writer which writes responses to some destination.
+    /// the act of building this writer may include writing initial content to some sink,
+    /// such as a file header.
+    pub fn build(&self) -> Result<ResponseWriter, CompassAppError> {
+        match self {
+            ResponseOutputPolicy::RunBatchFileSink { filename, format } => {
+                let output_file_path = PathBuf::from(filename);
+
+                // initialize the file
+                let header = format
+                    .initial_file_contents()
+                    .unwrap_or_else(|| String::from(""));
+                std::fs::write(&output_file_path, header)?;
+
+                // open the file with the option to append to it
+                let file = OpenOptions::new().append(true).open(&output_file_path)?;
+
+                // wrap the file in a mutex so we can share it between threads
+                let file_shareable = Arc::new(Mutex::new(file));
+
+                Ok(ResponseWriter::RunBatchFileSink {
+                    filename: filename.clone(),
+                    file: file_shareable,
+                    format: *format,
+                    delimiter: format.delimiter(),
+                })
+            }
+        }
+    }
+}

--- a/rust/routee-compass/src/app/compass/response/response_persistence_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_persistence_policy.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+/// declares a policy for search object response memory persistence.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponsePersistencePolicy {
+    PersistResponseInMemory,
+    DiscardResponseFromMemory,
+}

--- a/rust/routee-compass/src/app/compass/response/response_writer.rs
+++ b/rust/routee-compass/src/app/compass/response/response_writer.rs
@@ -22,7 +22,7 @@ impl ResponseWriter {
                 filename: _,
                 file,
                 format,
-                delimiter,
+                delimiter: _,
             } => {
                 let file_ref = Arc::clone(file);
                 let mut file_attained = file_ref.lock().map_err(|e| {
@@ -53,7 +53,7 @@ impl ResponseWriter {
                 filename,
                 file,
                 format,
-                delimiter,
+                delimiter: _,
             } => {
                 let file_ref = Arc::clone(file);
                 let mut file_attained = file_ref.lock().map_err(|e| {

--- a/rust/routee-compass/src/app/compass/response/response_writer.rs
+++ b/rust/routee-compass/src/app/compass/response/response_writer.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 pub enum ResponseWriter {
+    NoOutputWriter,
     RunBatchFileSink {
         filename: String,
         file: Arc<Mutex<File>>,
@@ -18,6 +19,7 @@ pub enum ResponseWriter {
 impl ResponseWriter {
     pub fn write_response(&self, response: &serde_json::Value) -> Result<(), CompassAppError> {
         match self {
+            ResponseWriter::NoOutputWriter => Ok(()),
             ResponseWriter::RunBatchFileSink {
                 filename: _,
                 file,
@@ -49,6 +51,7 @@ impl ResponseWriter {
 
     pub fn close(&self) -> Result<String, CompassAppError> {
         match self {
+            ResponseWriter::NoOutputWriter => Ok(String::from("")),
             ResponseWriter::RunBatchFileSink {
                 filename,
                 file,

--- a/rust/routee-compass/src/app/compass/response/response_writer.rs
+++ b/rust/routee-compass/src/app/compass/response/response_writer.rs
@@ -1,0 +1,75 @@
+use super::response_output_format::ResponseOutputFormat;
+use crate::app::compass::compass_app_error::CompassAppError;
+use std::io::prelude::*;
+use std::{
+    fs::File,
+    sync::{Arc, Mutex},
+};
+
+pub enum ResponseWriter {
+    RunBatchFileSink {
+        filename: String,
+        file: Arc<Mutex<File>>,
+        format: ResponseOutputFormat,
+        delimiter: Option<String>,
+    },
+}
+
+impl ResponseWriter {
+    pub fn write_response(&self, response: &serde_json::Value) -> Result<(), CompassAppError> {
+        match self {
+            ResponseWriter::RunBatchFileSink {
+                filename: _,
+                file,
+                format,
+                delimiter,
+            } => {
+                let file_ref = Arc::clone(file);
+                let mut file_attained = file_ref.lock().map_err(|e| {
+                    CompassAppError::ReadOnlyPoisonError(format!(
+                        "Could not aquire lock on output file: {}",
+                        e
+                    ))
+                })?;
+
+                // if write_delimiter {
+                //     match delimiter {
+                //         None => {}
+                //         Some(delim) => writeln!(file_attained, "{}", delim)
+                //             .map_err(CompassAppError::IOError)?,
+                //     }
+                // }
+
+                let output_row = format.format_response(response)?;
+                writeln!(file_attained, "{}", output_row).map_err(CompassAppError::IOError)?;
+                Ok(())
+            }
+        }
+    }
+
+    pub fn close(&self) -> Result<String, CompassAppError> {
+        match self {
+            ResponseWriter::RunBatchFileSink {
+                filename,
+                file,
+                format,
+                delimiter,
+            } => {
+                let file_ref = Arc::clone(file);
+                let mut file_attained = file_ref.lock().map_err(|e| {
+                    CompassAppError::ReadOnlyPoisonError(format!(
+                        "Could not aquire lock on output file: {}",
+                        e
+                    ))
+                })?;
+
+                let final_contents = format
+                    .final_file_contents()
+                    .unwrap_or_else(|| String::from(""));
+                writeln!(file_attained, "{}", final_contents).map_err(CompassAppError::IOError)?;
+
+                Ok(filename.clone())
+            }
+        }
+    }
+}

--- a/rust/routee-compass/src/app/compass/response_memory_persistence.rs
+++ b/rust/routee-compass/src/app/compass/response_memory_persistence.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+/// declares a policy for search object response memory persistence.
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseMemoryPersistence {
+    PersistResponseInMemory,
+    DiscardResponseFromMemory,
+}

--- a/rust/routee-compass/src/app/compass/response_persistence_policy.rs
+++ b/rust/routee-compass/src/app/compass/response_persistence_policy.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// declares a policy for search object response memory persistence.
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
-pub enum ResponseMemoryPersistence {
+pub enum ResponsePersistencePolicy {
     PersistResponseInMemory,
     DiscardResponseFromMemory,
 }

--- a/rust/routee-compass/src/app/compass/response_persistence_policy.rs
+++ b/rust/routee-compass/src/app/compass/response_persistence_policy.rs
@@ -1,9 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-/// declares a policy for search object response memory persistence.
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum ResponsePersistencePolicy {
-    PersistResponseInMemory,
-    DiscardResponseFromMemory,
-}

--- a/rust/routee-compass/src/main.rs
+++ b/rust/routee-compass/src/main.rs
@@ -39,7 +39,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     let user_queries = user_json.get_queries()?;
     info!("Query: {:?}", user_json);
 
-    let results = compass_app.run(user_queries)?;
+    let run_config = match args.run_config {
+        Some(run_config_path) => {
+            let f = File::open(run_config_path)?;
+            let r = std::io::BufReader::new(f);
+            let j: serde_json::Value = serde_json::from_reader(r)?;
+            Some(j)
+        }
+        None => None,
+    };
+
+    let results = compass_app.run(user_queries, run_config.as_ref())?;
 
     // scan the results and log any json values that have "error" in them
     for result in results.iter() {

--- a/rust/routee-compass/src/plugin/output/default/edgeidlist/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/edgeidlist/plugin.rs
@@ -10,11 +10,11 @@ pub struct EdgeIdListOutputPlugin {}
 impl OutputPlugin for EdgeIdListOutputPlugin {
     fn process(
         &self,
-        output: &serde_json::Value,
+        output: &mut serde_json::Value,
         search_result: &Result<SearchAppResult, CompassAppError>,
-    ) -> Result<Vec<serde_json::Value>, PluginError> {
+    ) -> Result<(), PluginError> {
         match search_result {
-            Err(_e) => Ok(vec![output.clone()]),
+            Err(_e) => Ok(()),
             Ok(result) => {
                 let edge_ids = result
                     .route
@@ -22,9 +22,8 @@ impl OutputPlugin for EdgeIdListOutputPlugin {
                     .iter()
                     .map(|e| e.edge_id)
                     .collect::<Vec<_>>();
-                let mut updated = output.clone();
-                updated.add_edge_list(&edge_ids)?;
-                Ok(vec![updated])
+                output.add_edge_list(&edge_ids)?;
+                Ok(())
             }
         }
     }

--- a/rust/routee-compass/src/plugin/output/default/summary/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/summary/plugin.rs
@@ -12,42 +12,20 @@ impl OutputPlugin for SummaryOutputPlugin {
     /// append "Cost" value to the output JSON
     fn process(
         &self,
-        output: &serde_json::Value,
+        output: &mut serde_json::Value,
         search_result: &Result<SearchAppResult, CompassAppError>,
-    ) -> Result<Vec<serde_json::Value>, PluginError> {
+    ) -> Result<(), PluginError> {
         match search_result {
-            Err(_e) => Ok(vec![output.clone()]),
+            Err(_e) => Ok(()),
             Ok(result) => {
-                let mut updated_output = output.clone();
-                let updated = updated_output.as_object_mut().ok_or_else(|| {
-                    PluginError::InternalError(format!(
-                        "expected output JSON to be an object, found {}",
-                        output
-                    ))
-                })?;
                 let memory_usage = allocative::size_of_unique(result) as f64;
-                updated.insert("result_memory_usage_bytes".to_string(), memory_usage.into());
-
-                updated.insert(
-                    "search_executed_time".to_string(),
-                    result.search_executed_time.clone().into(),
-                );
-
-                updated.insert(
-                    "algorithm_runtime".to_string(),
-                    result.algorithm_runtime.hhmmss().into(),
-                );
-
-                updated.insert(
-                    "search_app_runtime".to_string(),
-                    result.search_app_runtime.hhmmss().into(),
-                );
-
-                updated.insert("route_edge_count".to_string(), result.route.len().into());
-
-                updated.insert("tree_edge_count".to_string(), result.tree.len().into());
-
-                Ok(vec![updated_output])
+                output["result_memory_usage_bytes"] = memory_usage.into();
+                output["search_executed_time"] = result.search_executed_time.clone().into();
+                output["algorithm_runtime"] = result.algorithm_runtime.hhmmss().into();
+                output["search_app_runtime"] = result.search_app_runtime.hhmmss().into();
+                output["route_edge_count"] = result.route.len().into();
+                output["tree_edge_count"] = result.tree.len().into();
+                Ok(())
             }
         }
     }

--- a/rust/routee-compass/src/plugin/output/default/to_disk/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/to_disk/plugin.rs
@@ -18,9 +18,9 @@ pub struct ToDiskOutputPlugin {
 impl OutputPlugin for ToDiskOutputPlugin {
     fn process(
         &self,
-        output: &serde_json::Value,
+        output: &mut serde_json::Value,
         _result: &Result<SearchAppResult, CompassAppError>,
-    ) -> Result<Vec<serde_json::Value>, PluginError> {
+    ) -> Result<(), PluginError> {
         let file_ref = Arc::clone(&self.output_file);
         let mut file = file_ref.lock().map_err(|e| {
             PluginError::FileReadError(
@@ -39,6 +39,6 @@ impl OutputPlugin for ToDiskOutputPlugin {
         })?;
 
         // return empty vec since we already wrote the result to a file
-        Ok(Vec::new())
+        Ok(())
     }
 }

--- a/rust/routee-compass/src/plugin/output/default/to_disk/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/to_disk/plugin.rs
@@ -1,15 +1,15 @@
-use std::fs::File;
-use std::io::prelude::*;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-
 use crate::{
     app::{
         compass::compass_app_error::CompassAppError, search::search_app_result::SearchAppResult,
     },
     plugin::{output::output_plugin::OutputPlugin, plugin_error::PluginError},
 };
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
+/// Deprecated: use ResponseOutputPolicy instead.
 pub struct ToDiskOutputPlugin {
     pub output_file_path: PathBuf,
     pub output_file: Arc<Mutex<File>>,

--- a/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
@@ -161,7 +161,7 @@ mod tests {
         let geom_plugin =
             TraversalPlugin::from_file(&filename, Some(TraversalOutputFormat::Wkt), None).unwrap();
 
-        let result = geom_plugin
+        geom_plugin
             .process(&mut output_result, &Ok(search_result))
             .unwrap();
         let geometry_wkt = output_result.get_route_geometry_wkt().unwrap();

--- a/rust/routee-compass/src/plugin/output/initial_output_ops.rs
+++ b/rust/routee-compass/src/plugin/output/initial_output_ops.rs
@@ -1,0 +1,89 @@
+use std::{sync::Arc, time::Duration};
+
+use routee_compass_core::{
+    algorithm::search::edge_traversal::EdgeTraversal,
+    model::{cost::cost_model::CostModel, traversal::traversal_model::TraversalModel},
+    util::duration_extension::DurationExtension,
+};
+use serde_json::{json, Value};
+
+use crate::app::{
+    compass::compass_app_error::CompassAppError,
+    search::{search_app::SearchApp, search_app_result::SearchAppResult},
+};
+
+/// creates the initial output with summary information from the search app,
+/// which happens regardless of the output plugin setup.
+pub fn create_initial_output(
+    req: &Value,
+    res: &Result<SearchAppResult, CompassAppError>,
+    app: &SearchApp,
+) -> Result<Value, Value> {
+    match &res {
+        Err(e) => Err(package_error(req, e)),
+        Ok(result) => {
+            let start_time = chrono::Local::now();
+            let mut init_output = serde_json::json!({
+                "request": req,
+            });
+
+            let route = result.route.to_vec();
+
+            // build and append summaries if there is a route
+            if let Some(et) = route.last() {
+                // build instances of traversal and cost models to compute summaries
+                let t = get_traversal_model(et, req, app)?;
+                let c = get_cost_model(et, req, app, t.clone())?;
+                init_output["traversal_summary"] = t.serialize_state_with_info(&et.result_state);
+                let cost_summary = match c.serialize_cost_with_info(&et.result_state) {
+                    Ok(summary) => summary,
+                    Err(e) => return Err(package_error(req, e)),
+                };
+                init_output["cost_summary"] = cost_summary;
+            }
+
+            // append the runtime required to compute these summaries
+            let output_plugin_executed_time = chrono::Local::now();
+            let basic_summary_runtime = output_plugin_executed_time - start_time;
+            let basic_summary_runtime_str = basic_summary_runtime
+                .to_std()
+                .unwrap_or(Duration::ZERO)
+                .hhmmss();
+            init_output["basic_summary_runtime"] = serde_json::json!(basic_summary_runtime_str);
+            init_output["output_plugin_executed_time"] =
+                serde_json::json!(output_plugin_executed_time.to_rfc3339());
+
+            Ok(init_output)
+        }
+    }
+}
+
+pub fn package_error<E: ToString>(req: &Value, error: E) -> Value {
+    json!({
+        "request": req,
+        "error": error.to_string()
+    })
+}
+
+pub fn get_traversal_model(
+    et: &EdgeTraversal,
+    req: &Value,
+    app: &SearchApp,
+) -> Result<Arc<dyn TraversalModel>, Value> {
+    match app.build_traversal_model(req) {
+        Err(e) => Err(package_error(req, e)),
+        Ok(tmodel) => Ok(tmodel),
+    }
+}
+
+pub fn get_cost_model(
+    et: &EdgeTraversal,
+    req: &Value,
+    app: &SearchApp,
+    tmodel: Arc<dyn TraversalModel>,
+) -> Result<CostModel, Value> {
+    match app.build_cost_model_for_traversal_model(req, tmodel.clone()) {
+        Err(e) => Err(package_error(req, e)),
+        Ok(cmodel) => Ok(cmodel),
+    }
+}

--- a/rust/routee-compass/src/plugin/output/initial_output_ops.rs
+++ b/rust/routee-compass/src/plugin/output/initial_output_ops.rs
@@ -66,7 +66,7 @@ pub fn package_error<E: ToString>(req: &Value, error: E) -> Value {
 }
 
 pub fn get_traversal_model(
-    et: &EdgeTraversal,
+    _et: &EdgeTraversal,
     req: &Value,
     app: &SearchApp,
 ) -> Result<Arc<dyn TraversalModel>, Value> {
@@ -77,7 +77,7 @@ pub fn get_traversal_model(
 }
 
 pub fn get_cost_model(
-    et: &EdgeTraversal,
+    _et: &EdgeTraversal,
     req: &Value,
     app: &SearchApp,
     tmodel: Arc<dyn TraversalModel>,

--- a/rust/routee-compass/src/plugin/output/mod.rs
+++ b/rust/routee-compass/src/plugin/output/mod.rs
@@ -1,2 +1,3 @@
 pub mod default;
+pub mod initial_output_ops;
 pub mod output_plugin;

--- a/rust/routee-compass/src/plugin/output/output_plugin.rs
+++ b/rust/routee-compass/src/plugin/output/output_plugin.rs
@@ -36,7 +36,7 @@ pub trait OutputPlugin: Send + Sync {
     /// [internal representation]: crate::app::search::search_app_result::SearchAppResult
     fn process(
         &self,
-        output: &serde_json::Value,
+        output: &mut serde_json::Value,
         result: &Result<SearchAppResult, CompassAppError>,
-    ) -> Result<Vec<serde_json::Value>, PluginError>;
+    ) -> Result<(), PluginError>;
 }


### PR DESCRIPTION
This PR attempts to improve Compass performance by making the OutputPlugin process method a mutable update on the output JSON.

the existing code requires a copy for any processing, and wraps that copy in a vector to allow flat_map semantics (producing multiple output rows from the upstream JSON). for very large batches, this creates a lot of unnecessary memory pressure which grows over the course of a run.

### remaining work

one downside immediately is that this nullifies our `to_disk` plugin, since that plugin would "void" a response after writing it. my working plan is to move this logic permanently into the CompassApp and activate the logic based on the presence of an output file location specified either by an argument on the run method or by some default specified at the base level of the TOML. thoughts? 

Closes #116.