### PR TITLE
Rjf/input plugins mutable

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -516,7 +516,7 @@ pub fn run_batch_without_responses(
 }
 
 /// helper that applies the input plugins to a query, returning the result(s) or an error if failed
-pub fn apply_input_plugins<'a>(
+pub fn apply_input_plugins(
     query: &serde_json::Value,
     plugins: &Vec<Arc<dyn InputPlugin>>,
 ) -> Result<Vec<serde_json::Value>, serde_json::Value> {
@@ -528,29 +528,6 @@ pub fn apply_input_plugins<'a>(
     }
     let result = in_ops::json_array_flatten(&mut plugin_state)?;
     Ok(result)
-    // let init = Ok(vec![query.clone()]);
-    // let result = plugins
-    //     .iter()
-    //     .fold(init, |acc, p| {
-    //         acc.and_then(|outer| {
-    //             outer
-    //                 .iter()
-    //                 .map(|q| p.process(q))
-    //                 .collect::<Result<Vec<_>, PluginError>>()
-    //                 .map(|inner| {
-    //                     inner
-    //                         .into_iter()
-    //                         .flatten()
-    //                         .collect::<Vec<serde_json::Value>>()
-    //                 })
-    //         })
-    //     })
-    //     .map_err(|e| {
-    //         serde_json::json!({
-    //             "request": query,
-    //             "error": e.to_string()
-    //         })
-    //     })?;
 }
 
 // helper that applies the output processing. this includes

--- a/rust/routee-compass/src/plugin/input/default/debug/debug_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/debug/debug_plugin.rs
@@ -3,9 +3,9 @@ use crate::plugin::{input::input_plugin::InputPlugin, plugin_error::PluginError}
 pub struct DebugInputPlugin {}
 
 impl InputPlugin for DebugInputPlugin {
-    fn process(&self, input: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
+    fn process(&self, input: &mut serde_json::Value) -> Result<(), PluginError> {
         let string = serde_json::to_string_pretty(input).map_err(PluginError::JsonError)?;
         println!("{}", string);
-        Ok(vec![input.clone()])
+        Ok(())
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
@@ -29,7 +29,7 @@ pub struct EdgeRtreeInputPlugin {
 impl InputPlugin for EdgeRtreeInputPlugin {
     /// finds the nearest edge ids to the user-provided origin and destination coordinates.
     /// optionally restricts the search to a subset of road classes tagged by the user.
-    fn process(&self, query: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
+    fn process(&self, query: &mut serde_json::Value) -> Result<(), PluginError> {
         let road_classes = query
             .get_config_serde_optional::<HashSet<String>>(&"road_classes", &"")
             .map_err(|e| {
@@ -48,15 +48,15 @@ impl InputPlugin for EdgeRtreeInputPlugin {
         }?;
 
         let mut updated = query.clone();
-        updated.add_origin_edge(source_edge_id)?;
+        query.add_origin_edge(source_edge_id)?;
         match destination_edge_id_option {
             None => {}
             Some(destination_edge_id) => {
-                updated.add_destination_edge(destination_edge_id)?;
+                query.add_destination_edge(destination_edge_id)?;
             }
         }
 
-        Ok(vec![updated])
+        Ok(())
     }
 }
 

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
@@ -47,7 +47,7 @@ impl InputPlugin for EdgeRtreeInputPlugin {
                 .ok_or_else(|| matching_error(&dst_coord, self.tolerance)),
         }?;
 
-        let mut updated = query.clone();
+        let _updated = query.clone();
         query.add_origin_edge(source_edge_id)?;
         match destination_edge_id_option {
             None => {}

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
@@ -47,7 +47,6 @@ impl InputPlugin for EdgeRtreeInputPlugin {
                 .ok_or_else(|| matching_error(&dst_coord, self.tolerance)),
         }?;
 
-        let _updated = query.clone();
         query.add_origin_edge(source_edge_id)?;
         match destination_edge_id_option {
             None => {}

--- a/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
@@ -79,7 +79,7 @@ impl InputPlugin for GridSearchPlugin {
 
 #[cfg(test)]
 mod test {
-
+    use serde_json::json;
     use super::GridSearchPlugin;
     use crate::plugin::input::input_plugin::InputPlugin;
 
@@ -92,22 +92,31 @@ mod test {
             }
         });
         let plugin = GridSearchPlugin {};
-        let result = plugin
-            .process(&mut input)
-            .unwrap()
-            .iter()
-            .map(serde_json::to_string)
-            .collect::<Result<Vec<String>, serde_json::Error>>()
-            .unwrap();
+        plugin.process(&mut input).unwrap();
+        // .iter()
+        // .map(serde_json::to_string)
+        // .collect::<Result<Vec<String>, serde_json::Error>>()
+        // .unwrap();
+        // let expected = vec![
+        //     String::from("{\"bar\":\"a\",\"foo\":1.2}"),
+        //     String::from("{\"bar\":\"b\",\"foo\":1.2}"),
+        //     String::from("{\"bar\":\"c\",\"foo\":1.2}"),
+        //     String::from("{\"bar\":\"a\",\"foo\":3.4}"),
+        //     String::from("{\"bar\":\"b\",\"foo\":3.4}"),
+        //     String::from("{\"bar\":\"c\",\"foo\":3.4}"),
+        // ];
         let expected = vec![
-            String::from("{\"bar\":\"a\",\"foo\":1.2}"),
-            String::from("{\"bar\":\"b\",\"foo\":1.2}"),
-            String::from("{\"bar\":\"c\",\"foo\":1.2}"),
-            String::from("{\"bar\":\"a\",\"foo\":3.4}"),
-            String::from("{\"bar\":\"b\",\"foo\":3.4}"),
-            String::from("{\"bar\":\"c\",\"foo\":3.4}"),
+            json![{"bar":"a","foo":1.2}],
+            json![{"bar":"b","foo":1.2}],
+            json![{"bar":"c","foo":1.2}],
+            json![{"bar":"a","foo":3.4}],
+            json![{"bar":"b","foo":3.4}],
+            json![{"bar":"c","foo":3.4}],
         ];
-        assert_eq!(result, expected);
+        match input {
+            serde_json::Value::Array(result) => assert_eq!(result, expected),
+            other => panic!("expected array result, found {}", other),
+        }
     }
 
     #[test]
@@ -120,22 +129,28 @@ mod test {
             }
         });
         let plugin = GridSearchPlugin {};
-        let result = plugin
-            .process(&mut input)
-            .unwrap()
-            .iter()
-            .map(serde_json::to_string)
-            .collect::<Result<Vec<String>, serde_json::Error>>()
-            .unwrap();
+        plugin.process(&mut input).unwrap();
+
+        // let expected = vec![
+        //     String::from("{\"bar\":\"a\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
+        //     String::from("{\"bar\":\"b\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
+        //     String::from("{\"bar\":\"c\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
+        //     String::from("{\"bar\":\"a\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
+        //     String::from("{\"bar\":\"b\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
+        //     String::from("{\"bar\":\"c\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
+        // ];
         let expected = vec![
-            String::from("{\"bar\":\"a\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
-            String::from("{\"bar\":\"b\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
-            String::from("{\"bar\":\"c\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
-            String::from("{\"bar\":\"a\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
-            String::from("{\"bar\":\"b\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
-            String::from("{\"bar\":\"c\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
+            json![{"bar":"a","foo":1.2,"ignored_key": "ignored_value"}],
+            json![{"bar":"b","foo":1.2,"ignored_key": "ignored_value"}],
+            json![{"bar":"c","foo":1.2,"ignored_key": "ignored_value"}],
+            json![{"bar":"a","foo":3.4,"ignored_key": "ignored_value"}],
+            json![{"bar":"b","foo":3.4,"ignored_key": "ignored_value"}],
+            json![{"bar":"c","foo":3.4,"ignored_key": "ignored_value"}],
         ];
-        assert_eq!(result, expected);
+        match input {
+            serde_json::Value::Array(result) => assert_eq!(result, expected),
+            other => panic!("expected array result, found {}", other),
+        }
     }
 
     #[test]
@@ -151,20 +166,18 @@ mod test {
             }
         });
         let plugin = GridSearchPlugin {};
-        let result = plugin
-            .process(&mut input)
-            .unwrap()
-            .iter()
-            .map(serde_json::to_string)
-            .collect::<Result<Vec<String>, serde_json::Error>>()
-            .unwrap();
+        plugin.process(&mut input).unwrap();
         let expected = vec![
-            String::from("{\"a\":1,\"ignored_key\":\"ignored_value\",\"x\":0,\"y\":0}"),
-            String::from("{\"a\":2,\"ignored_key\":\"ignored_value\",\"x\":0,\"y\":0}"),
-            String::from("{\"a\":1,\"ignored_key\":\"ignored_value\",\"x\":1,\"y\":1}"),
-            String::from("{\"a\":2,\"ignored_key\":\"ignored_value\",\"x\":1,\"y\":1}"),
+            json![{"a":1,"ignored_key":"ignored_value","x":0,"y":0}],
+            json![{"a":2,"ignored_key":"ignored_value","x":0,"y":0}],
+            json![{"a":1,"ignored_key":"ignored_value","x":1,"y":1}],
+            json![ {"a":2,"ignored_key":"ignored_value","x":1,"y":1}],
         ];
-        assert_eq!(result, expected);
+        // assert_eq!(result, expected);
+        match input {
+            serde_json::Value::Array(result) => assert_eq!(result, expected),
+            other => panic!("expected array result, found {}", other),
+        }
     }
 
     #[test]
@@ -181,22 +194,19 @@ mod test {
             }
         });
         let plugin = GridSearchPlugin {};
-        let result = plugin
-            .process(&mut input)
-            .unwrap()
-            .iter()
-            .map(serde_json::to_string)
-            .collect::<Result<Vec<String>, serde_json::Error>>()
-            .unwrap();
+        plugin.process(&mut input).unwrap();
         let expected = vec![
-            String::from("{\"abc\":123,\"model_name\":\"2016_TOYOTA_Camry_4cyl_2WD\",\"name\":\"d1\",\"state_variable_coefficients\":{\"distance\":1,\"energy_electric\":0,\"time\":0}}"),
-            String::from("{\"abc\":123,\"model_name\":\"2016_TOYOTA_Camry_4cyl_2WD\",\"name\":\"t1\",\"state_variable_coefficients\":{\"distance\":0,\"energy_electric\":0,\"time\":1}}"),
-            String::from("{\"abc\":123,\"model_name\":\"2016_TOYOTA_Camry_4cyl_2WD\",\"name\":\"e1\",\"state_variable_coefficients\":{\"distance\":0,\"energy_electric\":1,\"time\":0}}"),
-            String::from("{\"abc\":123,\"model_name\":\"2017_CHEVROLET_Bolt\",\"name\":\"d1\",\"state_variable_coefficients\":{\"distance\":1,\"energy_electric\":0,\"time\":0}}"),
-            String::from("{\"abc\":123,\"model_name\":\"2017_CHEVROLET_Bolt\",\"name\":\"t1\",\"state_variable_coefficients\":{\"distance\":0,\"energy_electric\":0,\"time\":1}}"),
-            String::from("{\"abc\":123,\"model_name\":\"2017_CHEVROLET_Bolt\",\"name\":\"e1\",\"state_variable_coefficients\":{\"distance\":0,\"energy_electric\":1,\"time\":0}}"),
+            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"d1","state_variable_coefficients":{"distance":1,"energy_electric":0,"time":0}}],
+            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"t1","state_variable_coefficients":{"distance":0,"energy_electric":0,"time":1}}],
+            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"e1","state_variable_coefficients":{"distance":0,"energy_electric":1,"time":0}}],
+            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"d1","state_variable_coefficients":{"distance":1,"energy_electric":0,"time":0}}],
+            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"t1","state_variable_coefficients":{"distance":0,"energy_electric":0,"time":1}}],
+            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"e1","state_variable_coefficients":{"distance":0,"energy_electric":1,"time":0}}],
         ];
-        assert_eq!(result, expected);
+        match input {
+            serde_json::Value::Array(result) => assert_eq!(result, expected),
+            other => panic!("expected array result, found {}", other),
+        }
     }
 
     #[test]

--- a/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
@@ -9,7 +9,7 @@ use routee_compass_core::util::multiset::MultiSet;
 pub struct GridSearchPlugin {}
 
 impl InputPlugin for GridSearchPlugin {
-    fn process(&self, mut input: &mut serde_json::Value) -> Result<(), PluginError> {
+    fn process(&self, input: &mut serde_json::Value) -> Result<(), PluginError> {
         match input.get_grid_search() {
             None => Ok(()),
             Some(grid_search_input) => {
@@ -68,8 +68,6 @@ impl InputPlugin for GridSearchPlugin {
                         instance
                     })
                     .collect();
-
-                // let new_array = serde_json::Value::Array(result);
 
                 let mut replacement = serde_json::json![result];
                 std::mem::swap(&mut replacement, input);

--- a/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
@@ -72,7 +72,7 @@ impl InputPlugin for GridSearchPlugin {
                 // let new_array = serde_json::Value::Array(result);
 
                 let mut replacement = serde_json::json![result];
-                std::mem::swap(&mut replacement, &mut input);
+                std::mem::swap(&mut replacement, input);
                 Ok(())
             }
         }

--- a/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
@@ -79,9 +79,9 @@ impl InputPlugin for GridSearchPlugin {
 
 #[cfg(test)]
 mod test {
-    use serde_json::json;
     use super::GridSearchPlugin;
     use crate::plugin::input::input_plugin::InputPlugin;
+    use serde_json::json;
 
     #[test]
     fn test_grid_search_empty_parent_object() {
@@ -93,18 +93,6 @@ mod test {
         });
         let plugin = GridSearchPlugin {};
         plugin.process(&mut input).unwrap();
-        // .iter()
-        // .map(serde_json::to_string)
-        // .collect::<Result<Vec<String>, serde_json::Error>>()
-        // .unwrap();
-        // let expected = vec![
-        //     String::from("{\"bar\":\"a\",\"foo\":1.2}"),
-        //     String::from("{\"bar\":\"b\",\"foo\":1.2}"),
-        //     String::from("{\"bar\":\"c\",\"foo\":1.2}"),
-        //     String::from("{\"bar\":\"a\",\"foo\":3.4}"),
-        //     String::from("{\"bar\":\"b\",\"foo\":3.4}"),
-        //     String::from("{\"bar\":\"c\",\"foo\":3.4}"),
-        // ];
         let expected = vec![
             json![{"bar":"a","foo":1.2}],
             json![{"bar":"b","foo":1.2}],
@@ -131,14 +119,6 @@ mod test {
         let plugin = GridSearchPlugin {};
         plugin.process(&mut input).unwrap();
 
-        // let expected = vec![
-        //     String::from("{\"bar\":\"a\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
-        //     String::from("{\"bar\":\"b\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
-        //     String::from("{\"bar\":\"c\",\"foo\":1.2,\"ignored_key\":\"ignored_value\"}"),
-        //     String::from("{\"bar\":\"a\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
-        //     String::from("{\"bar\":\"b\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
-        //     String::from("{\"bar\":\"c\",\"foo\":3.4,\"ignored_key\":\"ignored_value\"}"),
-        // ];
         let expected = vec![
             json![{"bar":"a","foo":1.2,"ignored_key": "ignored_value"}],
             json![{"bar":"b","foo":1.2,"ignored_key": "ignored_value"}],

--- a/rust/routee-compass/src/plugin/input/default/inject/inject_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/inject/inject_plugin.rs
@@ -1,5 +1,3 @@
-use serde_json::json;
-
 use crate::plugin::{input::input_plugin::InputPlugin, plugin_error::PluginError};
 
 pub struct InjectInputPlugin {
@@ -14,15 +12,8 @@ impl InjectInputPlugin {
 }
 
 impl InputPlugin for InjectInputPlugin {
-    fn process(&self, input: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
-        let mut updated_obj = input.clone();
-        let updated = updated_obj.as_object_mut().ok_or_else(|| {
-            PluginError::InternalError(format!(
-                "expected input JSON to be an object, found {}",
-                input
-            ))
-        })?;
-        updated.insert(self.key.clone(), self.value.clone());
-        Ok(vec![json!(updated)])
+    fn process(&self, input: &mut serde_json::Value) -> Result<(), PluginError> {
+        input[self.key.clone()] = self.value.clone();
+        Ok(())
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/plugin.rs
@@ -10,7 +10,7 @@ pub struct LoadBalancerPlugin {
 impl InputPlugin for LoadBalancerPlugin {
     fn process(&self, query: &mut serde_json::Value) -> Result<(), PluginError> {
         let w = self.heuristic.estimate_weight(query)?;
-        let mut updated = query.clone();
+        let _updated = query.clone();
         query.add_query_weight_estimate(w)?;
         Ok(())
     }

--- a/rust/routee-compass/src/plugin/input/default/load_balancer/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/load_balancer/plugin.rs
@@ -8,10 +8,10 @@ pub struct LoadBalancerPlugin {
 }
 
 impl InputPlugin for LoadBalancerPlugin {
-    fn process(&self, query: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError> {
+    fn process(&self, query: &mut serde_json::Value) -> Result<(), PluginError> {
         let w = self.heuristic.estimate_weight(query)?;
         let mut updated = query.clone();
-        updated.add_query_weight_estimate(w)?;
-        Ok(vec![updated])
+        query.add_query_weight_estimate(w)?;
+        Ok(())
     }
 }

--- a/rust/routee-compass/src/plugin/input/default/vertex_rtree/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/vertex_rtree/plugin.rs
@@ -246,20 +246,25 @@ mod test {
         let query_str = fs::read_to_string(query_filepath).unwrap();
         let rtree_plugin = RTreePlugin::new(&vertices_filepath, None, None).unwrap();
         let mut query: serde_json::Value = serde_json::from_str(&query_str).unwrap();
-        let processed_query = rtree_plugin.process(&mut query).unwrap();
+        rtree_plugin.process(&mut query).unwrap();
 
-        assert_eq!(
-            processed_query[0],
-            json!(
-                {
-                    InputField::OriginX.to_str(): 0.1,
-                    InputField::OriginY.to_str(): 0.1,
-                    InputField::DestinationX.to_str(): 1.9,
-                    InputField::DestinationY.to_str(): 2.1,
-                    InputField::OriginVertex.to_str(): 0,
-                    InputField::DestinationVertex.to_str(): 2,
-                }
-            )
-        );
+        match query {
+            serde_json::Value::Object(obj) => {
+                assert_eq!(
+                    json![obj],
+                    json!(
+                        {
+                            InputField::OriginX.to_str(): 0.1,
+                            InputField::OriginY.to_str(): 0.1,
+                            InputField::DestinationX.to_str(): 1.9,
+                            InputField::DestinationY.to_str(): 2.1,
+                            InputField::OriginVertex.to_str(): 0,
+                            InputField::DestinationVertex.to_str(): 2,
+                        }
+                    )
+                );
+            }
+            other => panic!("expected object result, found {}", other),
+        }
     }
 }

--- a/rust/routee-compass/src/plugin/input/input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/input_plugin.rs
@@ -26,5 +26,5 @@ pub trait InputPlugin: Send + Sync {
     /// # Returns
     ///
     /// A `Vec` of JSON values to replace the input JSON, or an error
-    fn process(&self, input: &serde_json::Value) -> Result<Vec<serde_json::Value>, PluginError>;
+    fn process(&self, input: &mut serde_json::Value) -> Result<(), PluginError>;
 }

--- a/rust/routee-compass/src/plugin/input/input_plugin_ops.rs
+++ b/rust/routee-compass/src/plugin/input/input_plugin_ops.rs
@@ -32,7 +32,7 @@ pub fn package_invariant_error(
             let json = serde_json::to_string_pretty(q).unwrap_or_else(|e| {
                 format!(
                     "oops, i can't even serialize that query because of an error: {}",
-                    e.to_string()
+                    e
                 )
             });
             format!("{}\n\n{}", json_intro, json)
@@ -46,7 +46,7 @@ pub fn package_invariant_error(
             let ss_json = serde_json::to_string_pretty(&ss).unwrap_or_else(|e| {
                 format!(
                     "oops, i can't even serialize that sub-section because of an error: {}",
-                    e.to_string()
+                    e
                 )
             });
 
@@ -93,7 +93,7 @@ pub fn json_array_flatten(result: &mut Value) -> Result<Vec<Value>, Value> {
     let mut error: Option<&mut Value> = None;
     match result {
         Value::Array(sub_array) => {
-            for sub_obj in sub_array.into_iter() {
+            for sub_obj in sub_array.iter_mut() {
                 match sub_obj {
                     Value::Object(obj) => {
                         flattened.push(json![obj]);

--- a/rust/routee-compass/src/plugin/input/input_plugin_ops.rs
+++ b/rust/routee-compass/src/plugin/input/input_plugin_ops.rs
@@ -1,0 +1,119 @@
+use std::rc::Rc;
+
+use crate::plugin::plugin_error::PluginError;
+use serde_json::{json, Value};
+
+/// helper to return errors as JSON response objects which include the
+/// original request along with the error message
+pub fn package_error<E: ToString>(query: &Value, error: E) -> Value {
+    json!({
+        "request": query,
+        "error": error.to_string()
+    })
+}
+
+pub fn package_invariant_error(
+    query: Option<&mut Value>,
+    sub_section: Option<&mut Value>,
+) -> Value {
+    let intro = r#"
+    an input plugin has broken the invariant of the query state which requires
+    that the query's JSON representation has a top-level JSON Array ([]) whose only
+    elements are JSON objects ({}). please confirm that all included InputPlugin 
+    instances do not break this invariant.
+    "#;
+
+    let json_msg = match query {
+        None => String::from(
+            "unable to display query state as it may have been modified during this process.",
+        ),
+        Some(ref q) => {
+            let json_intro = "here is the invalid query state that was found:";
+            let json = serde_json::to_string_pretty(q).unwrap_or_else(|e| {
+                format!(
+                    "oops, i can't even serialize that query because of an error: {}",
+                    e.to_string()
+                )
+            });
+            format!("{}\n\n{}", json_intro, json)
+        }
+    };
+
+    let msg = match sub_section {
+        None => format!("{}\n{}", intro, json_msg),
+        Some(ss) => {
+            let ss_msg = "error triggered by the following sub-section:";
+            let ss_json = serde_json::to_string_pretty(&ss).unwrap_or_else(|e| {
+                format!(
+                    "oops, i can't even serialize that sub-section because of an error: {}",
+                    e.to_string()
+                )
+            });
+
+            format!("{}\n\n{}\n\n{}\n\n{}", intro, json_msg, ss_msg, ss_json)
+        }
+    };
+
+    match query {
+        Some(q) => package_error(q, msg),
+        None => package_error(&json![{"error": "unable to display query"}], msg),
+    }
+}
+
+pub type ArrayOp<'a> = Rc<dyn Fn(&mut Value) -> Result<(), PluginError> + 'a>;
+
+/// executes an operation on an input query. maintains the invariant that
+/// input queries should always remain wrapped in a top-level JSON Array
+/// so that we can perform operations like grid search, which transform a
+/// single query into multiple child queries.
+pub fn json_array_op<'a>(query: &'a mut Value, op: ArrayOp<'a>) -> Result<(), Value> {
+    match query {
+        Value::Array(queries) => {
+            for q in queries.iter_mut() {
+                op(q).map_err(|e| package_error(&json![{}], e))?;
+            }
+            Ok(())
+        }
+        other => {
+            let error = package_invariant_error(None, Some(other));
+            Err(error)
+        }
+    }
+}
+
+/// flattens the result of input processing into a response vector, ensuring
+/// that the nesting and types are correct. returns a new vector of values,
+/// moving the valid input processing results into the new flattened vector.
+pub fn json_array_flatten(result: &mut Value) -> Result<Vec<Value>, Value> {
+    let mut flattened: Vec<Value> = vec![];
+    if !result.is_array() {
+        let error_response = package_invariant_error(Some(result), None);
+        return Err(error_response);
+    }
+    let mut error: Option<&mut Value> = None;
+    match result {
+        Value::Array(sub_array) => {
+            for sub_obj in sub_array.into_iter() {
+                match sub_obj {
+                    Value::Object(obj) => {
+                        flattened.push(json![obj]);
+                    }
+                    other => {
+                        error = Some(other);
+                    }
+                }
+            }
+        }
+        other => {
+            error = Some(other);
+        }
+    }
+
+    match error {
+        Some(_) => {
+            let error_response = package_invariant_error(None, error);
+            Err(error_response)?
+        }
+        None => Ok(flattened),
+    }
+}

--- a/rust/routee-compass/src/plugin/input/mod.rs
+++ b/rust/routee-compass/src/plugin/input/mod.rs
@@ -2,3 +2,4 @@ pub mod default;
 pub mod input_field;
 pub mod input_json_extensions;
 pub mod input_plugin;
+pub mod input_plugin_ops;

--- a/rust/routee-compass/src/plugin/output/mod.rs
+++ b/rust/routee-compass/src/plugin/output/mod.rs
@@ -1,3 +1,3 @@
 pub mod default;
-pub mod initial_output_ops;
 pub mod output_plugin;
+pub mod output_plugin_ops;

--- a/rust/routee-compass/src/plugin/output/output_plugin_ops.rs
+++ b/rust/routee-compass/src/plugin/output/output_plugin_ops.rs
@@ -58,6 +58,8 @@ pub fn create_initial_output(
     }
 }
 
+/// helper to return errors as JSON response objects which include the
+/// original request along with the error message
 pub fn package_error<E: ToString>(req: &Value, error: E) -> Value {
     json!({
         "request": req,


### PR DESCRIPTION
this PR modifies the signature of input plugin so that it relies on mutable semantics, like the recent changes to output plugins, in order to reduce allocations and improve runtime performance, especially for very large input sets.

Closes #124.