### PR TITLE
use indoc for error formatting

### DIFF
--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -76,7 +76,9 @@ class CompassApp:
         app = CompassAppWrapper._from_config_toml_string(toml_string, path_str)
         return cls(app)
 
-    def run(self, query: Union[Query, List[Query]], config: Optional[Dict] = None) -> Result:
+    def run(
+        self, query: Union[Query, List[Query]], config: Optional[Dict] = None
+    ) -> Result:
         """
         Run a query (or multiple queries) against the CompassApp
 

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -76,7 +76,7 @@ class CompassApp:
         app = CompassAppWrapper._from_config_toml_string(toml_string, path_str)
         return cls(app)
 
-    def run(self, query: Union[Query, List[Query]], config: Optional[Dict]) -> Result:
+    def run(self, query: Union[Query, List[Query]], config: Optional[Dict] = None) -> Result:
         """
         Run a query (or multiple queries) against the CompassApp
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,3 +28,4 @@ wkt = { version = "0.10.3", features = ["serde"] }
 config = "0.14"
 ordered-float = { version = "4.1.1", features = ["serde"] }
 allocative = "0.3.1"
+indoc = "2"

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["science", "science::geo"]
 
 [dependencies]
 routee-compass-core = { path = "../routee-compass-core", version = "0.6.1" }
-routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.6.1"}
+routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.6.1" }
 thiserror = { workspace = true }
 flate2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -42,3 +42,4 @@ clap = { version = "4.3.19", features = ["derive"] }
 itertools = { workspace = true }
 ordered-float = { workspace = true }
 allocative = { workspace = true }
+indoc = { workspace = true }

--- a/rust/routee-compass/src/app/compass/compass_app_error.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_error.rs
@@ -42,6 +42,6 @@ pub enum CompassAppError {
     MissingInputField(CompassInputField),
     #[error("error accessing shared read-only dataset: {0}")]
     ReadOnlyPoisonError(String),
-    #[error("error decoding input: {0}")]
+    #[error("error decoding input:\n{0}")]
     InvalidInput(String),
 }

--- a/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_parser.rs
+++ b/rust/routee-compass/src/app/compass/config/frontier_model/road_class/road_class_parser.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use indoc::formatdoc;
 use serde::Deserialize;
 
 use crate::app::compass::compass_app_error::CompassAppError;
@@ -23,15 +24,15 @@ impl RoadClassParser {
                     .or_else(|_| {
                         if self.mapping.is_empty() {
                             // if we don't have a road class mapping then we fail
+                            let value_string = value.to_string();
                             Err(CompassAppError::InvalidInput(
-                                String::from(
-                                    r#"
-                                    Could not parse incoming query valid road_classes as an array of integers 
+                                formatdoc! {r#"
+                                    Could not parse incoming query valid road_classes of {value_string} as an array of integers 
                                     and this FrontierModel does not specify a mapping of string to integer. 
                                     Either pass a valid array of integers or reload the application with a 
                                     mapping from string road class to integer road class.
                                     "#
-                                )
+                                }.to_string()
                             ))
                         } else {
                                 let strings =

--- a/rust/routee-compass/src/main.rs
+++ b/rust/routee-compass/src/main.rs
@@ -54,7 +54,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // scan the results and log any json values that have "error" in them
     for result in results.iter() {
         if let Some(error) = result.get("error") {
-            error!("Error: {}", error);
+            let error_string = error.to_string().replace("\\n", "\n");
+            error!("Error: {}", error_string);
         }
     }
 

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin.rs
@@ -2,7 +2,6 @@ use super::edge_rtree_record::EdgeRtreeRecord;
 use crate::{
     app::compass::config::{
         compass_configuration_error::CompassConfigurationError,
-        config_json_extension::ConfigJsonExtensions,
         frontier_model::road_class::road_class_parser::RoadClassParser,
     },
     plugin::{
@@ -34,7 +33,7 @@ impl InputPlugin for EdgeRtreeInputPlugin {
     fn process(&self, query: &mut serde_json::Value) -> Result<(), PluginError> {
         let road_classes = self.road_class_parser.read_query(query).map_err(|e| {
             PluginError::InputError(format!(
-                "Unable to process EdgeRtree Input Plugin due to: {}",
+                "Unable to apply EdgeRtree Input Plugin due to:\n\n{}",
                 e
             ))
         })?;

--- a/rust/routee-compass/src/plugin/plugin_error.rs
+++ b/rust/routee-compass/src/plugin/plugin_error.rs
@@ -10,7 +10,7 @@ pub enum PluginError {
     ParseError(String, String),
     #[error("missing field {0}")]
     MissingField(String),
-    #[error("error with parsing inputs: {0}")]
+    #[error("error with parsing query inputs:\n{0}")]
     InputError(String),
     #[error("error with building plugin")]
     BuildError,


### PR DESCRIPTION
A couple of minor updates:
 - use indoc to format the multiline error message a little nicer
 - pass the query as a mutable reference to the `package_error` function