### PR TITLE
fix state model update ordering

### DIFF
--- a/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
@@ -308,9 +308,9 @@ mod tests {
         let mut state = updated_state_model.initial_state().unwrap();
         let e1 = mock_edge(0);
         // 100 meters @ 10kph should take 36 seconds ((0.1/10) * 3600)
-        let result = model
+        model
             .traverse_edge((&v, &e1, &v), &mut state, &updated_state_model)
             .unwrap();
-        println!("{:?}", result);
+        println!("{:?}", state);
     }
 }

--- a/rust/routee-compass/src/app/search/search_app.rs
+++ b/rust/routee-compass/src/app/search/search_app.rs
@@ -163,18 +163,18 @@ impl SearchApp {
         query: &serde_json::Value,
     ) -> Result<SearchInstance, SearchError> {
         let traversal_model = self.traversal_model_service.build(query)?;
+        let state_model = Arc::new(self.state_model.extend(traversal_model.state_features())?);
         let cost_model = self
             .cost_model_service
-            .build(query, self.state_model.clone())
+            .build(query, state_model.clone())
             .map_err(|e| SearchError::BuildError(e.to_string()))?;
         let frontier_model = self
             .frontier_model_service
-            .build(query, self.state_model.clone())?;
-        let state_model = self.state_model.extend(traversal_model.state_features())?;
+            .build(query, state_model.clone())?;
 
         let search_assets = SearchInstance {
             directed_graph: self.directed_graph.clone(),
-            state_model: Arc::new(state_model),
+            state_model,
             traversal_model,
             cost_model,
             frontier_model,


### PR DESCRIPTION
this itty bitty PR feeds the updated state model into the builders for CostModel and FrontierModel instead of using the instance of the state model that does not know about TraversalModel features. flipping this ordering fixes the problem where the cost summary doesn't seem to report cost summaries for all features.

Closes #143 .