### PR TITLE
Rjf/unit create by ref

### DIFF
--- a/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
@@ -33,11 +33,11 @@ impl TraversalModel for SpeedTraversalModel {
         let distance = BASE_DISTANCE_UNIT.convert(&edge.distance, &self.engine.distance_unit);
         let speed = get_speed(&self.engine.speed_table, edge.edge_id)?;
         let edge_time = Time::create(
-            speed,
-            self.engine.speed_unit,
-            distance,
-            self.engine.distance_unit,
-            self.engine.time_unit,
+            &speed,
+            &self.engine.speed_unit,
+            &distance,
+            &self.engine.distance_unit,
+            &self.engine.time_unit,
         )?;
 
         state_model.add_time(state, "time", &edge_time, &self.engine.time_unit)?;
@@ -69,11 +69,11 @@ impl TraversalModel for SpeedTraversalModel {
         }
 
         let estimated_time = Time::create(
-            self.engine.max_speed,
-            self.engine.speed_unit,
-            distance,
-            self.engine.distance_unit,
-            self.engine.time_unit,
+            &self.engine.max_speed,
+            &self.engine.speed_unit,
+            &distance,
+            &self.engine.distance_unit,
+            &self.engine.time_unit,
         )?;
         state_model.add_time(state, "time", &estimated_time, &self.engine.time_unit)?;
 

--- a/rust/routee-compass-core/src/model/unit/builders.rs
+++ b/rust/routee-compass-core/src/model/unit/builders.rs
@@ -18,24 +18,24 @@ pub const BASE_SPEED_UNIT: SpeedUnit = SpeedUnit::MetersPerSecond;
 /// base units. performs the division operation to get time and converts to the target
 /// time unit.
 pub fn create_time(
-    speed: Speed,
-    speed_unit: SpeedUnit,
-    distance: Distance,
-    distance_unit: DistanceUnit,
-    time_unit: TimeUnit,
+    speed: &Speed,
+    speed_unit: &SpeedUnit,
+    distance: &Distance,
+    distance_unit: &DistanceUnit,
+    time_unit: &TimeUnit,
 ) -> Result<Time, UnitError> {
-    let d = distance_unit.convert(&distance, &BASE_DISTANCE_UNIT);
-    let s = speed_unit.convert(speed, BASE_SPEED_UNIT);
+    let d = distance_unit.convert(distance, &BASE_DISTANCE_UNIT);
+    let s = speed_unit.convert(speed, &BASE_SPEED_UNIT);
     if s <= Speed::ZERO || d <= Distance::ZERO {
         Err(UnitError::TimeFromSpeedAndDistanceError(
-            speed,
-            speed_unit,
-            distance,
-            distance_unit,
+            *speed,
+            *speed_unit,
+            *distance,
+            *distance_unit,
         ))
     } else {
         let time = (d, s).into();
-        let result = BASE_TIME_UNIT.convert(&time, &time_unit);
+        let result = BASE_TIME_UNIT.convert(&time, time_unit);
         Ok(result)
     }
 }
@@ -45,19 +45,19 @@ pub fn create_time(
 /// base units. performs the division operation to get speed and converts to the target
 /// speed unit.
 pub fn create_speed(
-    time: Time,
-    time_unit: TimeUnit,
-    distance: Distance,
-    distance_unit: DistanceUnit,
-    speed_unit: SpeedUnit,
+    time: &Time,
+    time_unit: &TimeUnit,
+    distance: &Distance,
+    distance_unit: &DistanceUnit,
+    speed_unit: &SpeedUnit,
 ) -> Result<Speed, UnitError> {
-    let d = distance_unit.convert(&distance, &BASE_DISTANCE_UNIT);
-    let t = time_unit.convert(&time, &BASE_TIME_UNIT);
+    let d = distance_unit.convert(distance, &BASE_DISTANCE_UNIT);
+    let t = time_unit.convert(time, &BASE_TIME_UNIT);
     if t <= Time::ZERO {
-        Err(UnitError::SpeedFromTimeAndDistanceError(time, distance))
+        Err(UnitError::SpeedFromTimeAndDistanceError(*time, *distance))
     } else {
         let speed = (d, t).into();
-        let result = BASE_SPEED_UNIT.convert(speed, speed_unit);
+        let result = BASE_SPEED_UNIT.convert(&speed, speed_unit);
         Ok(result)
     }
 }
@@ -65,17 +65,17 @@ pub fn create_speed(
 /// calculates an energy value based on some energy rate and distance.
 /// the resulting energy unit is based on the energy rate unit provided.
 pub fn create_energy(
-    energy_rate: EnergyRate,
-    energy_rate_unit: EnergyRateUnit,
-    distance: Distance,
-    distance_unit: DistanceUnit,
+    energy_rate: &EnergyRate,
+    energy_rate_unit: &EnergyRateUnit,
+    distance: &Distance,
+    distance_unit: &DistanceUnit,
 ) -> Result<(Energy, EnergyUnit), UnitError> {
     // we don't make a conversion to a base energy unit here, since that's non-sensical for some unit types
     // instead, we rely on the associated units to direct our calculation.
     let rate_distance_unit = energy_rate_unit.associated_distance_unit();
     let energy_unit = energy_rate_unit.associated_energy_unit();
-    let calc_distance = distance_unit.convert(&distance, &rate_distance_unit);
-    let energy = (energy_rate, calc_distance).into();
+    let calc_distance = distance_unit.convert(distance, &rate_distance_unit);
+    let energy = (*energy_rate, calc_distance).into();
     Ok((energy, energy_unit))
 }
 
@@ -127,11 +127,11 @@ mod test {
     #[test]
     fn test_speed_calculate_fails() {
         let failure = create_speed(
-            Time::ZERO,
-            TimeUnit::Seconds,
-            Distance::ONE,
-            DistanceUnit::Meters,
-            SpeedUnit::MetersPerSecond,
+            &Time::ZERO,
+            &TimeUnit::Seconds,
+            &Distance::ONE,
+            &DistanceUnit::Meters,
+            &SpeedUnit::MetersPerSecond,
         );
         assert!(failure.is_err());
     }
@@ -139,11 +139,11 @@ mod test {
     #[test]
     fn test_speed_calculate_idempotent() {
         let one_mps = create_speed(
-            Time::ONE,
-            TimeUnit::Seconds,
-            Distance::ONE,
-            DistanceUnit::Meters,
-            SpeedUnit::MetersPerSecond,
+            &Time::ONE,
+            &TimeUnit::Seconds,
+            &Distance::ONE,
+            &DistanceUnit::Meters,
+            &SpeedUnit::MetersPerSecond,
         )
         .unwrap();
         assert_eq!(Speed::ONE, one_mps);
@@ -152,11 +152,11 @@ mod test {
     #[test]
     fn test_speed_calculate_imperial_to_si() {
         let speed_kph = create_speed(
-            Time::ONE,
-            TimeUnit::Hours,
-            Distance::ONE,
-            DistanceUnit::Miles,
-            SpeedUnit::KilometersPerHour,
+            &Time::ONE,
+            &TimeUnit::Hours,
+            &Distance::ONE,
+            &DistanceUnit::Miles,
+            &SpeedUnit::KilometersPerHour,
         )
         .unwrap();
         approx_eq_speed(Speed::new(1.60934), speed_kph, 0.001);
@@ -165,67 +165,68 @@ mod test {
     #[test]
     fn test_speed_calculate_kph_to_base() {
         let speed_kph = create_speed(
-            Time::ONE,
-            TimeUnit::Hours,
-            Distance::ONE,
-            DistanceUnit::Kilometers,
-            BASE_SPEED_UNIT,
+            &Time::ONE,
+            &TimeUnit::Hours,
+            &Distance::ONE,
+            &DistanceUnit::Kilometers,
+            &BASE_SPEED_UNIT,
         )
         .unwrap();
-        let expected = SpeedUnit::KilometersPerHour.convert(Speed::ONE, BASE_SPEED_UNIT);
+        let expected = SpeedUnit::KilometersPerHour.convert(&Speed::ONE, &BASE_SPEED_UNIT);
         approx_eq_speed(speed_kph, expected, 0.001);
     }
 
     #[test]
     fn test_speed_calculate_base_to_kph() {
         let speed_kph = create_speed(
-            Time::ONE,
-            BASE_TIME_UNIT,
-            Distance::ONE,
-            BASE_DISTANCE_UNIT,
-            SpeedUnit::KilometersPerHour,
+            &Time::ONE,
+            &BASE_TIME_UNIT,
+            &Distance::ONE,
+            &BASE_DISTANCE_UNIT,
+            &SpeedUnit::KilometersPerHour,
         )
         .unwrap();
-        let expected = SpeedUnit::MetersPerSecond.convert(Speed::ONE, SpeedUnit::KilometersPerHour);
+        let expected =
+            SpeedUnit::MetersPerSecond.convert(&Speed::ONE, &SpeedUnit::KilometersPerHour);
         approx_eq_speed(speed_kph, expected, 0.001);
     }
 
     #[test]
     fn test_speed_calculate_mph_to_base() {
         let speed_kph = create_speed(
-            Time::ONE,
-            TimeUnit::Hours,
-            Distance::ONE,
-            DistanceUnit::Miles,
-            BASE_SPEED_UNIT,
+            &Time::ONE,
+            &TimeUnit::Hours,
+            &Distance::ONE,
+            &DistanceUnit::Miles,
+            &BASE_SPEED_UNIT,
         )
         .unwrap();
-        let expected = SpeedUnit::MilesPerHour.convert(Speed::ONE, BASE_SPEED_UNIT);
+        let expected = SpeedUnit::MilesPerHour.convert(&Speed::ONE, &BASE_SPEED_UNIT);
         approx_eq_speed(speed_kph, expected, 0.001);
     }
 
     #[test]
     fn test_speed_calculate_base_to_mph() {
         let speed_kph = create_speed(
-            Time::ONE,
-            BASE_TIME_UNIT,
-            Distance::ONE,
-            BASE_DISTANCE_UNIT,
-            SpeedUnit::MilesPerHour,
+            &Time::ONE,
+            &BASE_TIME_UNIT,
+            &Distance::ONE,
+            &BASE_DISTANCE_UNIT,
+            &SpeedUnit::MilesPerHour,
         )
         .unwrap();
-        let expected = SpeedUnit::MetersPerSecond.convert(Speed::ONE, SpeedUnit::MilesPerHour);
+        let expected = SpeedUnit::MetersPerSecond.convert(&Speed::ONE, &SpeedUnit::MilesPerHour);
         approx_eq_speed(speed_kph, expected, 0.001);
     }
 
     #[test]
     fn test_time_calculate_fails() {
         let failure = create_time(
-            Speed::ZERO,
-            SpeedUnit::KilometersPerHour,
-            Distance::ONE,
-            DistanceUnit::Meters,
-            BASE_TIME_UNIT,
+            &Speed::ZERO,
+            &SpeedUnit::KilometersPerHour,
+            &Distance::ONE,
+            &DistanceUnit::Meters,
+            &BASE_TIME_UNIT,
         );
         assert!(failure.is_err());
     }
@@ -233,11 +234,11 @@ mod test {
     #[test]
     fn test_time_calculate_idempotent() {
         let one_sec = create_time(
-            Speed::ONE,
-            SpeedUnit::MetersPerSecond,
-            Distance::ONE,
-            DistanceUnit::Meters,
-            BASE_TIME_UNIT,
+            &Speed::ONE,
+            &SpeedUnit::MetersPerSecond,
+            &Distance::ONE,
+            &DistanceUnit::Meters,
+            &BASE_TIME_UNIT,
         )
         .unwrap();
         assert_eq!(Time::ONE, one_sec);
@@ -246,11 +247,11 @@ mod test {
     #[test]
     fn test_time_calculate_kph_to_base() {
         let time = create_time(
-            Speed::ONE,
-            SpeedUnit::KilometersPerHour,
-            Distance::ONE,
-            DistanceUnit::Kilometers,
-            BASE_TIME_UNIT,
+            &Speed::ONE,
+            &SpeedUnit::KilometersPerHour,
+            &Distance::ONE,
+            &DistanceUnit::Kilometers,
+            &BASE_TIME_UNIT,
         )
         .unwrap();
         let expected = TimeUnit::Hours.convert(&Time::ONE, &BASE_TIME_UNIT);
@@ -260,11 +261,11 @@ mod test {
     #[test]
     fn test_time_calculate_base_to_kph() {
         let time = create_time(
-            Speed::ONE,
-            BASE_SPEED_UNIT,
-            Distance::ONE,
-            BASE_DISTANCE_UNIT,
-            TimeUnit::Hours,
+            &Speed::ONE,
+            &BASE_SPEED_UNIT,
+            &Distance::ONE,
+            &BASE_DISTANCE_UNIT,
+            &TimeUnit::Hours,
         )
         .unwrap();
         let expected = BASE_TIME_UNIT.convert(&Time::ONE, &TimeUnit::Hours);
@@ -274,11 +275,11 @@ mod test {
     #[test]
     fn test_time_calculate_mph_to_base() {
         let time = create_time(
-            Speed::ONE,
-            SpeedUnit::MilesPerHour,
-            Distance::ONE,
-            DistanceUnit::Miles,
-            BASE_TIME_UNIT,
+            &&Speed::ONE,
+            &&SpeedUnit::MilesPerHour,
+            &&Distance::ONE,
+            &&DistanceUnit::Miles,
+            &&BASE_TIME_UNIT,
         )
         .unwrap();
         let expected = TimeUnit::Hours.convert(&Time::ONE, &BASE_TIME_UNIT);
@@ -288,11 +289,11 @@ mod test {
     #[test]
     fn test_time_calculate_base_to_mph() {
         let time = create_time(
-            Speed::ONE,
-            BASE_SPEED_UNIT,
-            Distance::ONE,
-            BASE_DISTANCE_UNIT,
-            TimeUnit::Hours,
+            &Speed::ONE,
+            &BASE_SPEED_UNIT,
+            &Distance::ONE,
+            &BASE_DISTANCE_UNIT,
+            &TimeUnit::Hours,
         )
         .unwrap();
         let expected = BASE_TIME_UNIT.convert(&Time::ONE, &TimeUnit::Hours);
@@ -303,10 +304,10 @@ mod test {
     fn test_energy_ggpm_meters() {
         let ten_mpg_rate = 1.0 / 10.0;
         let (energy, energy_unit) = create_energy(
-            EnergyRate::new(ten_mpg_rate),
-            EnergyRateUnit::GallonsGasolinePerMile,
-            Distance::new(1609.0),
-            DistanceUnit::Meters,
+            &EnergyRate::new(ten_mpg_rate),
+            &EnergyRateUnit::GallonsGasolinePerMile,
+            &Distance::new(1609.0),
+            &DistanceUnit::Meters,
         )
         .unwrap();
         approx_eq_energy(energy, Energy::new(ten_mpg_rate), 0.00001);
@@ -317,10 +318,10 @@ mod test {
     fn test_energy_ggpm_miles() {
         let ten_mpg_rate = 1.0 / 10.0;
         let (energy, energy_unit) = create_energy(
-            EnergyRate::new(ten_mpg_rate),
-            EnergyRateUnit::GallonsGasolinePerMile,
-            Distance::new(1.0),
-            DistanceUnit::Miles,
+            &EnergyRate::new(ten_mpg_rate),
+            &EnergyRateUnit::GallonsGasolinePerMile,
+            &Distance::new(1.0),
+            &DistanceUnit::Miles,
         )
         .unwrap();
         approx_eq_energy(energy, Energy::new(ten_mpg_rate), 0.00001);

--- a/rust/routee-compass-core/src/model/unit/builders.rs
+++ b/rust/routee-compass-core/src/model/unit/builders.rs
@@ -275,11 +275,11 @@ mod test {
     #[test]
     fn test_time_calculate_mph_to_base() {
         let time = create_time(
-            &&Speed::ONE,
-            &&SpeedUnit::MilesPerHour,
-            &&Distance::ONE,
-            &&DistanceUnit::Miles,
-            &&BASE_TIME_UNIT,
+            &Speed::ONE,
+            &SpeedUnit::MilesPerHour,
+            &Distance::ONE,
+            &DistanceUnit::Miles,
+            &BASE_TIME_UNIT,
         )
         .unwrap();
         let expected = TimeUnit::Hours.convert(&Time::ONE, &BASE_TIME_UNIT);

--- a/rust/routee-compass-core/src/model/unit/energy.rs
+++ b/rust/routee-compass-core/src/model/unit/energy.rs
@@ -71,10 +71,10 @@ impl Energy {
         Energy(InternalFloat::new(value))
     }
     pub fn create(
-        energy_rate: EnergyRate,
-        energy_rate_unit: EnergyRateUnit,
-        distance: Distance,
-        distance_unit: DistanceUnit,
+        energy_rate: &EnergyRate,
+        energy_rate_unit: &EnergyRateUnit,
+        distance: &Distance,
+        distance_unit: &DistanceUnit,
     ) -> Result<(Energy, EnergyUnit), UnitError> {
         create_energy(energy_rate, energy_rate_unit, distance, distance_unit)
     }

--- a/rust/routee-compass-core/src/model/unit/grade_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/grade_unit.rs
@@ -12,18 +12,18 @@ pub enum GradeUnit {
 }
 
 impl GradeUnit {
-    pub fn convert(&self, value: Grade, target: GradeUnit) -> Grade {
+    pub fn convert(&self, value: &Grade, target: &GradeUnit) -> Grade {
         use GradeUnit as G;
         match (self, target) {
-            (G::Percent, G::Percent) => value,
-            (G::Decimal, G::Decimal) => value,
-            (G::Millis, G::Millis) => value,
-            (G::Percent, G::Decimal) => value / 100.0,
-            (G::Percent, G::Millis) => value * 10.0,
-            (G::Decimal, G::Percent) => value * 100.0,
-            (G::Decimal, G::Millis) => value * 1000.0,
-            (G::Millis, G::Percent) => value / 10.0,
-            (G::Millis, G::Decimal) => value / 1000.0,
+            (G::Percent, G::Percent) => *value,
+            (G::Decimal, G::Decimal) => *value,
+            (G::Millis, G::Millis) => *value,
+            (G::Percent, G::Decimal) => *value / 100.0,
+            (G::Percent, G::Millis) => *value * 10.0,
+            (G::Decimal, G::Percent) => *value * 100.0,
+            (G::Decimal, G::Millis) => *value * 1000.0,
+            (G::Millis, G::Percent) => *value / 10.0,
+            (G::Millis, G::Decimal) => *value / 1000.0,
         }
     }
 }
@@ -69,32 +69,32 @@ mod test {
     #[test]
     fn test_conversions() {
         assert_approx_eq(
-            G::Percent.convert(Grade::new(10.0), G::Decimal),
+            G::Percent.convert(&Grade::new(10.0), &G::Decimal),
             Grade::new(0.1),
             0.001,
         );
         assert_approx_eq(
-            G::Percent.convert(Grade::new(10.0), G::Millis),
+            G::Percent.convert(&Grade::new(10.0), &G::Millis),
             Grade::new(100.0),
             0.001,
         );
         assert_approx_eq(
-            G::Decimal.convert(Grade::new(0.1), G::Percent),
+            G::Decimal.convert(&Grade::new(0.1), &G::Percent),
             Grade::new(10.0),
             0.001,
         );
         assert_approx_eq(
-            G::Decimal.convert(Grade::new(0.1), G::Millis),
+            G::Decimal.convert(&Grade::new(0.1), &G::Millis),
             Grade::new(100.0),
             0.001,
         );
         assert_approx_eq(
-            G::Millis.convert(Grade::new(100.0), G::Percent),
+            G::Millis.convert(&Grade::new(100.0), &G::Percent),
             Grade::new(10.0),
             0.001,
         );
         assert_approx_eq(
-            G::Millis.convert(Grade::new(100.0), G::Decimal),
+            G::Millis.convert(&Grade::new(100.0), &G::Decimal),
             Grade::new(0.1),
             0.001,
         );

--- a/rust/routee-compass-core/src/model/unit/speed.rs
+++ b/rust/routee-compass-core/src/model/unit/speed.rs
@@ -82,11 +82,11 @@ impl Speed {
         Speed(InternalFloat::new(value))
     }
     pub fn create(
-        time: Time,
-        time_unit: TimeUnit,
-        distance: Distance,
-        distance_unit: DistanceUnit,
-        speed_unit: SpeedUnit,
+        time: &Time,
+        time_unit: &TimeUnit,
+        distance: &Distance,
+        distance_unit: &DistanceUnit,
+        speed_unit: &SpeedUnit,
     ) -> Result<Speed, UnitError> {
         builders::create_speed(time, time_unit, distance, distance_unit, speed_unit)
     }

--- a/rust/routee-compass-core/src/model/unit/speed_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/speed_unit.rs
@@ -73,18 +73,18 @@ impl SpeedUnit {
     }
 
     /// converts a value from the current speed unit to some target speed unit.
-    pub fn convert(&self, value: Speed, target: SpeedUnit) -> Speed {
+    pub fn convert(&self, value: &Speed, target: &SpeedUnit) -> Speed {
         use SpeedUnit as S;
         match (self, target) {
-            (S::KilometersPerHour, S::KilometersPerHour) => value,
-            (S::KilometersPerHour, S::MilesPerHour) => value * 0.621371,
-            (S::KilometersPerHour, S::MetersPerSecond) => value * 0.2777777778,
-            (S::MilesPerHour, S::KilometersPerHour) => value * 1.60934,
-            (S::MilesPerHour, S::MilesPerHour) => value,
-            (S::MilesPerHour, S::MetersPerSecond) => value * 0.44704,
-            (S::MetersPerSecond, S::KilometersPerHour) => value * 3.6,
-            (S::MetersPerSecond, S::MilesPerHour) => value * 2.237,
-            (S::MetersPerSecond, S::MetersPerSecond) => value,
+            (S::KilometersPerHour, S::KilometersPerHour) => *value,
+            (S::KilometersPerHour, S::MilesPerHour) => *value * 0.621371,
+            (S::KilometersPerHour, S::MetersPerSecond) => *value * 0.2777777778,
+            (S::MilesPerHour, S::KilometersPerHour) => *value * 1.60934,
+            (S::MilesPerHour, S::MilesPerHour) => *value,
+            (S::MilesPerHour, S::MetersPerSecond) => *value * 0.44704,
+            (S::MetersPerSecond, S::KilometersPerHour) => *value * 3.6,
+            (S::MetersPerSecond, S::MilesPerHour) => *value * 2.237,
+            (S::MetersPerSecond, S::MetersPerSecond) => *value,
         }
     }
 
@@ -120,47 +120,47 @@ mod test {
     #[test]
     fn test_conversions() {
         assert_approx_eq(
-            S::KilometersPerHour.convert(Speed::ONE, S::KilometersPerHour),
+            S::KilometersPerHour.convert(&Speed::ONE, &S::KilometersPerHour),
             Speed::ONE,
             0.001,
         );
         assert_approx_eq(
-            S::KilometersPerHour.convert(Speed::ONE, S::MilesPerHour),
+            S::KilometersPerHour.convert(&Speed::ONE, &S::MilesPerHour),
             Speed::new(0.6215040398),
             0.001,
         );
         assert_approx_eq(
-            S::KilometersPerHour.convert(Speed::ONE, S::MetersPerSecond),
+            S::KilometersPerHour.convert(&Speed::ONE, &S::MetersPerSecond),
             Speed::new(0.277778),
             0.001,
         );
         assert_approx_eq(
-            S::MilesPerHour.convert(Speed::ONE, S::KilometersPerHour),
+            S::MilesPerHour.convert(&Speed::ONE, &S::KilometersPerHour),
             Speed::new(1.60934),
             0.001,
         );
         assert_approx_eq(
-            S::MilesPerHour.convert(Speed::ONE, S::MilesPerHour),
+            S::MilesPerHour.convert(&Speed::ONE, &S::MilesPerHour),
             Speed::ONE,
             0.001,
         );
         assert_approx_eq(
-            S::MilesPerHour.convert(Speed::ONE, S::MetersPerSecond),
+            S::MilesPerHour.convert(&Speed::ONE, &S::MetersPerSecond),
             Speed::new(0.44704),
             0.001,
         );
         assert_approx_eq(
-            S::MetersPerSecond.convert(Speed::ONE, S::KilometersPerHour),
+            S::MetersPerSecond.convert(&Speed::ONE, &S::KilometersPerHour),
             Speed::new(3.6),
             0.001,
         );
         assert_approx_eq(
-            S::MetersPerSecond.convert(Speed::ONE, S::MilesPerHour),
+            S::MetersPerSecond.convert(&Speed::ONE, &S::MilesPerHour),
             Speed::new(2.23694),
             0.001,
         );
         assert_approx_eq(
-            S::MetersPerSecond.convert(Speed::ONE, S::MetersPerSecond),
+            S::MetersPerSecond.convert(&Speed::ONE, &S::MetersPerSecond),
             Speed::ONE,
             0.001,
         );

--- a/rust/routee-compass-core/src/model/unit/time.rs
+++ b/rust/routee-compass-core/src/model/unit/time.rs
@@ -71,11 +71,11 @@ impl Time {
         Time(InternalFloat::new(value))
     }
     pub fn create(
-        speed: Speed,
-        speed_unit: SpeedUnit,
-        distance: Distance,
-        distance_unit: DistanceUnit,
-        time_unit: TimeUnit,
+        speed: &Speed,
+        speed_unit: &SpeedUnit,
+        distance: &Distance,
+        distance_unit: &DistanceUnit,
+        time_unit: &TimeUnit,
     ) -> Result<Time, UnitError> {
         builders::create_time(speed, speed_unit, distance, distance_unit, time_unit)
     }

--- a/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/interpolation/interpolation_speed_grade_model.rs
@@ -29,8 +29,8 @@ impl PredictionModel for InterpolationSpeedGradeModel {
     ) -> Result<(EnergyRate, EnergyRateUnit), TraversalModelError> {
         let (speed, speed_unit) = speed;
         let (grade, grade_unit) = grade;
-        let speed_value = speed_unit.convert(speed, self.speed_unit).as_f64();
-        let grade_value = grade_unit.convert(grade, self.grade_unit).as_f64();
+        let speed_value = speed_unit.convert(&speed, &self.speed_unit).as_f64();
+        let grade_value = grade_unit.convert(&grade, &self.grade_unit).as_f64();
 
         // snap incoming speed and grade to the grid
         let min_speed = self.interpolator.x[0].0;

--- a/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_record.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/prediction_model_record.rs
@@ -55,10 +55,10 @@ impl PredictionModelRecord {
         let energy_rate_real_world = energy_rate * self.real_world_energy_adjustment;
 
         let (energy, energy_unit) = Energy::create(
-            energy_rate_real_world,
-            self.energy_rate_unit,
-            distance,
-            distance_unit,
+            &energy_rate_real_world,
+            &self.energy_rate_unit,
+            &distance,
+            &distance_unit,
         )?;
 
         Ok((energy, energy_unit))

--- a/rust/routee-compass-powertrain/src/routee/prediction/smartcore/smartcore_speed_grade_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/prediction/smartcore/smartcore_speed_grade_model.rs
@@ -24,8 +24,8 @@ impl PredictionModel for SmartcoreSpeedGradeModel {
     ) -> Result<(EnergyRate, EnergyRateUnit), TraversalModelError> {
         let (speed, speed_unit) = speed;
         let (grade, grade_unit) = grade;
-        let speed_value = speed_unit.convert(speed, self.speed_unit).as_f64();
-        let grade_value = grade_unit.convert(grade, self.grade_unit).as_f64();
+        let speed_value = speed_unit.convert(&speed, &self.speed_unit).as_f64();
+        let grade_value = grade_unit.convert(&grade, &self.grade_unit).as_f64();
         let x = DenseMatrix::from_2d_vec(&vec![vec![speed_value, grade_value]]);
         let y = self
             .rf

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -80,10 +80,10 @@ impl VehicleType for BEV {
         let (distance, distance_unit) = distance;
 
         let energy = Energy::create(
-            self.prediction_model_record.ideal_energy_rate,
-            self.prediction_model_record.energy_rate_unit,
-            distance,
-            distance_unit,
+            &self.prediction_model_record.ideal_energy_rate,
+            &self.prediction_model_record.energy_rate_unit,
+            &distance,
+            &distance_unit,
         )?;
 
         Ok(energy)

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/ice.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/ice.rs
@@ -47,10 +47,10 @@ impl VehicleType for ICE {
     ) -> Result<(Energy, EnergyUnit), TraversalModelError> {
         let (distance, distance_unit) = distance;
         let energy = Energy::create(
-            self.prediction_model_record.ideal_energy_rate,
-            self.prediction_model_record.energy_rate_unit,
-            distance,
-            distance_unit,
+            &self.prediction_model_record.ideal_energy_rate,
+            &self.prediction_model_record.energy_rate_unit,
+            &distance,
+            &distance_unit,
         )?;
         Ok(energy)
     }

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
@@ -99,10 +99,10 @@ impl VehicleType for PHEV {
 
         // assume lowest energy cost scenario for a PHEV is to just use the battery
         let energy = Energy::create(
-            self.charge_depleting_model.ideal_energy_rate,
-            self.charge_depleting_model.energy_rate_unit,
-            distance,
-            distance_unit,
+            &self.charge_depleting_model.ideal_energy_rate,
+            &self.charge_depleting_model.energy_rate_unit,
+            &distance,
+            &distance_unit,
         )?;
         Ok(energy)
     }


### PR DESCRIPTION
this PR makes it so any units functions take references to their arguments instead of pass-by-value semantics, which should reduce a bunch of unnecessary allocations in our core floating point operations.

still, looking at the bottom of the call stack at the code in routee-compass/src/model/unit/builders.rs, i'm not convinced that we have made these operations as fast as they can be. some additional work could be done to ensure we're not allocating temp objects and perhaps bypassing a conversion to the base units too.