### PR TITLE
Rjf/output name collisions

### DIFF
--- a/rust/routee-compass-core/src/model/cost/cost_error.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_error.rs
@@ -13,7 +13,7 @@ pub enum CostError {
     StateVariableNotFound(String, String, String),
     #[error("index {0} for state variable {1} out of bounds, not found in traversal state")]
     StateIndexOutOfBounds(usize, String),
-    #[error("index {0} for {1} state vectori is out of bounds")]
+    #[error("index {0} for {1} state vector is out of bounds")]
     CostVectorOutOfBounds(usize, String),
     #[error("invalid cost variables, sum of state variable coefficients must be non-zero")]
     InvalidCostVariables,

--- a/rust/routee-compass-core/src/model/state/state_model.rs
+++ b/rust/routee-compass-core/src/model/state/state_model.rs
@@ -502,6 +502,13 @@ impl StateModel {
         self.update_state(state, name, &encoded_value, UpdateOperation::Replace)
     }
 
+    /// uses the state model to pretty print a state instance as a JSON object
+    ///
+    /// # Arguments
+    /// * `state` - any (valid) state vector instance
+    ///
+    /// # Result
+    /// A JSON object representation of that vector
     pub fn serialize_state(&self, state: &[StateVar]) -> serde_json::Value {
         let output = self
             .iter()
@@ -511,19 +518,9 @@ impl StateModel {
         json![output]
     }
 
+    /// uses the built-in serialization codec to output the state model representation as a JSON object
     pub fn serialize_state_model(&self) -> serde_json::Value {
         json![self.iter().collect::<HashMap<_, _>>()]
-    }
-
-    pub fn serialize_state_and_model(&self, state: &[StateVar]) -> serde_json::Value {
-        let mut summary = self.serialize_state(state);
-        if let serde_json::Value::Object(m) = self.serialize_state_model() {
-            for (k, v) in m.into_iter() {
-                summary[k] = v;
-            }
-        }
-
-        summary
     }
 }
 

--- a/rust/routee-compass/src/plugin/output/output_plugin_ops.rs
+++ b/rust/routee-compass/src/plugin/output/output_plugin_ops.rs
@@ -28,15 +28,16 @@ pub fn create_initial_output(
             // build and append summaries if there is a route
             if let Some(et) = route.last() {
                 // build instances of traversal and cost models to compute summaries
-                // let t = get_traversal_model(et, req, app)?;
-                // let c = get_cost_model(et, req, app, t.clone())?;
-                init_output["traversal_summary"] =
-                    si.state_model.serialize_state_and_model(&et.result_state);
-                let cost_summary = match si.cost_model.serialize_cost_with_info(&et.result_state) {
-                    Ok(summary) => summary,
-                    Err(e) => return Err(package_error(req, e)),
-                };
-                init_output["cost_summary"] = cost_summary;
+                init_output["traversal_summary"] = si.state_model.serialize_state(&et.result_state);
+                init_output["state_model"] = si.state_model.serialize_state_model();
+                init_output["cost"] = si
+                    .cost_model
+                    .serialize_cost(&et.result_state)
+                    .map_err(|e| package_error(req, e))?;
+                init_output["cost_model"] = si
+                    .cost_model
+                    .serialize_cost_info()
+                    .map_err(|e| package_error(req, e))?;
             }
 
             // append the runtime required to compute these summaries


### PR DESCRIPTION
this PR changes how cost + state outputs are added to the output object. the state model and traversal summary were both using the feature names as keys, causing a key collision. to fix this and improve readability, the values and info sections were unbundled for both cost and state:

```json
{
  "cost": {},
  "cost_model": {},
  "traversal_summary": {},
  "state_model": {}
}
```

additionally, the cost model output was changed from a struct of vecs to nested structs so that all information related to a single feature is organized.

Closes #141.