### PR TITLE
incoming grade unit required

### DIFF
--- a/rust/routee-compass-powertrain/src/routee/energy_model_service.rs
+++ b/rust/routee-compass-powertrain/src/routee/energy_model_service.rs
@@ -29,7 +29,7 @@ impl EnergyModelService {
         time_model_service: Arc<dyn TraversalModelService>,
         time_model_speed_unit: SpeedUnit,
         grade_table_path_option: &Option<P>,
-        grade_table_grade_unit_option: Option<GradeUnit>,
+        grade_table_grade_unit: GradeUnit,
         output_time_unit_option: Option<TimeUnit>,
         output_distance_unit_option: Option<DistanceUnit>,
         vehicle_library: HashMap<String, Arc<dyn VehicleType>>,
@@ -46,7 +46,6 @@ impl EnergyModelService {
             )),
             None => Arc::new(None),
         };
-        let grade_table_grade_unit = grade_table_grade_unit_option.unwrap_or(GradeUnit::Decimal);
 
         let headings_table: Arc<Option<Box<[EdgeHeading]>>> = match headings_table_path {
             Some(headings_path) => {

--- a/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
+++ b/rust/routee-compass-powertrain/src/routee/energy_traversal_model.rs
@@ -314,7 +314,7 @@ mod tests {
             // &speed_file_path,
             &Some(grade_file_path),
             // SpeedUnit::KilometersPerHour,
-            Some(GradeUnit::Millis),
+            GradeUnit::Millis,
             None,
             None,
             model_library,

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
@@ -54,8 +54,8 @@ impl TraversalModelBuilder for EnergyModelBuilder {
         let grade_table_path_option = params
             .get_config_path_optional(&"grade_table_input_file", &parent_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
-        let grade_table_grade_unit_option = params
-            .get_config_serde_optional::<GradeUnit>(&"graph_grade_unit", &parent_key)
+        let grade_table_grade_unit = params
+            .get_config_serde::<GradeUnit>(&"grade_table_grade_unit", &parent_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let vehicle_configs = params
@@ -92,7 +92,7 @@ impl TraversalModelBuilder for EnergyModelBuilder {
             time_model_service,
             time_model_speed_unit,
             &grade_table_path_option,
-            grade_table_grade_unit_option,
+            grade_table_grade_unit,
             time_unit_option,
             distance_unit_option,
             vehicle_library,


### PR DESCRIPTION
Update the expected key for the incoming energy model grade units to match the existing format. Also makes the grade unit a required attribute so it doesn't default to something unexpected. 