### PR TITLE
remove deprecated key

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -72,7 +72,6 @@ grade_table_input_file = "edges-grade-enumerated.txt.gz"
 grade_table_grade_unit = "decimal"
 time_unit = "minutes"
 distance_unit = "miles"
-headings_table_input_file = "edges-headings-enumerated.txt.gz"
 
 [traversal.time_model]
 type = "speed_table"


### PR DESCRIPTION
ugh, one more quick fix, forgot to remove the headings file key from the energy model (and, it blows up when the path normalization function tries to normalize it)