### PR TITLE
remove default state from config

### DIFF
--- a/rust/routee-compass/src/app/compass/config.default.toml
+++ b/rust/routee-compass/src/app/compass/config.default.toml
@@ -11,9 +11,6 @@ type = "no_output"
 # filename = "output.json"
 # format = { type = "json", newline_delimited = true }
 
-[state]
-distance = { distance_unit = "kilometers", initial = 0.0 }
-
 [graph]
 verbose = true
 


### PR DESCRIPTION
Now that traversal models are declaring their state, we should remove the state entry from the default config file.