### PR TITLE
allow multi line strings for plotting routes

### DIFF
--- a/python/nrel/routee/compass/plot/plot_folium.py
+++ b/python/nrel/routee/compass/plot/plot_folium.py
@@ -72,7 +72,12 @@ def plot_route_folium(
     else:
         raise ValueError("Could not parse route geometry")
 
-    coords = [(lat, lon) for lon, lat in linestring.coords]
+    if isinstance(linestring, shapely.geometry.MultiLineString):
+        coords = []
+        for line in linestring.geoms:
+            coords.extend([(lat, lon) for lon, lat in line.coords])
+    else:
+        coords = [(lat, lon) for lon, lat in linestring.coords]
 
     if folium_map is None:
         mid = coords[int(len(coords) / 2)]


### PR DESCRIPTION
Just a small fix to allow the plotting function to take in a multi-linestring object from the resulting route. Even though we do a line merge on all the incoming route geojson objects, it's still possible that the merge will return a multi-linestring (the particular case where I found this was an exit ramp that loops under the highway). This will just plot all the linestrings in a multi-linestring if that's what we get. 