### PR TITLE
flush file sink per optional config parameter

### DIFF
--- a/rust/routee-compass/src/app/compass/response/response_output_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_policy.rs
@@ -1,5 +1,5 @@
 use super::{response_output_format::ResponseOutputFormat, response_sink::ResponseSink};
-use crate::app::compass::compass_app_error::CompassAppError;
+use crate::app::compass::{compass_app::CompassApp, compass_app_error::CompassAppError};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::OpenOptions,
@@ -14,6 +14,7 @@ pub enum ResponseOutputPolicy {
     File {
         filename: String,
         format: ResponseOutputFormat,
+        file_flush_rate: Option<i64>,
     },
     Combined {
         policies: Vec<Box<ResponseOutputPolicy>>,
@@ -27,7 +28,11 @@ impl ResponseOutputPolicy {
     pub fn build(&self) -> Result<ResponseSink, CompassAppError> {
         match self {
             ResponseOutputPolicy::None => Ok(ResponseSink::None),
-            ResponseOutputPolicy::File { filename, format } => {
+            ResponseOutputPolicy::File {
+                filename,
+                format,
+                file_flush_rate,
+            } => {
                 let output_file_path = PathBuf::from(filename);
 
                 // initialize the file
@@ -42,11 +47,24 @@ impl ResponseOutputPolicy {
                 // wrap the file in a mutex so we can share it between threads
                 let file_shareable = Arc::new(Mutex::new(file));
 
+                let iterations_per_flush = match file_flush_rate {
+                    Some(rate) if *rate <= 0 => Err(CompassAppError::InvalidInput(format!(
+                        "file policy iterations_per_flush must be positive, found {}",
+                        rate
+                    ))),
+                    None => Ok(1),
+                    Some(rate) => Ok(*rate as u64),
+                }?;
+
+                let iterations: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
+
                 Ok(ResponseSink::File {
                     filename: filename.clone(),
                     file: file_shareable,
                     format: format.clone(),
                     delimiter: format.delimiter(),
+                    iterations_per_flush,
+                    iterations,
                 })
             }
             ResponseOutputPolicy::Combined { policies } => {

--- a/rust/routee-compass/src/app/compass/response/response_output_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_policy.rs
@@ -1,5 +1,5 @@
 use super::{response_output_format::ResponseOutputFormat, response_sink::ResponseSink};
-use crate::app::compass::{compass_app::CompassApp, compass_app_error::CompassAppError};
+use crate::app::compass::compass_app_error::CompassAppError;
 use serde::{Deserialize, Serialize};
 use std::{
     fs::OpenOptions,


### PR DESCRIPTION
this PR addresses the fact that the line-writing of responses to a file output sink does not have an auto-flush cadence. for a file output policy, the user can now specify an optional `file_flush_rate` which is a positive integer. after writing every `$file_flush_rate` lines, flush will be called on the output buffer. if not specified, flush is called after every row.