### PR TITLE
cost attrs in TOML should be optional

### DIFF
--- a/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
@@ -3,9 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use super::cost_error::CostError;
 
-#[derive(Deserialize, Serialize, Clone, Copy, Debug)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CostAggregation {
+    #[default]
     Sum,
     Mul,
 }

--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
@@ -18,20 +18,24 @@ impl CostModelBuilder {
         config: &serde_json::Value,
     ) -> Result<CostModelService, CompassConfigurationError> {
         let parent_key = CompassConfigurationField::Cost.to_string();
-        let vehicle_rates: HashMap<String, VehicleCostRate> =
-            config.get_config_serde(&"vehicle_rates", &parent_key)?;
-        let network_rates: HashMap<String, NetworkCostRate> =
-            config.get_config_serde(&"network_rates", &parent_key)?;
+        let vehicle_rates: HashMap<String, VehicleCostRate> = config
+            .get_config_serde_optional(&"vehicle_rates", &parent_key)?
+            .unwrap_or_default();
+        let network_rates: HashMap<String, NetworkCostRate> = config
+            .get_config_serde_optional(&"network_rates", &parent_key)?
+            .unwrap_or_default();
 
-        let coefficients: HashMap<String, f64> =
-            config.get_config_serde(&"weights", &parent_key)?;
-        let cost_aggregation: CostAggregation =
-            config.get_config_serde(&"cost_aggregation", &parent_key)?;
+        let weights: HashMap<String, f64> = config
+            .get_config_serde_optional(&"weights", &parent_key)?
+            .unwrap_or_default();
+        let cost_aggregation: CostAggregation = config
+            .get_config_serde_optional(&"cost_aggregation", &parent_key)?
+            .unwrap_or_default();
 
         let model = CostModelService {
             vehicle_rates: Arc::new(vehicle_rates),
             network_rates: Arc::new(network_rates),
-            weights: Arc::new(coefficients),
+            weights: Arc::new(weights),
             cost_aggregation,
         };
         Ok(model)


### PR DESCRIPTION
ran into this error:

```
Error: CompassConfigurationError(ExpectedFieldForComponent("weights", "cost"))
```

this is because a TOML didn't include a section for cost weights. but, for this server, it was expected that users would always provide these weight values. the CostModelBuilder doesn't allow for optional arguments.

this PR changes that behavior to the opposite extreme, allowing all arguments to be optional. the belief is that the eventual failure is handled downstream in the CostModel::new method, when both TOML and query-time arguments have both been specified.
