### PR TITLE
allow query to overwrite state features

### DIFF
--- a/rust/routee-compass-core/src/model/state/state_error.rs
+++ b/rust/routee-compass-core/src/model/state/state_error.rs
@@ -12,6 +12,8 @@ pub enum StateError {
     UnknownStateVariableName(String, String),
     #[error("invalid state variable index {0}, should be in range [0, {1})")]
     InvalidStateVariableIndex(usize, usize),
+    #[error("expected feature to have name '{0}' but found '{1}'")]
+    UnexpectedFeatureName(String, String),
     #[error("expected feature to have {0} unit type but found {1}")]
     UnexpectedFeatureUnit(String, String),
     #[error("{0}")]

--- a/rust/routee-compass-core/src/model/state/state_error.rs
+++ b/rust/routee-compass-core/src/model/state/state_error.rs
@@ -12,9 +12,9 @@ pub enum StateError {
     UnknownStateVariableName(String, String),
     #[error("invalid state variable index {0}, should be in range [0, {1})")]
     InvalidStateVariableIndex(usize, usize),
-    #[error("expected feature to have name '{0}' but found '{1}'")]
-    UnexpectedFeatureName(String, String),
-    #[error("expected feature to have {0} unit type but found {1}")]
+    #[error("expected feature to have type '{0}' but found '{1}'")]
+    UnexpectedFeatureType(String, String),
+    #[error("expected feature unit to be {0} but found {1}")]
     UnexpectedFeatureUnit(String, String),
     #[error("{0}")]
     BuildError(String),

--- a/rust/routee-compass-core/src/model/state/state_feature.rs
+++ b/rust/routee-compass-core/src/model/state/state_feature.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 /// field names. see link for more information:
 /// https://serde.rs/enum-representations.html#untagged
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq)]
 #[serde(untagged)]
 pub enum StateFeature {
     Distance {
@@ -49,6 +49,57 @@ pub enum StateFeature {
         unit: String,
         format: CustomFeatureFormat,
     },
+}
+
+impl PartialEq for StateFeature {
+    /// tests equality based on the unit type, ignoring the stated initial value
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                StateFeature::Distance {
+                    distance_unit: a,
+                    initial: _,
+                },
+                StateFeature::Distance {
+                    distance_unit: b,
+                    initial: _,
+                },
+            ) => a == b,
+            (
+                StateFeature::Time {
+                    time_unit: a,
+                    initial: _,
+                },
+                StateFeature::Time {
+                    time_unit: b,
+                    initial: _,
+                },
+            ) => a == b,
+            (
+                StateFeature::Energy {
+                    energy_unit: a,
+                    initial: _,
+                },
+                StateFeature::Energy {
+                    energy_unit: b,
+                    initial: _,
+                },
+            ) => a == b,
+            (
+                StateFeature::Custom {
+                    name: a_name,
+                    unit: a_unit,
+                    format: _,
+                },
+                StateFeature::Custom {
+                    name: b_name,
+                    unit: b_unit,
+                    format: _,
+                },
+            ) => a_name == b_name && a_unit == b_unit,
+            _ => false,
+        }
+    }
 }
 
 impl Display for StateFeature {

--- a/rust/routee-compass-core/src/model/state/state_feature.rs
+++ b/rust/routee-compass-core/src/model/state/state_feature.rs
@@ -196,7 +196,25 @@ impl StateFeature {
     }
 
     pub fn get_initial(&self) -> Result<StateVar, StateError> {
-        self.get_feature_format().initial()
+        match self {
+            StateFeature::Distance {
+                distance_unit: _,
+                initial,
+            } => Ok((*initial).into()),
+            StateFeature::Time {
+                time_unit: _,
+                initial,
+            } => Ok((*initial).into()),
+            StateFeature::Energy {
+                energy_unit: _,
+                initial,
+            } => Ok((*initial).into()),
+            StateFeature::Custom {
+                r#type: _,
+                unit: _,
+                format,
+            } => format.initial(),
+        }
     }
 
     pub fn get_distance_unit(&self) -> Result<unit::DistanceUnit, StateError> {

--- a/rust/routee-compass-core/src/model/state/state_feature.rs
+++ b/rust/routee-compass-core/src/model/state/state_feature.rs
@@ -45,54 +45,62 @@ pub enum StateFeature {
         initial: unit::Energy,
     },
     Custom {
-        name: String,
+        r#type: String,
         unit: String,
         format: CustomFeatureFormat,
     },
 }
 
 impl PartialEq for StateFeature {
-    /// tests equality based on the unit type, ignoring the stated initial value
+    /// tests equality based on the feature type.
+    ///
+    /// for distance|time|energy, it's fine to modify either the unit
+    /// or the initial value as this should not interfere with properly-
+    /// implemented TraversalModel, AccessModel, and FrontierModel instances.
+    ///
+    /// for custom features, we are stricter about this equality test.
+    /// for instance, we cannot allow a user to change the "meaning" of a
+    /// state of charge value, that it is a floating point value in the range [0.0, 1.0].
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (
                 StateFeature::Distance {
-                    distance_unit: a,
+                    distance_unit: _,
                     initial: _,
                 },
                 StateFeature::Distance {
-                    distance_unit: b,
+                    distance_unit: _,
                     initial: _,
                 },
-            ) => a == b,
+            ) => true,
             (
                 StateFeature::Time {
-                    time_unit: a,
+                    time_unit: _,
                     initial: _,
                 },
                 StateFeature::Time {
-                    time_unit: b,
+                    time_unit: _,
                     initial: _,
                 },
-            ) => a == b,
+            ) => true,
             (
                 StateFeature::Energy {
-                    energy_unit: a,
+                    energy_unit: _,
                     initial: _,
                 },
                 StateFeature::Energy {
-                    energy_unit: b,
+                    energy_unit: _,
                     initial: _,
                 },
-            ) => a == b,
+            ) => true,
             (
                 StateFeature::Custom {
-                    name: a_name,
+                    r#type: a_name,
                     unit: a_unit,
                     format: _,
                 },
                 StateFeature::Custom {
-                    name: b_name,
+                    r#type: b_name,
                     unit: b_unit,
                     format: _,
                 },
@@ -116,7 +124,11 @@ impl Display for StateFeature {
                 energy_unit,
                 initial,
             } => write!(f, "unit: {}, initial: {}", energy_unit, initial),
-            StateFeature::Custom { name, unit, format } => {
+            StateFeature::Custom {
+                r#type: name,
+                unit,
+                format,
+            } => {
                 write!(f, "name: {} unit: {}, repr: {}", name, unit, format)
             }
         }
@@ -124,7 +136,7 @@ impl Display for StateFeature {
 }
 
 impl StateFeature {
-    pub fn get_feature_name(&self) -> String {
+    pub fn get_feature_type(&self) -> String {
         match self {
             StateFeature::Distance {
                 distance_unit: _,
@@ -139,10 +151,10 @@ impl StateFeature {
                 initial: _,
             } => String::from("energy"),
             StateFeature::Custom {
-                name,
+                r#type,
                 unit: _,
                 format: _,
-            } => name.clone(),
+            } => r#type.clone(),
         }
     }
 
@@ -161,7 +173,7 @@ impl StateFeature {
                 initial: _,
             } => energy_unit.to_string(),
             StateFeature::Custom {
-                name: _,
+                r#type: _,
                 unit,
                 format: _,
             } => unit.clone(),
@@ -175,7 +187,7 @@ impl StateFeature {
     pub fn get_feature_format(&self) -> CustomFeatureFormat {
         match self {
             StateFeature::Custom {
-                name: _,
+                r#type: _,
                 unit: _,
                 format,
             } => *format,
@@ -195,7 +207,7 @@ impl StateFeature {
             } => Ok(*unit),
             _ => Err(StateError::UnexpectedFeatureUnit(
                 String::from("distance"),
-                self.get_feature_name(),
+                self.get_feature_type(),
             )),
         }
     }
@@ -208,7 +220,7 @@ impl StateFeature {
             } => Ok(*unit),
             _ => Err(StateError::UnexpectedFeatureUnit(
                 String::from("time"),
-                self.get_feature_name(),
+                self.get_feature_type(),
             )),
         }
     }
@@ -221,7 +233,7 @@ impl StateFeature {
             } => Ok(*energy_unit),
             _ => Err(StateError::UnexpectedFeatureUnit(
                 String::from("energy"),
-                self.get_feature_name(),
+                self.get_feature_type(),
             )),
         }
     }
@@ -229,13 +241,13 @@ impl StateFeature {
     pub fn get_custom_feature_format(&self) -> Result<&CustomFeatureFormat, StateError> {
         match self {
             StateFeature::Custom {
-                name: _,
+                r#type: _,
                 unit: _,
                 format,
             } => Ok(format),
             _ => Err(StateError::UnexpectedFeatureUnit(
                 self.get_feature_unit_name(),
-                self.get_feature_name(),
+                self.get_feature_type(),
             )),
         }
     }

--- a/rust/routee-compass-core/src/model/state/state_model.rs
+++ b/rust/routee-compass-core/src/model/state/state_model.rs
@@ -35,8 +35,9 @@ impl StateModel {
     }
 
     /// extends a state model by adding additional key/value pairs to the model mapping.
-    /// in the case of name collision, a warning is logged to the user and the newer
-    /// variable is used.
+    /// in the case of name collision, we compare old and new state features at that name.
+    /// if the state feature has the same unit (tested by StateFeature::Eq), then it can
+    /// overwrite the existing.
     ///
     /// this method is used when state models are updated by the user query as Services
     /// become Models in the SearchApp.

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -63,7 +63,7 @@ impl VehicleType for BEV {
             (
                 String::from(BEV::SOC_FEATURE_NAME),
                 StateFeature::Custom {
-                    name: String::from("soc"),
+                    r#type: String::from("soc"),
                     unit: String::from("percent"),
                     format: CustomFeatureFormat::FloatingPoint {
                         initial: initial_soc.into(),

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
@@ -74,7 +74,7 @@ impl VehicleType for PHEV {
             (
                 String::from(PHEV::SOC_FEATURE_NAME),
                 StateFeature::Custom {
-                    name: String::from("soc"),
+                    r#type: String::from("soc"),
                     unit: String::from("percent"),
                     format: CustomFeatureFormat::FloatingPoint {
                         initial: initial_soc.into(),

--- a/rust/routee-compass/src/app/search/mod.rs
+++ b/rust/routee-compass/src/app/search/mod.rs
@@ -1,3 +1,4 @@
 pub mod search_app;
 pub mod search_app_graph_ops;
+pub mod search_app_ops;
 pub mod search_app_result;

--- a/rust/routee-compass/src/app/search/search_app.rs
+++ b/rust/routee-compass/src/app/search/search_app.rs
@@ -2,15 +2,11 @@ use super::{search_app_ops, search_app_result::SearchAppResult};
 use crate::{
     app::compass::{
         compass_app_error::CompassAppError,
-        config::{
-            config_json_extension::ConfigJsonExtensions,
-            cost_model::cost_model_service::CostModelService,
-        },
+        config::cost_model::cost_model_service::CostModelService,
     },
     plugin::input::input_json_extensions::InputJsonExtensions,
 };
 use chrono::Local;
-use itertools::Itertools;
 use routee_compass_core::{
     algorithm::search::{
         backtrack, search_algorithm::SearchAlgorithm, search_error::SearchError,
@@ -18,15 +14,13 @@ use routee_compass_core::{
     },
     model::{
         access::access_model_service::AccessModelService,
-        frontier::frontier_model_service::FrontierModelService,
-        road_network::graph::Graph,
-        state::{state_feature::StateFeature, state_model::StateModel},
-        termination::termination_model::TerminationModel,
+        frontier::frontier_model_service::FrontierModelService, road_network::graph::Graph,
+        state::state_model::StateModel, termination::termination_model::TerminationModel,
         traversal::traversal_model_service::TraversalModelService,
     },
 };
+use std::sync::Arc;
 use std::time;
-use std::{collections::HashMap, sync::Arc};
 
 /// a configured and loaded application to execute searches.
 pub struct SearchApp {

--- a/rust/routee-compass/src/app/search/search_app_ops.rs
+++ b/rust/routee-compass/src/app/search/search_app_ops.rs
@@ -48,14 +48,6 @@ pub fn collect_features(
                     feature.get_feature_type(),
                 ))
             }
-            Some(existing)
-                if existing.get_feature_unit_name() != feature.get_feature_unit_name() =>
-            {
-                Err(StateError::UnexpectedFeatureUnit(
-                    existing.get_feature_unit_name(),
-                    feature.get_feature_unit_name(),
-                ))
-            }
             Some(_) => Ok((name, feature)),
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/rust/routee-compass/src/app/search/search_app_ops.rs
+++ b/rust/routee-compass/src/app/search/search_app_ops.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, sync::Arc};
+
+use itertools::Itertools;
+use routee_compass_core::model::{
+    access::access_model::AccessModel,
+    state::{state_error::StateError, state_feature::StateFeature},
+    traversal::traversal_model::TraversalModel,
+};
+
+use crate::app::compass::config::config_json_extension::ConfigJsonExtensions;
+
+/// collects the state features to use in this search. the features are collected in
+/// the following order:
+///   1. from the traversal model
+///   2. from the access model
+///   3. optionally from the query itself
+/// using the order above, each new source optionally overwrites any existing feature
+/// by name (tuple index 0) as long as they match in StateFeature::get_feature_name and
+/// StateFeature::get_feature_unit_name.
+pub fn collect_features(
+    query: &serde_json::Value,
+    traversal_model: Arc<dyn TraversalModel>,
+    access_model: Arc<dyn AccessModel>,
+) -> Result<Vec<(String, StateFeature)>, StateError> {
+    // prepare the set of features for this state model
+    let model_features = traversal_model
+        .state_features()
+        .into_iter()
+        .chain(access_model.state_features())
+        .collect::<HashMap<_, _>>();
+    // build the state model. inject state features from the traversal and access models
+    // and then allow the user to optionally override any initial conditions for those
+    // state features.
+    let user_features_option: Option<HashMap<String, StateFeature>> = query
+        .get_config_serde_optional(&"state_features", &"query")
+        .map_err(|e| StateError::BuildError(e.to_string()))?;
+    let user_features = user_features_option
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(name, feature)| match model_features.get(&name) {
+            None => {
+                let fnames = model_features.keys().join(",");
+                Err(StateError::UnknownStateVariableName(name, fnames))
+            }
+            Some(existing) if existing.get_feature_name() != feature.get_feature_name() => {
+                Err(StateError::UnexpectedFeatureName(
+                    feature.get_feature_name(),
+                    existing.get_feature_name(),
+                ))
+            }
+            Some(existing)
+                if existing.get_feature_unit_name() != feature.get_feature_unit_name() =>
+            {
+                Err(StateError::UnexpectedFeatureUnit(
+                    feature.get_feature_unit_name(),
+                    existing.get_feature_unit_name(),
+                ))
+            }
+            Some(_) => Ok((name, feature)),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut added_features: Vec<(String, StateFeature)> = model_features.into_iter().collect_vec();
+    added_features.extend(user_features);
+    Ok(added_features)
+}

--- a/rust/routee-compass/src/app/search/search_app_ops.rs
+++ b/rust/routee-compass/src/app/search/search_app_ops.rs
@@ -42,18 +42,18 @@ pub fn collect_features(
                 let fnames = model_features.keys().join(",");
                 Err(StateError::UnknownStateVariableName(name, fnames))
             }
-            Some(existing) if existing.get_feature_name() != feature.get_feature_name() => {
-                Err(StateError::UnexpectedFeatureName(
-                    feature.get_feature_name(),
-                    existing.get_feature_name(),
+            Some(existing) if existing.get_feature_type() != feature.get_feature_type() => {
+                Err(StateError::UnexpectedFeatureType(
+                    existing.get_feature_type(),
+                    feature.get_feature_type(),
                 ))
             }
             Some(existing)
                 if existing.get_feature_unit_name() != feature.get_feature_unit_name() =>
             {
                 Err(StateError::UnexpectedFeatureUnit(
-                    feature.get_feature_unit_name(),
                     existing.get_feature_unit_name(),
+                    feature.get_feature_unit_name(),
                 ))
             }
             Some(_) => Ok((name, feature)),


### PR DESCRIPTION
This PR gives the user the option to overwrite initial values for state features at query time. the user
  - must be overriding an existing state feature by name
  - must match the feature type of the existing (if it was a StateFeature::Distance, it should still be that)
  - can ovewrite the initial value of the feature (go from 0.0 to 10.0 minutes initial time)
  - can also overwrite the enum variant of the unit (go from Kilometers to Meters)

Added issue #185, that would help further protect against invalid overwrites (a percent should still be a percent).

Closes #145.