### PR TITLE
Rjf/edge rtree optional road class

### DIFF
--- a/rust/routee-compass-core/src/util/geo/geo_io_utils.rs
+++ b/rust/routee-compass-core/src/util/geo/geo_io_utils.rs
@@ -5,9 +5,12 @@ use std::path::Path;
 use wkt::TryFromWkt;
 
 /// reads a collection of LINESTRINGS
-pub fn read_linestring_text_file(file: &Path) -> Result<Box<[LineString<f32>]>, std::io::Error> {
-    let is_gzip = fs_utils::is_gzip(file);
-    let count = fs_utils::line_count(file, is_gzip)?;
+pub fn read_linestring_text_file<F: AsRef<Path>>(
+    file: F,
+) -> Result<Box<[LineString<f32>]>, std::io::Error> {
+    let filepath: &Path = file.as_ref();
+    let is_gzip = fs_utils::is_gzip(filepath);
+    let count = fs_utils::line_count(filepath, is_gzip)?;
 
     let mut pb = Bar::builder()
         .total(count)
@@ -20,7 +23,7 @@ pub fn read_linestring_text_file(file: &Path) -> Result<Box<[LineString<f32>]>, 
         let _ = pb.update(1);
     });
     let geoms: Box<[LineString<f32>]> =
-        read_utils::read_raw_file(file, parse_linestring, Some(cb))?;
+        read_utils::read_raw_file(filepath, parse_linestring, Some(cb))?;
     Ok(geoms)
 }
 

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -29,6 +29,11 @@ pub trait ConfigJsonExtensions {
         key: &dyn AsRef<str>,
         parent_key: &dyn AsRef<str>,
     ) -> Result<String, CompassConfigurationError>;
+    fn get_config_string_optional(
+        &self,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
+    ) -> Result<Option<String>, CompassConfigurationError>;
     fn get_config_array(
         &self,
         key: &dyn AsRef<str>,
@@ -139,6 +144,27 @@ impl ConfigJsonExtensions for serde_json::Value {
                 )
             })?;
         Ok(value)
+    }
+
+    fn get_config_string_optional(
+        &self,
+        key: &dyn AsRef<str>,
+        parent_key: &dyn AsRef<str>,
+    ) -> Result<Option<String>, CompassConfigurationError> {
+        let key_path = key.as_ref();
+        let parent_path = parent_key.as_ref();
+        match self.get(key_path) {
+            None => Ok(None),
+            Some(value) => value
+                .as_str()
+                .map(|v| Some(String::from(v)))
+                .ok_or_else(|| {
+                    CompassConfigurationError::ExpectedFieldWithType(
+                        String::from(key_path),
+                        String::from("String"),
+                    )
+                }),
+        }
     }
 
     fn get_config_array(

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -152,7 +152,6 @@ impl ConfigJsonExtensions for serde_json::Value {
         parent_key: &dyn AsRef<str>,
     ) -> Result<Option<String>, CompassConfigurationError> {
         let key_path = key.as_ref();
-        let parent_path = parent_key.as_ref();
         match self.get(key_path) {
             None => Ok(None),
             Some(value) => value

--- a/rust/routee-compass/src/app/compass/config/config_json_extension.rs
+++ b/rust/routee-compass/src/app/compass/config/config_json_extension.rs
@@ -32,7 +32,6 @@ pub trait ConfigJsonExtensions {
     fn get_config_string_optional(
         &self,
         key: &dyn AsRef<str>,
-        parent_key: &dyn AsRef<str>,
     ) -> Result<Option<String>, CompassConfigurationError>;
     fn get_config_array(
         &self,
@@ -149,7 +148,6 @@ impl ConfigJsonExtensions for serde_json::Value {
     fn get_config_string_optional(
         &self,
         key: &dyn AsRef<str>,
-        parent_key: &dyn AsRef<str>,
     ) -> Result<Option<String>, CompassConfigurationError> {
         let key_path = key.as_ref();
         match self.get(key_path) {

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
@@ -20,8 +20,7 @@ impl InputPluginBuilder for EdgeRtreeInputPluginBuilder {
     ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("edge_rtree");
         let linestring_file = parameters.get_config_string(&"geometry_input_file", &parent_key)?;
-        let road_class_file =
-            parameters.get_config_string_optional(&"road_class_input_file", &parent_key)?;
+        let road_class_file = parameters.get_config_string_optional(&"road_class_input_file")?;
 
         let distance_tolerance_option =
             parameters.get_config_serde_optional::<Distance>(&"distance_tolerance", &parent_key)?;

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_input_plugin_builder.rs
@@ -19,8 +19,9 @@ impl InputPluginBuilder for EdgeRtreeInputPluginBuilder {
         parameters: &serde_json::Value,
     ) -> Result<Arc<dyn InputPlugin>, CompassConfigurationError> {
         let parent_key = String::from("edge_rtree");
-        let linestring_file = parameters.get_config_path(&"geometry_input_file", &parent_key)?;
-        let road_class_file = parameters.get_config_path(&"road_class_input_file", &parent_key)?;
+        let linestring_file = parameters.get_config_string(&"geometry_input_file", &parent_key)?;
+        let road_class_file =
+            parameters.get_config_string_optional(&"road_class_input_file", &parent_key)?;
 
         let distance_tolerance_option =
             parameters.get_config_serde_optional::<Distance>(&"distance_tolerance", &parent_key)?;
@@ -35,8 +36,8 @@ impl InputPluginBuilder for EdgeRtreeInputPluginBuilder {
             .unwrap_or_default();
 
         let plugin = EdgeRtreeInputPlugin::new(
-            &road_class_file,
-            &linestring_file,
+            road_class_file,
+            linestring_file,
             distance_tolerance_option,
             distance_unit_option,
             road_class_parser,

--- a/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_record.rs
+++ b/rust/routee-compass/src/plugin/input/default/edge_rtree/edge_rtree_record.rs
@@ -5,16 +5,11 @@ use rstar::{PointDistance, RTreeObject, AABB};
 pub struct EdgeRtreeRecord {
     pub edge_id: EdgeId,
     pub geometry: LineString<f32>,
-    pub road_class: u8,
 }
 
 impl EdgeRtreeRecord {
-    pub fn new(edge_id: EdgeId, geometry: LineString<f32>, road_class: u8) -> EdgeRtreeRecord {
-        EdgeRtreeRecord {
-            edge_id,
-            geometry,
-            road_class,
-        }
+    pub fn new(edge_id: EdgeId, geometry: LineString<f32>) -> EdgeRtreeRecord {
+        EdgeRtreeRecord { edge_id, geometry }
     }
 }
 


### PR DESCRIPTION
this PR makes it so the road classes argument for an EdgeRtreeInputPlugin can be _optional_. this allows Compass to be configured with edge map matching that does not perform road class filtering.

Closes #188.