### PR TITLE
K-Shortest Paths Solver

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -9,7 +9,7 @@ use crate::model::road_network::vertex_id::VertexId;
 use crate::model::unit::cost::ReverseCost;
 use crate::model::unit::Cost;
 use crate::util::priority_queue::InternalPriorityQueue;
-use priority_queue::PriorityQueue;
+
 use std::collections::HashMap;
 use std::time::Instant;
 

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -307,7 +307,7 @@ fn advance_search(
 ) -> Result<Option<VertexId>, SearchError> {
     match (cost.pop(), target) {
         (None, Some(target_vertex_id)) => {
-            return Err(SearchError::NoPathExists(source, target_vertex_id))
+            Err(SearchError::NoPathExists(source, target_vertex_id))
         }
         (None, None) => Ok(None),
         (Some((current_v, _)), Some(target_v)) if current_v == target_v => Ok(None),

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -47,60 +47,18 @@ pub fn run_a_star(
     let mut iterations = 0;
 
     loop {
-        // handle app-level termination conditions
-        let should_terminate =
-            si.termination_model
-                .terminate_search(&start_time, solution.len(), iterations)?;
+        si.termination_model
+            .test(&start_time, solution.len(), iterations)?;
 
-        if should_terminate {
-            let explanation =
-                si.termination_model
-                    .explain_termination(&start_time, solution.len(), iterations);
-            match explanation {
-                None => {
-                    return Err(SearchError::InternalSearchError(format!(
-                        "unable to explain termination with start_time, solution_size, iterations: {:?}, {}, {}",
-                        &start_time,
-                        solution.len(),
-                        iterations
-                    )))
-                }
-                Some(msg) => return Err(SearchError::QueryTerminated(msg)),
-            }
-        }
-
-        // grab the current vertex id, but handle some other termination conditions
-        // based on the state of the priority queue and optional search destination
-        // - we reach the destination                                       (Ok)
-        // - if the set is ever empty and there's no destination            (Ok)
-        // - if the set is ever empty and there's a destination             (Err)
-        let current_vertex_id = match (costs.pop(), target) {
-            (None, Some(target_vertex_id)) => {
-                return Err(SearchError::NoPathExists(source, target_vertex_id))
-            }
-            (None, None) => break,
-            (Some((current_v, _)), Some(target_v)) if current_v == target_v => break,
-            (Some((current_vertex_id, _)), _) => current_vertex_id,
+        let current_vertex_id = match advance_search(&mut costs, source, target)? {
+            None => break,
+            Some(id) => id,
         };
 
-        let previous_edge = if current_vertex_id == source {
-            None
-        } else {
-            let edge_id = solution
-                .get(&current_vertex_id)
-                .ok_or_else(|| {
-                    SearchError::InternalSearchError(format!(
-                        "expected vertex id {} missing from solution",
-                        current_vertex_id
-                    ))
-                })?
-                .edge_traversal
-                .edge_id;
-            let edge = si
-                .directed_graph
-                .get_edge(edge_id)
-                .map_err(SearchError::GraphError)?;
-            Some(edge)
+        let last_edge_id = get_last_traversed_edge_id(&current_vertex_id, &source, &solution)?;
+        let last_edge = match last_edge_id {
+            Some(id) => Some(si.directed_graph.get_edge(id)?),
+            None => None,
         };
 
         // grab the current state from the solution
@@ -121,52 +79,48 @@ pub fn run_a_star(
         };
 
         // visit all neighbors of this source vertex
-        for edge_id in si.directed_graph.out_edges_iter(current_vertex_id)? {
+        let incident_edge_iterator = direction.get_incident_edges(&current_vertex_id, si)?;
+        for edge_id in incident_edge_iterator {
             let e = si.directed_graph.get_edge(*edge_id)?;
-            let src_id = e.src_vertex_id;
-            let dst_id = e.dst_vertex_id;
 
-            if !si.frontier_model.valid_frontier(
-                e,
-                &current_state,
-                previous_edge,
-                &si.state_model,
-            )? {
+            let terminal_vertex_id = direction.terminal_vertex_id(e);
+            let key_vertex_id = direction.tree_key_vertex_id(e);
+
+            let valid_frontier =
+                si.frontier_model
+                    .valid_frontier(e, &current_state, last_edge, &si.state_model)?;
+            if !valid_frontier {
                 continue;
             }
-            let et = EdgeTraversal::perform_traversal(
-                *edge_id,
-                previous_edge.map(|pe| pe.edge_id),
-                &current_state,
-                si,
-            )?;
+            let et =
+                direction.perform_edge_traversal(*edge_id, last_edge_id, &current_state, si)?;
             let current_gscore = traversal_costs
-                .get(&src_id)
+                .get(&terminal_vertex_id)
                 .unwrap_or(&Cost::INFINITY)
                 .to_owned();
             let tentative_gscore = current_gscore + et.total_cost();
             let existing_gscore = traversal_costs
-                .get(&dst_id)
+                .get(&key_vertex_id)
                 .unwrap_or(&Cost::INFINITY)
                 .to_owned();
             if tentative_gscore < existing_gscore {
-                traversal_costs.insert(dst_id, tentative_gscore);
+                traversal_costs.insert(key_vertex_id, tentative_gscore);
 
                 // update solution
                 let traversal = SearchTreeBranch {
-                    terminal_vertex: src_id,
+                    terminal_vertex: terminal_vertex_id,
                     edge_traversal: et,
                 };
-                solution.insert(dst_id, traversal);
+                solution.insert(key_vertex_id, traversal);
 
                 let dst_h_cost = match target {
                     None => Cost::ZERO,
                     Some(target_v) => {
-                        si.estimate_traversal_cost(dst_id, target_v, &current_state)?
+                        si.estimate_traversal_cost(key_vertex_id, target_v, &current_state)?
                     }
                 };
                 let f_score_value = tentative_gscore + dst_h_cost;
-                costs.push_increase(dst_id, f_score_value.into());
+                costs.push_increase(key_vertex_id, f_score_value.into());
             }
         }
         iterations += 1;
@@ -264,8 +218,8 @@ pub fn run_a_star_edge_oriented(
             } else if e1_dst == e2_src {
                 // route is simply source -> target
                 let init_state = si.state_model.initial_state()?;
-                let src_et = EdgeTraversal::perform_traversal(source, None, &init_state, si)?;
-                let dst_et = EdgeTraversal::perform_traversal(
+                let src_et = EdgeTraversal::forward_traversal(source, None, &init_state, si)?;
+                let dst_et = EdgeTraversal::forward_traversal(
                     target_edge,
                     Some(source),
                     &src_et.result_state,
@@ -328,6 +282,74 @@ pub fn run_a_star_edge_oriented(
                 Ok(result)
             }
         }
+    }
+}
+
+/// grab the current vertex id, but handle some other termination conditions
+/// based on the state of the priority queue and optional search destination
+/// - we reach the destination                                       (Ok)
+/// - if the set is ever empty and there's no destination            (Ok)
+/// - if the set is ever empty and there's a destination             (Err)
+///
+/// # Arguments
+/// * `cost`   - queue of priority-ranked vertices for exploration
+/// * `source` - search source vertex
+/// * `target` - optional search destination
+///
+/// # Results
+/// The next vertex to search. None if the queue has been exhausted in a search with no
+/// destination, or we have reached our destination.
+/// An error if no path exists for a search that includes a destination.
+fn advance_search(
+    cost: &mut InternalPriorityQueue<VertexId, ReverseCost>,
+    source: VertexId,
+    target: Option<VertexId>,
+) -> Result<Option<VertexId>, SearchError> {
+    match (cost.pop(), target) {
+        (None, Some(target_vertex_id)) => {
+            return Err(SearchError::NoPathExists(source, target_vertex_id))
+        }
+        (None, None) => Ok(None),
+        (Some((current_v, _)), Some(target_v)) if current_v == target_v => Ok(None),
+        (Some((current_vertex_id, _)), _) => Ok(Some(current_vertex_id)),
+    }
+}
+
+/// Find the last-traversed edge before reaching this vertex id.
+/// The logic is the same for forward and reverse searches but finds
+/// a different result because the trees are different.
+/// Forward case: find `prev` from v2 in `(v1)-[prev]->(v2)-[next]->(v3)`
+/// Reverse case: find `next` from v2 in `(v1)-[prev]->(v2)-[next]->(v3)`
+///
+/// # Arguments
+/// * `this_vertex_id`  - current vertex, v2 in diagram
+/// * `first_vertex_id` - source of this search, the origin vertex in a forward
+///                       search or the destination vertex in a reverse search
+/// * `tree`            - current search solution tree
+///
+/// # Returns
+///
+/// The EdgeId for the edge that was traversed to reach this vertex, or None
+/// if no edges have yet been traversed.
+fn get_last_traversed_edge_id(
+    this_vertex_id: &VertexId,
+    first_vertex_id: &VertexId,
+    tree: &HashMap<VertexId, SearchTreeBranch>,
+) -> Result<Option<EdgeId>, SearchError> {
+    if this_vertex_id == first_vertex_id {
+        Ok(None)
+    } else {
+        let edge_id = tree
+            .get(this_vertex_id)
+            .ok_or_else(|| {
+                SearchError::InternalSearchError(format!(
+                    "expected vertex id {} missing from solution",
+                    this_vertex_id
+                ))
+            })?
+            .edge_traversal
+            .edge_id;
+        Ok(Some(edge_id))
     }
 }
 

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -29,8 +29,7 @@ pub fn run_a_star(
     }
 
     // context for the search (graph, search functions, frontier priority queue)
-    let mut costs: InternalPriorityQueue<VertexId, ReverseCost> =
-        InternalPriorityQueue(PriorityQueue::new());
+    let mut costs: InternalPriorityQueue<VertexId, ReverseCost> = InternalPriorityQueue::default();
     let mut traversal_costs: HashMap<VertexId, Cost> = HashMap::new();
     let mut solution: HashMap<VertexId, SearchTreeBranch> = HashMap::new();
 
@@ -306,9 +305,7 @@ fn advance_search(
     target: Option<VertexId>,
 ) -> Result<Option<VertexId>, SearchError> {
     match (cost.pop(), target) {
-        (None, Some(target_vertex_id)) => {
-            Err(SearchError::NoPathExists(source, target_vertex_id))
-        }
+        (None, Some(target_vertex_id)) => Err(SearchError::NoPathExists(source, target_vertex_id)),
         (None, None) => Ok(None),
         (Some((current_v, _)), Some(target_v)) if current_v == target_v => Ok(None),
         (Some((current_vertex_id, _)), _) => Ok(Some(current_vertex_id)),

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -1,3 +1,4 @@
+use crate::algorithm::search::direction::Direction;
 use crate::algorithm::search::edge_traversal::EdgeTraversal;
 use crate::algorithm::search::search_error::SearchError;
 use crate::algorithm::search::search_instance::SearchInstance;
@@ -20,6 +21,7 @@ use std::time::Instant;
 pub fn run_a_star(
     source: VertexId,
     target: Option<VertexId>,
+    direction: &Direction,
     si: &SearchInstance,
 ) -> Result<SearchResult, SearchError> {
     if target.map_or(false, |t| t == source) {
@@ -221,6 +223,7 @@ pub fn run_a_star(
 pub fn run_a_star_edge_oriented(
     source: EdgeId,
     target: Option<EdgeId>,
+    direction: &Direction,
     si: &SearchInstance,
 ) -> Result<SearchResult, SearchError> {
     // 1. guard against edge conditions (src==dst, src.dst_v == dst.src_v)
@@ -242,7 +245,7 @@ pub fn run_a_star_edge_oriented(
             let SearchResult {
                 mut tree,
                 iterations,
-            } = run_a_star(e1_dst, None, si)?;
+            } = run_a_star(e1_dst, None, direction, si)?;
             if !tree.contains_key(&e1_dst) {
                 tree.extend([(e1_dst, src_branch)]);
             }
@@ -287,7 +290,7 @@ pub fn run_a_star_edge_oriented(
                 let SearchResult {
                     mut tree,
                     iterations,
-                } = run_a_star(e1_dst, Some(e2_src), si)?;
+                } = run_a_star(e1_dst, Some(e2_src), direction, si)?;
 
                 if tree.is_empty() {
                     return Err(SearchError::NoPathExists(e1_dst, e2_src));
@@ -473,7 +476,8 @@ mod tests {
             .clone()
             .into_par_iter()
             .map(|(o, d, _expected)| {
-                run_a_star(o, Some(d), &si).map(|search_result| search_result.tree)
+                run_a_star(o, Some(d), &Direction::Forward, &si)
+                    .map(|search_result| search_result.tree)
             })
             .collect();
 

--- a/rust/routee-compass-core/src/algorithm/search/a_star/bidirectional_a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/bidirectional_a_star_algorithm.rs
@@ -1,0 +1,78 @@
+use itertools::Itertools;
+
+use crate::algorithm::search::{
+    edge_traversal::EdgeTraversal, search_error::SearchError, search_instance::SearchInstance,
+};
+
+/// helper function to address how the reverse route state and costs are assigned.
+///
+/// the state values in the reverse route monotonically increase in the reverse direction.
+/// the marginal state changes need to be extracted for each link and then added to the final
+/// state of the forward route.
+///
+/// finally, the updated route is reversed so that it can be appended to the forward route.
+///
+/// # Arguments
+/// * `fwd_route` - the forward-oriented route of a bidirectional search
+/// * `rev_route` - the reverse-oriented route of a bidirectional search (mutated here)
+/// * `si`        - the search instance
+pub fn reorient_reverse_route(
+    fwd_route: &[EdgeTraversal],
+    rev_route: &[EdgeTraversal],
+    si: &SearchInstance,
+) -> Result<Vec<EdgeTraversal>, SearchError> {
+    // get the final edge id and state for the forward traversal
+    let (final_fwd_edge_id, mut acc_state) = match fwd_route.last() {
+        None => (
+            None,
+            si.state_model
+                .initial_state()
+                .map_err(SearchError::StateError)?,
+        ),
+        Some(last_edge) => (Some(last_edge.edge_id), last_edge.result_state.clone()),
+    };
+
+    // get all edge ids along the reverse route when traversed in forward direction,
+    // appending the (optional) last edge id of the forward route
+    let mut edge_ids = rev_route
+        .iter()
+        .rev()
+        .map(|e| Some(e.edge_id))
+        .collect_vec();
+    edge_ids.insert(0, final_fwd_edge_id);
+
+    // re-create all EdgeTraversal instances from each successive edge id pair, building
+    // from the final state of the forward traversal
+    let mut result: Vec<EdgeTraversal> = Vec::with_capacity(rev_route.len());
+    for (prev_opt, next_opt) in edge_ids.iter().tuple_windows() {
+        let next = next_opt.ok_or_else(|| {
+            SearchError::InternalSearchError(String::from("next_opt should never be None"))
+        })?;
+        let et = EdgeTraversal::forward_traversal(next, *prev_opt, &acc_state, si)?;
+        acc_state = et.result_state.clone();
+        result.push(et);
+    }
+
+    Ok(result)
+}
+
+/// identifies routes that have loops by checking if any two edges share
+/// the same source vertex.
+///
+/// # Arguments
+/// * `route` - the route to check
+/// * `si`    - the search instance
+///
+/// # Returns
+///
+/// true if there is a loop
+pub fn route_contains_loop(
+    route: &[EdgeTraversal],
+    si: &SearchInstance,
+) -> Result<bool, SearchError> {
+    let src_vertices = route
+        .iter()
+        .map(|e| si.directed_graph.src_vertex_id(e.edge_id))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(src_vertices.iter().unique().collect_vec().len() < src_vertices.len())
+}

--- a/rust/routee-compass-core/src/algorithm/search/a_star/mod.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/mod.rs
@@ -1,1 +1,2 @@
 pub mod a_star_algorithm;
+pub mod bidirectional_a_star_algorithm;

--- a/rust/routee-compass-core/src/algorithm/search/direction.rs
+++ b/rust/routee-compass-core/src/algorithm/search/direction.rs
@@ -1,6 +1,5 @@
 use super::{
     edge_traversal::EdgeTraversal, search_error::SearchError, search_instance::SearchInstance,
-    search_tree_branch::SearchTreeBranch,
 };
 use crate::model::{
     property::edge::Edge,
@@ -8,7 +7,7 @@ use crate::model::{
     traversal::state::state_variable::StateVar,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+
 
 #[derive(Copy, Clone, Serialize, Deserialize)]
 #[serde(rename = "snake_case")]

--- a/rust/routee-compass-core/src/algorithm/search/direction.rs
+++ b/rust/routee-compass-core/src/algorithm/search/direction.rs
@@ -8,10 +8,10 @@ use crate::model::{
 };
 use serde::{Deserialize, Serialize};
 
-
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Copy, Clone, Serialize, Deserialize, Default)]
 #[serde(rename = "snake_case")]
 pub enum Direction {
+    #[default]
     Forward,
     Reverse,
 }

--- a/rust/routee-compass-core/src/algorithm/search/direction.rs
+++ b/rust/routee-compass-core/src/algorithm/search/direction.rs
@@ -1,8 +1,62 @@
+use super::{
+    edge_traversal::EdgeTraversal, search_error::SearchError, search_instance::SearchInstance,
+    search_tree_branch::SearchTreeBranch,
+};
+use crate::model::{
+    property::edge::Edge,
+    road_network::{edge_id::EdgeId, graph_error::GraphError, vertex_id::VertexId},
+    traversal::state::state_variable::StateVar,
+};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Copy, Clone, Serialize, Deserialize)]
 #[serde(rename = "snake_case")]
 pub enum Direction {
     Forward,
     Reverse,
+}
+
+impl Direction {
+    pub fn get_incident_edges<'a>(
+        &'a self,
+        vertex_id: &VertexId,
+        si: &'a SearchInstance,
+    ) -> Result<Box<dyn Iterator<Item = &EdgeId> + 'a>, GraphError> {
+        match self {
+            Direction::Forward => si.directed_graph.out_edges_iter(*vertex_id),
+            Direction::Reverse => si.directed_graph.in_edges_iter(*vertex_id),
+        }
+    }
+
+    pub fn tree_key_vertex_id(&self, edge: &Edge) -> VertexId {
+        match self {
+            Direction::Forward => edge.dst_vertex_id,
+            Direction::Reverse => edge.src_vertex_id,
+        }
+    }
+
+    pub fn terminal_vertex_id(&self, edge: &Edge) -> VertexId {
+        match self {
+            Direction::Forward => edge.src_vertex_id,
+            Direction::Reverse => edge.dst_vertex_id,
+        }
+    }
+
+    pub fn perform_edge_traversal(
+        &self,
+        edge_id: EdgeId,
+        last_edge_id: Option<EdgeId>,
+        start_state: &[StateVar],
+        si: &SearchInstance,
+    ) -> Result<EdgeTraversal, SearchError> {
+        match self {
+            Direction::Forward => {
+                EdgeTraversal::forward_traversal(edge_id, last_edge_id, start_state, si)
+            }
+            Direction::Reverse => {
+                EdgeTraversal::reverse_traversal(edge_id, last_edge_id, start_state, si)
+            }
+        }
+    }
 }

--- a/rust/routee-compass-core/src/algorithm/search/edge_traversal.rs
+++ b/rust/routee-compass-core/src/algorithm/search/edge_traversal.rs
@@ -36,9 +36,21 @@ impl EdgeTraversal {
     /// traverses an edge, possibly after traversing some previous edge,
     /// collecting the access and traversal costs. returns the
     /// accumulated cost and updated search state.
-    pub fn perform_traversal(
+    ///
+    /// # Arguments
+    ///
+
+    /// * `next_edge_id`     - the edge to traverse
+    /// * `prev_edge_id_opt` - the previously traversed edge, if exists, for access costs
+    /// * `prev_state`       - the state before traversal, positioned closer to the destination
+    /// * `si`               - the search assets for this query
+    ///
+    /// # Returns
+    ///
+    /// An edge traversal summarizing the costs and result state of accessing and traversing the next edge.
+    pub fn forward_traversal(
         next_edge_id: EdgeId,
-        prev_edge_id: Option<EdgeId>,
+        prev_edge_id_opt: Option<EdgeId>,
         prev_state: &[StateVar],
         si: &SearchInstance,
     ) -> Result<EdgeTraversal, SearchError> {
@@ -51,10 +63,9 @@ impl EdgeTraversal {
             .edge_triplet_attrs(next_edge_id)
             .map_err(SearchError::GraphError)?;
 
-        // perform access traversal + access cost if a previous edge exists
-        // regardless of search direction, we grab the forward-oriented trajectory
-        // for computing costs: (v1)-[prev]->(v2)-[next]->(v3)
-        if let Some(prev_edge_id) = prev_edge_id {
+        // perform access traversal for (v2)-[next]->(v3)
+        // access cost for (v1)-[prev]->(v2)-[next]->(v3)
+        if let Some(prev_edge_id) = prev_edge_id_opt {
             let e1 = si
                 .directed_graph
                 .get_edge(prev_edge_id)
@@ -90,6 +101,85 @@ impl EdgeTraversal {
 
         let result = EdgeTraversal {
             edge_id: next_edge_id,
+            access_cost,
+            traversal_cost,
+            result_state,
+        };
+
+        Ok(result)
+    }
+
+    /// traverses an edge, possibly after traversing some next edge,
+    /// collecting the access and traversal costs in a reverse-oriented
+    /// tree building process. returns the accumulated cost and updated search state.
+    /// used in bi-directional search algorithms. definition of previous and next
+    /// edges is the same as the forward traversal: (v1)-[prev]->(v2)-[next]->(v3)
+    /// but the "next" edge is now the Optional edge.
+    ///
+    /// # Arguments
+    ///
+    /// * `prev_edge_id`     - the edge to traverse
+    /// * `next_edge_id_opt` - the edge previously traversed that appears closer to the origin
+    ///                        of this reverse search
+    /// * `prev_state`       - the state before traversal, positioned closer to the destination
+    /// * `si`               - the search assets for this query
+    ///
+    /// # Returns
+    ///
+    /// An edge traversal summarizing the costs and result state of accessing and traversing the previous edge.
+    pub fn reverse_traversal(
+        prev_edge_id: EdgeId,
+        next_edge_id_opt: Option<EdgeId>,
+        prev_state: &[StateVar],
+        si: &SearchInstance,
+    ) -> Result<EdgeTraversal, SearchError> {
+        let mut result_state = prev_state.to_vec();
+        let mut access_cost = Cost::ZERO;
+
+        // find this traversal in the graph
+        let traversal_trajectory = si
+            .directed_graph
+            .edge_triplet_attrs(prev_edge_id)
+            .map_err(SearchError::GraphError)?;
+
+        // perform access traversal for (v1)-[prev]->(v2)
+        // access cost for              (v1)-[prev]->(v2)-[next]->(v3)
+        if let Some(next_edge_id) = next_edge_id_opt {
+            let e2 = si
+                .directed_graph
+                .get_edge(next_edge_id)
+                .map_err(SearchError::GraphError)?;
+            let v3 = si
+                .directed_graph
+                .get_vertex(e2.dst_vertex_id)
+                .map_err(SearchError::GraphError)?;
+
+            let (v1, e1, v2) = traversal_trajectory;
+            let access_trajectory = (v1, e1, v2, e2, v3);
+
+            si.access_model
+                .access_edge(access_trajectory, &mut result_state, &si.state_model)?;
+
+            let ac = si
+                .cost_model
+                .access_cost(e1, e2, prev_state, &result_state)
+                .map_err(SearchError::CostError)?;
+            access_cost = access_cost + ac;
+        }
+
+        si.traversal_model
+            .traverse_edge(traversal_trajectory, &mut result_state, &si.state_model)
+            .map_err(SearchError::TraversalModelFailure)?;
+
+        let (_, edge, _) = traversal_trajectory;
+        let total_cost = si
+            .cost_model
+            .traversal_cost(edge, prev_state, &result_state)
+            .map_err(SearchError::CostError)?;
+        let traversal_cost = total_cost - access_cost;
+
+        let result = EdgeTraversal {
+            edge_id: prev_edge_id,
             access_cost,
             traversal_cost,
             result_state,

--- a/rust/routee-compass-core/src/algorithm/search/edge_traversal.rs
+++ b/rust/routee-compass-core/src/algorithm/search/edge_traversal.rs
@@ -37,7 +37,7 @@ impl EdgeTraversal {
     /// collecting the access and traversal costs. returns the
     /// accumulated cost and updated search state.
     pub fn perform_traversal(
-        edge_id: EdgeId,
+        next_edge_id: EdgeId,
         prev_edge_id: Option<EdgeId>,
         prev_state: &[StateVar],
         si: &SearchInstance,
@@ -48,10 +48,12 @@ impl EdgeTraversal {
         // find this traversal in the graph
         let traversal_trajectory = si
             .directed_graph
-            .edge_triplet_attrs(edge_id)
+            .edge_triplet_attrs(next_edge_id)
             .map_err(SearchError::GraphError)?;
 
         // perform access traversal + access cost if a previous edge exists
+        // regardless of search direction, we grab the forward-oriented trajectory
+        // for computing costs: (v1)-[prev]->(v2)-[next]->(v3)
         if let Some(prev_edge_id) = prev_edge_id {
             let e1 = si
                 .directed_graph
@@ -87,7 +89,7 @@ impl EdgeTraversal {
         let traversal_cost = total_cost - access_cost;
 
         let result = EdgeTraversal {
-            edge_id,
+            edge_id: next_edge_id,
             access_cost,
             traversal_cost,
             result_state,

--- a/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
@@ -1,5 +1,3 @@
-
-
 use super::route_similarity_function::RouteSimilarityFunction;
 use crate::{
     algorithm::search::{
@@ -8,10 +6,7 @@ use crate::{
         search_algorithm_result::SearchAlgorithmResult, search_error::SearchError,
         search_instance::SearchInstance,
     },
-    model::{
-        road_network::vertex_id::VertexId,
-        unit::cost::ReverseCost,
-    },
+    model::{road_network::vertex_id::VertexId, unit::cost::ReverseCost},
     util::priority_queue::InternalPriorityQueue,
 };
 use std::collections::HashMap;

--- a/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
@@ -1,16 +1,65 @@
+use super::route_similarity_function::RouteSimilarityFunction;
 use crate::{
     algorithm::search::{
-        search_algorithm::SearchAlgorithm, search_error::SearchError,
-        search_instance::SearchInstance, search_result::SearchResult,
+        direction::Direction, edge_traversal::EdgeTraversal, search_algorithm::SearchAlgorithm,
+        search_algorithm_result::SearchAlgorithmResult, search_error::SearchError,
+        search_instance::SearchInstance,
     },
-    model::road_network::vertex_id::VertexId,
+    model::{road_network::vertex_id::VertexId, unit::cost::ReverseCost},
+    util::priority_queue::InternalPriorityQueue,
 };
+use std::collections::HashMap;
 
-pub fn run_ksp(
-    _source: VertexId,
-    _target: Option<VertexId>,
-    _si: &SearchInstance,
-    _underlying: Box<SearchAlgorithm>,
-) -> Result<Vec<SearchResult>, SearchError> {
-    todo!()
+/// generates a set of k-shortest paths using the single-via path algorithm.
+pub fn run(
+    source: VertexId,
+    target: VertexId,
+    k: usize,
+    similarity: &RouteSimilarityFunction,
+    si: &SearchInstance,
+    underlying: &SearchAlgorithm,
+) -> Result<SearchAlgorithmResult, SearchError> {
+    // run forward and reverse search
+    let fwd_result =
+        underlying.run_vertex_oriented(source, Some(target), &Direction::Forward, si)?;
+    let rev_result =
+        underlying.run_vertex_oriented(source, Some(target), &Direction::Reverse, si)?;
+
+    // find intersection vertices
+    let fwd_vertices = fwd_result.trees.iter().flatten().collect::<HashMap<_, _>>();
+    let mut intersection_queue: InternalPriorityQueue<VertexId, ReverseCost> =
+        InternalPriorityQueue::default();
+    for tree in rev_result.trees {
+        for (vertex_id, rev_branch) in tree {
+            if let Some(fwd_branch) = fwd_vertices.get(&vertex_id) {
+                let total_cost =
+                    fwd_branch.edge_traversal.total_cost() + rev_branch.edge_traversal.total_cost();
+                intersection_queue.push(vertex_id, total_cost.into());
+            }
+        }
+    }
+
+    // todo: implement SimilarityFunction
+    let mut solution: Vec<Vec<EdgeTraversal>> = vec![];
+    loop {
+        if solution.len() == k {
+            break;
+        }
+        match intersection_queue.pop() {
+            None => break,
+            Some((intersection_vertex_id, _)) => {
+                // - backtrack both routes
+                // - compare with similarity to each solution route
+                // similarity.rank_similarity(a, b)
+                // - append when sufficiently dis-similar
+            }
+        }
+    }
+    // combine all data into this result
+    let result = SearchAlgorithmResult {
+        trees: todo!(),
+        routes: todo!(),
+        iterations: todo!(),
+    };
+    return Ok(result);
 }

--- a/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
@@ -1,9 +1,9 @@
 use super::route_similarity_function::RouteSimilarityFunction;
 use crate::{
     algorithm::search::{
-        direction::Direction, edge_traversal::EdgeTraversal, search_algorithm::SearchAlgorithm,
-        search_algorithm_result::SearchAlgorithmResult, search_error::SearchError,
-        search_instance::SearchInstance,
+        backtrack, direction::Direction, edge_traversal::EdgeTraversal,
+        search_algorithm::SearchAlgorithm, search_algorithm_result::SearchAlgorithmResult,
+        search_error::SearchError, search_instance::SearchInstance,
     },
     model::{road_network::vertex_id::VertexId, unit::cost::ReverseCost},
     util::priority_queue::InternalPriorityQueue,
@@ -20,26 +20,48 @@ pub fn run(
     underlying: &SearchAlgorithm,
 ) -> Result<SearchAlgorithmResult, SearchError> {
     // run forward and reverse search
-    let fwd_result =
-        underlying.run_vertex_oriented(source, Some(target), &Direction::Forward, si)?;
-    let rev_result =
-        underlying.run_vertex_oriented(source, Some(target), &Direction::Reverse, si)?;
+    let SearchAlgorithmResult {
+        trees: fwd_trees,
+        routes: _,
+        iterations: fwd_iterations,
+    } = underlying.run_vertex_oriented(source, Some(target), &Direction::Forward, si)?;
+    let SearchAlgorithmResult {
+        trees: rev_trees,
+        routes: _,
+        iterations: rev_iterations,
+    } = underlying.run_vertex_oriented(source, Some(target), &Direction::Reverse, si)?;
+    if fwd_trees.len() != 1 {
+        Err(SearchError::InternalSearchError(format!(
+            "ksp solver fwd trees count should be exactly 1, found {}",
+            fwd_trees.len()
+        )))?;
+    }
+    if rev_trees.len() != 1 {
+        Err(SearchError::InternalSearchError(format!(
+            "ksp solver rev trees count should be exactly 1, found {}",
+            rev_trees.len()
+        )))?;
+    }
+    let fwd_tree = fwd_trees.first().ok_or_else(|| {
+        SearchError::InternalSearchError(String::from("cannot retrieve fwd tree 0"))
+    })?;
+    let rev_tree = rev_trees.first().ok_or_else(|| {
+        SearchError::InternalSearchError(String::from("cannot retrieve rev tree 0"))
+    })?;
 
     // find intersection vertices
-    let fwd_vertices = fwd_result.trees.iter().flatten().collect::<HashMap<_, _>>();
+    let fwd_vertices = fwd_trees.iter().flatten().collect::<HashMap<_, _>>();
     let mut intersection_queue: InternalPriorityQueue<VertexId, ReverseCost> =
         InternalPriorityQueue::default();
-    for tree in rev_result.trees {
-        for (vertex_id, rev_branch) in tree {
-            if let Some(fwd_branch) = fwd_vertices.get(&vertex_id) {
-                let total_cost =
-                    fwd_branch.edge_traversal.total_cost() + rev_branch.edge_traversal.total_cost();
-                intersection_queue.push(vertex_id, total_cost.into());
-            }
+
+    for (vertex_id, rev_branch) in rev_tree {
+        if let Some(fwd_branch) = fwd_vertices.get(&vertex_id) {
+            let total_cost =
+                fwd_branch.edge_traversal.total_cost() + rev_branch.edge_traversal.total_cost();
+            intersection_queue.push(*vertex_id, total_cost.into());
         }
     }
 
-    // todo: implement SimilarityFunction
     let mut solution: Vec<Vec<EdgeTraversal>> = vec![];
     loop {
         if solution.len() == k {
@@ -48,18 +70,28 @@ pub fn run(
         match intersection_queue.pop() {
             None => break,
             Some((intersection_vertex_id, _)) => {
-                // - backtrack both routes
-                // - compare with similarity to each solution route
-                // similarity.rank_similarity(a, b)
-                // - append when sufficiently dis-similar
+                let fwd_route =
+                    backtrack::vertex_oriented_route(source, intersection_vertex_id, fwd_tree)?;
+                let mut rev_route =
+                    backtrack::vertex_oriented_route(target, intersection_vertex_id, rev_tree)?;
+                rev_route.reverse();
+                let this_route = fwd_route.into_iter().chain(rev_route).collect::<Vec<_>>();
+                for solution_route in solution.iter() {
+                    let similarity_value =
+                        similarity.rank_similarity(&this_route, solution_route, si)?;
+                    if !similarity.sufficiently_dissimilar(similarity_value) {
+                        break;
+                    }
+                }
+                solution.push(this_route);
             }
         }
     }
     // combine all data into this result
     let result = SearchAlgorithmResult {
-        trees: todo!(),
-        routes: todo!(),
-        iterations: todo!(),
+        trees: vec![fwd_tree.clone(), rev_tree.clone()], // todo: figure out how to avoid this clone
+        routes: solution,
+        iterations: fwd_iterations + rev_iterations,
     };
-    return Ok(result);
+    Ok(result)
 }

--- a/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
@@ -1,4 +1,4 @@
-use log::log;
+
 
 use super::route_similarity_function::RouteSimilarityFunction;
 use crate::{
@@ -9,7 +9,7 @@ use crate::{
         search_instance::SearchInstance,
     },
     model::{
-        road_network::vertex_id::VertexId, traversal::state::state_variable::StateVar,
+        road_network::vertex_id::VertexId,
         unit::cost::ReverseCost,
     },
     util::priority_queue::InternalPriorityQueue,

--- a/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/ksp_single_via_paths.rs
@@ -29,7 +29,7 @@ pub fn run(
         trees: rev_trees,
         routes: _,
         iterations: rev_iterations,
-    } = underlying.run_vertex_oriented(source, Some(target), &Direction::Reverse, si)?;
+    } = underlying.run_vertex_oriented(target, Some(source), &Direction::Reverse, si)?;
     if fwd_trees.len() != 1 {
         Err(SearchError::InternalSearchError(format!(
             "ksp solver fwd trees count should be exactly 1, found {}",
@@ -50,23 +50,31 @@ pub fn run(
     })?;
 
     // find intersection vertices
-    let fwd_vertices = fwd_trees.iter().flatten().collect::<HashMap<_, _>>();
+    let rev_vertices = rev_trees.iter().flatten().collect::<HashMap<_, _>>();
     let mut intersection_queue: InternalPriorityQueue<VertexId, ReverseCost> =
         InternalPriorityQueue::default();
 
-    for (vertex_id, rev_branch) in rev_tree {
-        if let Some(fwd_branch) = fwd_vertices.get(&vertex_id) {
-            let total_cost =
-                fwd_branch.edge_traversal.total_cost() + rev_branch.edge_traversal.total_cost();
-            intersection_queue.push(*vertex_id, total_cost.into());
+    // valid intersection vertices should appear both as terminal vertices and lookup vertices in both trees
+    // - being a "terminal vertex" places them at the shared meeting location, terminus of each tree somewhere
+    // - being a "lookup vertex" means we can use them for backtracking forward and reverse paths
+    for (vertex_id, fwd_branch) in fwd_tree {
+        if let Some(rev_branch) = rev_vertices.get(&fwd_branch.terminal_vertex) {
+            if rev_vertices.contains_key(&vertex_id) {
+                let total_cost =
+                    fwd_branch.edge_traversal.total_cost() + rev_branch.edge_traversal.total_cost();
+                intersection_queue.push(*vertex_id, total_cost.into());
+            }
         }
     }
 
-    let mut solution: Vec<Vec<EdgeTraversal>> = vec![];
+    let tsp = backtrack::vertex_oriented_route(source, target, fwd_tree)?;
+    let mut solution: Vec<Vec<EdgeTraversal>> = vec![tsp];
+    let mut ksp_iterations: u64 = 0;
     loop {
         if solution.len() == k {
             break;
         }
+        ksp_iterations += 1;
         match intersection_queue.pop() {
             None => break,
             Some((intersection_vertex_id, _)) => {
@@ -87,11 +95,12 @@ pub fn run(
             }
         }
     }
+
     // combine all data into this result
     let result = SearchAlgorithmResult {
         trees: vec![fwd_tree.clone(), rev_tree.clone()], // todo: figure out how to avoid this clone
         routes: solution,
-        iterations: fwd_iterations + rev_iterations,
+        iterations: fwd_iterations + rev_iterations + ksp_iterations, // todo: figure out how to report individually
     };
     Ok(result)
 }

--- a/rust/routee-compass-core/src/algorithm/search/ksp/mod.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/mod.rs
@@ -1,1 +1,2 @@
 pub mod ksp_single_via_paths;
+pub mod route_similarity_function;

--- a/rust/routee-compass-core/src/algorithm/search/ksp/route_similarity_function.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/route_similarity_function.rs
@@ -4,7 +4,7 @@ use crate::{
     algorithm::search::{
         edge_traversal::EdgeTraversal, search_error::SearchError, search_instance::SearchInstance,
     },
-    model::unit::as_f64::AsF64,
+    model::{road_network::edge_id::EdgeId, unit::as_f64::AsF64},
 };
 use serde::{Deserialize, Serialize};
 
@@ -64,41 +64,61 @@ impl RouteSimilarityFunction {
     ) -> Result<f64, SearchError> {
         match self {
             RouteSimilarityFunction::EdgeIdCosineSimilarity { threshold: _ } => {
-                let numer = a
-                    .iter()
-                    .map(|e| e.edge_id)
-                    .collect::<HashSet<_>>()
-                    .intersection(&b.iter().map(|e| e.edge_id).collect::<HashSet<_>>())
-                    .collect::<Vec<_>>()
-                    .len();
-                let denom = a.len() + b.len();
-                if denom == 0 {
-                    Ok(0.0)
-                } else {
-                    Ok(numer as f64 / denom as f64)
-                }
+                let unit_dist_fn = Box::new(|_| Ok(1.0));
+                cos_similarity(a, b, unit_dist_fn)
             }
             RouteSimilarityFunction::DistanceWeightedCosineSimilarity { threshold: _ } => {
-                let a_set = a
-                    .iter()
-                    .map(|e| {
-                        si.directed_graph
-                            .get_edge(e.edge_id)
-                            .map(|edge| (e.edge_id, edge.distance.as_f64()))
-                    })
-                    .collect::<Result<HashMap<_, _>, _>>()?;
-                let b_set = b
-                    .iter()
-                    .flat_map(|e| a_set.get(&e.edge_id).copied())
-                    .collect::<Vec<_>>();
-                let numer: f64 = b_set.into_iter().sum();
-                let denom = a.len() + b.len();
-                if denom == 0 {
-                    Ok(0.0)
-                } else {
-                    Ok(numer / denom as f64)
-                }
+                let dist_fn = Box::new(|edge_id| {
+                    si.directed_graph
+                        .get_edge(edge_id)
+                        .map(|edge| edge.distance.as_f64())
+                        .map_err(SearchError::GraphError)
+                });
+                cos_similarity(a, b, dist_fn)
             }
         }
     }
+}
+
+/// computes the cosine similarity of two routes using the provided distance function
+///
+/// # Arguments
+///
+/// * `a`       - this route
+/// * `b`       - that route
+/// * `dist_fn` - mapping from EdgeIds to some distance value
+///
+/// # Returns
+///
+/// the cosine similarity of the routes, a value from -1 to 1
+fn cos_similarity<'a>(
+    a: &[EdgeTraversal],
+    b: &[EdgeTraversal],
+    dist_fn: Box<dyn Fn(EdgeId) -> Result<f64, SearchError> + 'a>,
+) -> Result<f64, SearchError> {
+    let a_map = a
+        .iter()
+        .map(|e| dist_fn(e.edge_id).map(|dist| (e.edge_id, dist)))
+        .collect::<Result<HashMap<_, _>, _>>()?;
+    let b_map = b
+        .iter()
+        .map(|e| dist_fn(e.edge_id).map(|dist| (e.edge_id, dist)))
+        .collect::<Result<HashMap<_, _>, _>>()?;
+
+    let numer: f64 = a_map
+        .keys()
+        .collect::<HashSet<_>>()
+        .union(&b_map.keys().collect::<HashSet<_>>())
+        .map(|edge_id| {
+            let a_dist = a_map.get(edge_id).cloned().unwrap_or_default();
+            let b_dist = b_map.get(edge_id).cloned().unwrap_or_default();
+            a_dist * b_dist
+        })
+        .sum();
+
+    let denom_a: f64 = a_map.values().map(|d| d * d).sum();
+    let denom_b: f64 = b_map.values().map(|d| d * d).sum();
+    let denom = denom_a.sqrt() * denom_b.sqrt();
+    let cos_sim = numer / denom;
+    Ok(cos_sim)
 }

--- a/rust/routee-compass-core/src/algorithm/search/ksp/route_similarity_function.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/route_similarity_function.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+use crate::algorithm::search::edge_traversal::EdgeTraversal;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum RouteSimilarityFunction {}
+
+impl RouteSimilarityFunction {
+    pub fn rank_similarity(&self, a: Vec<EdgeTraversal>, b: Vec<EdgeTraversal>) -> f64 {
+        todo!()
+    }
+}

--- a/rust/routee-compass-core/src/algorithm/search/ksp/route_similarity_function.rs
+++ b/rust/routee-compass-core/src/algorithm/search/ksp/route_similarity_function.rs
@@ -1,13 +1,104 @@
-use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
-use crate::algorithm::search::edge_traversal::EdgeTraversal;
+use crate::{
+    algorithm::search::{
+        edge_traversal::EdgeTraversal, search_error::SearchError, search_instance::SearchInstance,
+    },
+    model::unit::as_f64::AsF64,
+};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
-pub enum RouteSimilarityFunction {}
+pub enum RouteSimilarityFunction {
+    EdgeIdCosineSimilarity { threshold: f64 },
+    DistanceWeightedCosineSimilarity { threshold: f64 },
+}
 
 impl RouteSimilarityFunction {
-    pub fn rank_similarity(&self, a: Vec<EdgeTraversal>, b: Vec<EdgeTraversal>) -> f64 {
-        todo!()
+    /// tests if a similarity rank value is dissimilar enough.
+    ///
+    /// # Arguments
+    /// * `similarity` - output of this rank_similarity function
+    ///
+    /// # Result
+    ///
+    /// true if the rank is sufficiently dissimilar
+    pub fn sufficiently_dissimilar(&self, similarity: f64) -> bool {
+        match self {
+            RouteSimilarityFunction::EdgeIdCosineSimilarity { threshold } => {
+                similarity <= *threshold
+            }
+            RouteSimilarityFunction::DistanceWeightedCosineSimilarity { threshold } => {
+                similarity <= *threshold
+            }
+        }
+    }
+
+    /// tests if a similarity rank value is similar enough.
+    ///
+    /// # Arguments
+    /// * `similarity` - output of this rank_similarity function
+    ///
+    /// # Result
+    ///
+    /// true if the rank is sufficiently similar
+    pub fn sufficiently_similar(&self, similarity: f64) -> bool {
+        !self.sufficiently_dissimilar(similarity)
+    }
+
+    /// ranks the similarity of two routes using this similarity function.
+    ///
+    /// # Arguments
+    /// * `a`  - one route
+    /// * `b`  - another route
+    /// * `si` - search instance for these routes
+    ///
+    /// # Returns
+    /// the similarity ranking of these routes
+    pub fn rank_similarity(
+        &self,
+        a: &[EdgeTraversal],
+        b: &[EdgeTraversal],
+        si: &SearchInstance,
+    ) -> Result<f64, SearchError> {
+        match self {
+            RouteSimilarityFunction::EdgeIdCosineSimilarity { threshold: _ } => {
+                let numer = a
+                    .iter()
+                    .map(|e| e.edge_id)
+                    .collect::<HashSet<_>>()
+                    .intersection(&b.iter().map(|e| e.edge_id).collect::<HashSet<_>>())
+                    .collect::<Vec<_>>()
+                    .len();
+                let denom = a.len() + b.len();
+                if denom == 0 {
+                    Ok(0.0)
+                } else {
+                    Ok(numer as f64 / denom as f64)
+                }
+            }
+            RouteSimilarityFunction::DistanceWeightedCosineSimilarity { threshold: _ } => {
+                let a_set = a
+                    .iter()
+                    .map(|e| {
+                        si.directed_graph
+                            .get_edge(e.edge_id)
+                            .map(|edge| (e.edge_id, edge.distance.as_f64()))
+                    })
+                    .collect::<Result<HashMap<_, _>, _>>()?;
+                let b_set = b
+                    .iter()
+                    .flat_map(|e| a_set.get(&e.edge_id).copied())
+                    .collect::<Vec<_>>();
+                let numer: f64 = b_set.into_iter().sum();
+                let denom = a.len() + b.len();
+                if denom == 0 {
+                    Ok(0.0)
+                } else {
+                    Ok(numer / denom as f64)
+                }
+            }
+        }
     }
 }

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -1,8 +1,8 @@
-use super::a_star::a_star_algorithm;
 use super::backtrack;
 use super::search_algorithm_result::SearchAlgorithmResult;
 use super::search_error::SearchError;
 use super::search_instance::SearchInstance;
+use super::{a_star::a_star_algorithm, direction::Direction};
 use crate::model::road_network::{edge_id::EdgeId, vertex_id::VertexId};
 use serde::{Deserialize, Serialize};
 
@@ -26,8 +26,12 @@ impl SearchAlgorithm {
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
             SearchAlgorithm::AStarAlgorithm => {
-                let search_result =
-                    a_star_algorithm::run_a_star(src_id, dst_id_opt, search_instance)?;
+                let search_result = a_star_algorithm::run_a_star(
+                    src_id,
+                    dst_id_opt,
+                    &Direction::Forward,
+                    search_instance,
+                )?;
                 let routes = match dst_id_opt {
                     None => vec![],
                     Some(dst_id) => {
@@ -59,6 +63,7 @@ impl SearchAlgorithm {
                 let search_result = a_star_algorithm::run_a_star_edge_oriented(
                     src_id,
                     dst_id_opt,
+                    &Direction::Forward,
                     search_instance,
                 )?;
                 let routes = match dst_id_opt {

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -1,12 +1,16 @@
 use super::backtrack;
+use super::edge_traversal::EdgeTraversal;
 use super::ksp::ksp_single_via_paths;
 use super::ksp::route_similarity_function::RouteSimilarityFunction;
 use super::search_algorithm_result::SearchAlgorithmResult;
 use super::search_error::SearchError;
 use super::search_instance::SearchInstance;
+use super::search_tree_branch::SearchTreeBranch;
 use super::{a_star::a_star_algorithm, direction::Direction};
 use crate::model::road_network::{edge_id::EdgeId, vertex_id::VertexId};
+use crate::model::unit::Cost;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
@@ -97,7 +101,150 @@ impl SearchAlgorithm {
                 k: _,
                 underlying: _,
                 similarity: _,
-            } => todo!(),
+            } => run_edge_oriented(src_id, dst_id_opt, direction, self, search_instance),
+        }
+    }
+}
+
+// convenience method when origin and destination are specified using
+/// edge ids instead of vertex ids. invokes a vertex-oriented search
+/// from the out-vertex of the source edge to the in-vertex of the
+/// target edge. composes the result with the source and target.
+///
+/// not tested.
+pub fn run_edge_oriented(
+    source: EdgeId,
+    target: Option<EdgeId>,
+    direction: &Direction,
+    alg: &SearchAlgorithm,
+    si: &SearchInstance,
+) -> Result<SearchAlgorithmResult, SearchError> {
+    // 1. guard against edge conditions (src==dst, src.dst_v == dst.src_v)
+    let e1_src = si.directed_graph.src_vertex_id(source)?;
+    let e1_dst = si.directed_graph.dst_vertex_id(source)?;
+    let src_et = EdgeTraversal {
+        edge_id: source,
+        access_cost: Cost::ZERO,
+        traversal_cost: Cost::ZERO,
+        result_state: si.state_model.initial_state()?,
+    };
+
+    match target {
+        None => {
+            let src_branch = SearchTreeBranch {
+                terminal_vertex: e1_src,
+                edge_traversal: src_et.clone(),
+            };
+            let SearchAlgorithmResult {
+                mut trees,
+                mut routes,
+                iterations,
+            } = alg.run_vertex_oriented(e1_dst, None, direction, si)?;
+            for tree in trees.iter_mut() {
+                if !tree.contains_key(&e1_dst) {
+                    tree.extend([(e1_dst, src_branch.clone())]);
+                }
+            }
+            for route in routes.iter_mut() {
+                route.insert(0, src_et.clone());
+            }
+            let updated = SearchAlgorithmResult {
+                trees,
+                routes,
+                iterations: iterations + 1,
+            };
+            Ok(updated)
+        }
+        Some(target_edge) => {
+            let e2_src = si.directed_graph.src_vertex_id(target_edge)?;
+            let e2_dst = si.directed_graph.dst_vertex_id(target_edge)?;
+
+            if source == target_edge {
+                Ok(SearchAlgorithmResult::default())
+            } else if e1_dst == e2_src {
+                // route is simply source -> target
+                let init_state = si.state_model.initial_state()?;
+                let src_et = EdgeTraversal::forward_traversal(source, None, &init_state, si)?;
+                let dst_et = EdgeTraversal::forward_traversal(
+                    target_edge,
+                    Some(source),
+                    &src_et.result_state,
+                    si,
+                )?;
+                let src_traversal = SearchTreeBranch {
+                    terminal_vertex: e2_src,
+                    edge_traversal: dst_et.clone(),
+                };
+                let dst_traversal = SearchTreeBranch {
+                    terminal_vertex: e1_src,
+                    edge_traversal: src_et.clone(),
+                };
+                let tree = HashMap::from([(e2_dst, src_traversal), (e1_dst, dst_traversal)]);
+                let route = vec![src_et, dst_et];
+                let result = SearchAlgorithmResult {
+                    trees: vec![tree],
+                    routes: vec![route],
+                    iterations: 1,
+                };
+                return Ok(result);
+            } else {
+                // run a search and append source/target edges to result
+                let SearchAlgorithmResult {
+                    trees,
+                    mut routes,
+                    iterations,
+                } = alg.run_vertex_oriented(e1_dst, Some(e2_src), direction, si)?;
+
+                if trees.is_empty() {
+                    return Err(SearchError::NoPathExists(e1_dst, e2_src));
+                }
+                // let src_branch = SearchTreeBranch {
+                //     terminal_vertex: e1_src,
+                //     edge_traversal: src_et.clone(),
+                // };
+
+                // it is possible that the search already found these vertices. one major edge
+                // case is when the trip starts with a u-turn.
+                for route in routes.iter_mut() {
+                    let final_branch =
+                        trees.iter().find_map(|t| t.get(&e2_src)).ok_or_else(|| {
+                            SearchError::InternalSearchError(format!(
+                                "finished search with trees but none contain required vertex {}",
+                                e2_src
+                            ))
+                        })?;
+                    // let final_state = &tree
+                    //     .get(&e2_src)
+                    //     .ok_or_else(|| SearchError::VertexMissingFromSearchTree(e2_src))?
+                    //     .edge_traversal
+                    //     .result_state;
+                    let dst_et = EdgeTraversal {
+                        edge_id: target_edge,
+                        access_cost: Cost::ZERO,
+                        traversal_cost: Cost::ZERO,
+                        result_state: final_branch.edge_traversal.result_state.to_vec(),
+                    };
+                    // let dst_branch = SearchTreeBranch {
+                    //     terminal_vertex: e2_src,
+                    //     edge_traversal: dst_et.clone(),
+                    // };
+                    // if !tree.contains_key(&e1_dst) {
+                    //     tree.extend([(e1_dst, src_branch.clone())]);
+                    // }
+                    // if !tree.contains_key(&e2_dst) {
+                    //     tree.extend([(e2_dst, dst_branch.clone())]);
+                    // }
+                    route.insert(0, src_et.clone());
+                    route.push(dst_et.clone());
+                }
+
+                let result = SearchAlgorithmResult {
+                    trees,
+                    routes,
+                    iterations: iterations + 2,
+                };
+                Ok(result)
+            }
         }
     }
 }

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -198,42 +198,20 @@ pub fn run_edge_oriented(
                 if trees.is_empty() {
                     return Err(SearchError::NoPathExists(e1_dst, e2_src));
                 }
-                // let src_branch = SearchTreeBranch {
-                //     terminal_vertex: e1_src,
-                //     edge_traversal: src_et.clone(),
-                // };
 
                 // it is possible that the search already found these vertices. one major edge
                 // case is when the trip starts with a u-turn.
                 for route in routes.iter_mut() {
-                    let final_branch =
-                        trees.iter().find_map(|t| t.get(&e2_src)).ok_or_else(|| {
-                            SearchError::InternalSearchError(format!(
-                                "finished search with trees but none contain required vertex {}",
-                                e2_src
-                            ))
-                        })?;
-                    // let final_state = &tree
-                    //     .get(&e2_src)
-                    //     .ok_or_else(|| SearchError::VertexMissingFromSearchTree(e2_src))?
-                    //     .edge_traversal
-                    //     .result_state;
+                    let final_state = route.last().ok_or_else(|| {
+                        SearchError::InternalSearchError(String::from("found empty result route"))
+                    })?;
+
                     let dst_et = EdgeTraversal {
                         edge_id: target_edge,
                         access_cost: Cost::ZERO,
                         traversal_cost: Cost::ZERO,
-                        result_state: final_branch.edge_traversal.result_state.to_vec(),
+                        result_state: final_state.result_state.to_vec(),
                     };
-                    // let dst_branch = SearchTreeBranch {
-                    //     terminal_vertex: e2_src,
-                    //     edge_traversal: dst_et.clone(),
-                    // };
-                    // if !tree.contains_key(&e1_dst) {
-                    //     tree.extend([(e1_dst, src_branch.clone())]);
-                    // }
-                    // if !tree.contains_key(&e2_dst) {
-                    //     tree.extend([(e2_dst, dst_branch.clone())]);
-                    // }
                     route.insert(0, src_et.clone());
                     route.push(dst_et.clone());
                 }

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -1,4 +1,6 @@
 use super::backtrack;
+use super::ksp::ksp_single_via_paths;
+use super::ksp::route_similarity_function::RouteSimilarityFunction;
 use super::search_algorithm_result::SearchAlgorithmResult;
 use super::search_error::SearchError;
 use super::search_instance::SearchInstance;
@@ -14,6 +16,7 @@ pub enum SearchAlgorithm {
     KspSingleVia {
         k: usize,
         underlying: Box<SearchAlgorithm>,
+        similarity: RouteSimilarityFunction,
     },
 }
 
@@ -22,16 +25,13 @@ impl SearchAlgorithm {
         &self,
         src_id: VertexId,
         dst_id_opt: Option<VertexId>,
-        search_instance: &SearchInstance,
+        direction: &Direction,
+        si: &SearchInstance,
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
             SearchAlgorithm::AStarAlgorithm => {
-                let search_result = a_star_algorithm::run_a_star(
-                    src_id,
-                    dst_id_opt,
-                    &Direction::Forward,
-                    search_instance,
-                )?;
+                let search_result =
+                    a_star_algorithm::run_a_star(src_id, dst_id_opt, direction, si)?;
                 let routes = match dst_id_opt {
                     None => vec![],
                     Some(dst_id) => {
@@ -47,15 +47,24 @@ impl SearchAlgorithm {
                 })
             }
             SearchAlgorithm::KspSingleVia {
-                k: _,
-                underlying: _,
-            } => todo!(),
+                k,
+                underlying,
+                similarity,
+            } => match dst_id_opt {
+                Some(dst_id) => {
+                    ksp_single_via_paths::run(src_id, dst_id, *k, similarity, si, underlying)
+                }
+                None => Err(SearchError::BuildError(String::from(
+                    "request has source but no destination which is invalid for k-shortest paths",
+                ))),
+            },
         }
     }
     pub fn run_edge_oriented(
         &self,
         src_id: EdgeId,
         dst_id_opt: Option<EdgeId>,
+        direction: &Direction,
         search_instance: &SearchInstance,
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
@@ -63,7 +72,7 @@ impl SearchAlgorithm {
                 let search_result = a_star_algorithm::run_a_star_edge_oriented(
                     src_id,
                     dst_id_opt,
-                    &Direction::Forward,
+                    direction,
                     search_instance,
                 )?;
                 let routes = match dst_id_opt {
@@ -87,6 +96,7 @@ impl SearchAlgorithm {
             SearchAlgorithm::KspSingleVia {
                 k: _,
                 underlying: _,
+                similarity: _,
             } => todo!(),
         }
     }

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm_result.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm_result.rs
@@ -2,6 +2,7 @@ use super::{edge_traversal::EdgeTraversal, search_tree_branch::SearchTreeBranch}
 use crate::model::road_network::vertex_id::VertexId;
 use std::collections::HashMap;
 
+#[derive(Default)]
 pub struct SearchAlgorithmResult {
     pub trees: Vec<HashMap<VertexId, SearchTreeBranch>>,
     pub routes: Vec<Vec<EdgeTraversal>>,

--- a/rust/routee-compass-core/src/model/road_network/graph.rs
+++ b/rust/routee-compass-core/src/model/road_network/graph.rs
@@ -142,10 +142,10 @@ impl Graph {
         }
     }
 
-    pub fn out_edges_iter(
-        &self,
+    pub fn out_edges_iter<'a>(
+        &'a self,
         src: VertexId,
-    ) -> Result<impl Iterator<Item = &EdgeId>, GraphError> {
+    ) -> Result<Box<dyn Iterator<Item = &EdgeId> + 'a>, GraphError> {
         match self.adj.get(src.0) {
             None => Err(GraphError::VertexWithoutOutEdges { vertex_id: src }),
             Some(out_map) => {
@@ -175,10 +175,10 @@ impl Graph {
         }
     }
 
-    pub fn in_edges_iter(
-        &self,
+    pub fn in_edges_iter<'a>(
+        &'a self,
         dst: VertexId,
-    ) -> Result<impl Iterator<Item = &EdgeId>, GraphError> {
+    ) -> Result<Box<dyn Iterator<Item = &EdgeId> + 'a>, GraphError> {
         match self.rev.get(dst.0) {
             None => Err(GraphError::VertexWithoutInEdges { vertex_id: dst }),
             Some(in_map) => {

--- a/rust/routee-compass-core/src/model/termination/termination_model.rs
+++ b/rust/routee-compass-core/src/model/termination/termination_model.rs
@@ -46,7 +46,7 @@ impl TerminationModel {
                 Some(msg) => return Err(TerminationModelError::QueryTerminated(msg)),
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     /// predicate to test whether a query should terminate based on

--- a/rust/routee-compass-core/src/model/termination/termination_model.rs
+++ b/rust/routee-compass-core/src/model/termination/termination_model.rs
@@ -24,6 +24,31 @@ pub enum TerminationModel {
 }
 
 impl TerminationModel {
+    /// Tests if the search should terminate.
+    pub fn test(
+        &self,
+        start_time: &Instant,
+        solution_size: usize,
+        iterations: u64,
+    ) -> Result<(), TerminationModelError> {
+        let should_terminate = self.terminate_search(start_time, solution_size, iterations)?;
+        if should_terminate {
+            let explanation = self.explain_termination(start_time, solution_size, iterations);
+            match explanation {
+                None => {
+                    return Err(TerminationModelError::RuntimeError(format!(
+                        "unable to explain termination with start_time, solution_size, iterations: {:?}, {}, {}",
+                        &start_time,
+                        solution_size,
+                        iterations
+                    )))
+                }
+                Some(msg) => return Err(TerminationModelError::QueryTerminated(msg)),
+            }
+        }
+        return Ok(());
+    }
+
     /// predicate to test whether a query should terminate based on
     /// application-level configurations
     pub fn terminate_search(

--- a/rust/routee-compass-core/src/model/termination/termination_model_error.rs
+++ b/rust/routee-compass-core/src/model/termination/termination_model_error.rs
@@ -1,2 +1,7 @@
 #[derive(thiserror::Error, Debug, Clone)]
-pub enum TerminationModelError {}
+pub enum TerminationModelError {
+    #[error("query terminated due to {0}")]
+    QueryTerminated(String),
+    #[error("termination model runtime error {0}")]
+    RuntimeError(String),
+}

--- a/rust/routee-compass-core/src/util/priority_queue.rs
+++ b/rust/routee-compass-core/src/util/priority_queue.rs
@@ -30,3 +30,9 @@ impl<H: Hash + Eq + Allocative, I: Ord + Allocative, S> Allocative
         let _visitor = visitor.enter_self_sized::<Self>();
     }
 }
+
+impl<I: Hash + Eq, P: Ord> Default for InternalPriorityQueue<I, P, RandomState> {
+    fn default() -> InternalPriorityQueue<I, P, RandomState> {
+        InternalPriorityQueue(PriorityQueue::new())
+    }
+}

--- a/rust/routee-compass/src/app/search/search_app.rs
+++ b/rust/routee-compass/src/app/search/search_app.rs
@@ -10,8 +10,9 @@ use crate::{
 use chrono::Local;
 use routee_compass_core::{
     algorithm::search::{
-        search_algorithm::SearchAlgorithm, search_algorithm_result::SearchAlgorithmResult,
-        search_error::SearchError, search_instance::SearchInstance,
+        direction::Direction, search_algorithm::SearchAlgorithm,
+        search_algorithm_result::SearchAlgorithmResult, search_error::SearchError,
+        search_instance::SearchInstance,
     },
     model::{
         access::access_model_service::AccessModelService,
@@ -120,7 +121,7 @@ impl SearchApp {
 
         let search_instance = self.build_search_instance(query)?;
         self.search_algorithm
-            .run_vertex_oriented(o, d, &search_instance)
+            .run_vertex_oriented(o, d, &Direction::Forward, &search_instance)
             .map(|search_result| (search_result, search_instance))
             .map_err(CompassAppError::SearchError)
     }
@@ -137,7 +138,7 @@ impl SearchApp {
             .map_err(CompassAppError::PluginError)?;
         let search_instance = self.build_search_instance(query)?;
         self.search_algorithm
-            .run_edge_oriented(o, d_opt, &search_instance)
+            .run_edge_oriented(o, d_opt, &Direction::Forward, &search_instance)
             .map(|search_result| (search_result, search_instance))
             .map_err(CompassAppError::SearchError)
     }


### PR DESCRIPTION
Here is a draft of a ksp algorithm that could possibly work well at national scale. It requires running a bi-directional a* search tree algorithm and then selecting candidate spots from the intersecting vertices from where to join paths from each search. It does this until it can generate $k$ paths meeting some (dis-) similarity threshold.

This _compiles_ but is not correct, but since my parental leave is imminent, I want to surface this in the condition it's in. Planning to wrap it up in the next few days. My current issue is a "search tree is missing linked vertex 413760" error, which may be due to how I'm building the two a* searches (one must be _reverse_-oriented) or how i collect the two routes into a new one.

In order to rule out mapping from edges to vertices, I am simply using the vertex rtree plugin and turning off road class filtering, since those could also cause connectivity issues.