### PR TITLE
Add distance to state model in SpeedTraversalModel and other small fixes

### DIFF
--- a/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
@@ -85,6 +85,12 @@ impl TraversalModel for SpeedTraversalModel {
             &estimated_time,
             &self.engine.time_unit,
         )?;
+        state_model.add_distance(
+            state,
+            &Self::DISTANCE.into(),
+            &distance,
+            &self.engine.distance_unit,
+        )?;
 
         Ok(())
     }

--- a/rust/routee-compass-core/src/util/priority_queue.rs
+++ b/rust/routee-compass-core/src/util/priority_queue.rs
@@ -30,3 +30,36 @@ impl<H: Hash + Eq + Allocative, I: Ord + Allocative, S> Allocative
         let _visitor = visitor.enter_self_sized::<Self>();
     }
 }
+
+mod tests {
+    use crate::model::{
+        road_network::vertex_id::VertexId,
+        unit::{cost::ReverseCost, Cost},
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_priority_queue() {
+        let mut costs: InternalPriorityQueue<VertexId, ReverseCost> =
+            InternalPriorityQueue(PriorityQueue::new());
+
+        costs.push(VertexId(0), Cost::from(0.0003).into());
+        costs.push(VertexId(1), Cost::from(0.0001).into());
+        costs.push(VertexId(2), Cost::from(0.0002).into());
+
+        let (vertex_id, _cost) = costs.pop().unwrap();
+
+        assert_eq!(vertex_id, VertexId(1));
+
+        costs.push_increase(VertexId(0), Cost::from(0.00001).into());
+
+        let (vertex_id, cost) = costs.pop().unwrap();
+
+        assert_eq!(vertex_id, VertexId(0));
+
+        let (vertex_id, cost) = costs.pop().unwrap();
+
+        assert_eq!(vertex_id, VertexId(2));
+    }
+}

--- a/rust/routee-compass/src/app/cli/cli_args.rs
+++ b/rust/routee-compass/src/app/cli/cli_args.rs
@@ -17,7 +17,7 @@ pub struct CliArgs {
     pub query_file: String,
 
     /// Size of batches to load into memory at a time
-    #[arg(short, long)]
+    #[arg(long)]
     pub chunksize: Option<i64>,
 
     /// Format of JSON queries file, if regular JSON or newline-delimited JSON

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
@@ -78,10 +78,10 @@ impl TraversalModelBuilder for EnergyModelBuilder {
         }
 
         let time_unit_option = params
-            .get_config_serde_optional::<TimeUnit>(&"output_time_unit", &parent_key)
+            .get_config_serde_optional::<TimeUnit>(&"time_unit", &parent_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let distance_unit_option = params
-            .get_config_serde_optional::<DistanceUnit>(&"output_distance_unit", &parent_key)
+            .get_config_serde_optional::<DistanceUnit>(&"distance_unit", &parent_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let service = EnergyModelService::new(

--- a/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/traversal_model/energy_model_builder.rs
@@ -78,10 +78,10 @@ impl TraversalModelBuilder for EnergyModelBuilder {
         }
 
         let time_unit_option = params
-            .get_config_serde_optional::<TimeUnit>(&"time_unit", &parent_key)
+            .get_config_serde_optional::<TimeUnit>(&"output_time_unit", &parent_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
         let distance_unit_option = params
-            .get_config_serde_optional::<DistanceUnit>(&"distance_unit", &parent_key)
+            .get_config_serde_optional::<DistanceUnit>(&"output_distance_unit", &parent_key)
             .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
 
         let service = EnergyModelService::new(


### PR DESCRIPTION
Some small fixes uncovered during a recent debugging session:
 - speed traversal model didn't add distance during the state estimation
 - adds a test to priority queue to make sure it works properly with reverse costs
 - corrects the expected keys for energy time and distance units
 - for the CLI app, sets `--chunksize` to only a long argument since the short argument `-c` conflicts with `--config-file`