### PR TITLE
Rjf/a star weight factor

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -8,6 +8,7 @@ use super::search_instance::SearchInstance;
 use super::search_tree_branch::SearchTreeBranch;
 use super::{a_star::a_star_algorithm, direction::Direction};
 use crate::model::road_network::{edge_id::EdgeId, vertex_id::VertexId};
+use crate::model::unit::as_f64::AsF64;
 use crate::model::unit::Cost;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -16,7 +17,7 @@ use std::collections::HashMap;
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum SearchAlgorithm {
     #[serde(rename = "a*")]
-    AStarAlgorithm,
+    AStarAlgorithm { weight_factor: Option<Cost> },
     KspSingleVia {
         k: usize,
         underlying: Box<SearchAlgorithm>,
@@ -33,9 +34,14 @@ impl SearchAlgorithm {
         si: &SearchInstance,
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
-            SearchAlgorithm::AStarAlgorithm => {
-                let search_result =
-                    a_star_algorithm::run_a_star(src_id, dst_id_opt, direction, si)?;
+            SearchAlgorithm::AStarAlgorithm { weight_factor } => {
+                let search_result = a_star_algorithm::run_a_star(
+                    src_id,
+                    dst_id_opt,
+                    direction,
+                    *weight_factor,
+                    si,
+                )?;
                 let routes = match dst_id_opt {
                     None => vec![],
                     Some(dst_id) => {
@@ -72,11 +78,12 @@ impl SearchAlgorithm {
         search_instance: &SearchInstance,
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
-            SearchAlgorithm::AStarAlgorithm => {
+            SearchAlgorithm::AStarAlgorithm { weight_factor } => {
                 let search_result = a_star_algorithm::run_a_star_edge_oriented(
                     src_id,
                     dst_id_opt,
                     direction,
+                    *weight_factor,
                     search_instance,
                 )?;
                 let routes = match dst_id_opt {

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -38,7 +38,7 @@ impl SearchAlgorithm {
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
             SearchAlgorithm::Dijkstra => SearchAlgorithm::AStarAlgorithm {
-                weight_factor: Some(Cost::ONE),
+                weight_factor: Some(Cost::ZERO),
             }
             .run_vertex_oriented(src_id, dst_id_opt, direction, si),
             SearchAlgorithm::AStarAlgorithm { weight_factor } => {
@@ -86,7 +86,7 @@ impl SearchAlgorithm {
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
             SearchAlgorithm::Dijkstra => SearchAlgorithm::AStarAlgorithm {
-                weight_factor: Some(Cost::ONE),
+                weight_factor: Some(Cost::ZERO),
             }
             .run_edge_oriented(src_id, dst_id_opt, direction, search_instance),
             SearchAlgorithm::AStarAlgorithm { weight_factor } => {

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -8,7 +8,7 @@ use super::search_instance::SearchInstance;
 use super::search_tree_branch::SearchTreeBranch;
 use super::{a_star::a_star_algorithm, direction::Direction};
 use crate::model::road_network::{edge_id::EdgeId, vertex_id::VertexId};
-use crate::model::unit::as_f64::AsF64;
+
 use crate::model::unit::Cost;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -16,8 +16,11 @@ use std::collections::HashMap;
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum SearchAlgorithm {
+    Dijkstra,
     #[serde(rename = "a*")]
-    AStarAlgorithm { weight_factor: Option<Cost> },
+    AStarAlgorithm {
+        weight_factor: Option<Cost>,
+    },
     KspSingleVia {
         k: usize,
         underlying: Box<SearchAlgorithm>,
@@ -34,6 +37,10 @@ impl SearchAlgorithm {
         si: &SearchInstance,
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
+            SearchAlgorithm::Dijkstra => SearchAlgorithm::AStarAlgorithm {
+                weight_factor: Some(Cost::ONE),
+            }
+            .run_vertex_oriented(src_id, dst_id_opt, direction, si),
             SearchAlgorithm::AStarAlgorithm { weight_factor } => {
                 let search_result = a_star_algorithm::run_a_star(
                     src_id,
@@ -78,6 +85,10 @@ impl SearchAlgorithm {
         search_instance: &SearchInstance,
     ) -> Result<SearchAlgorithmResult, SearchError> {
         match self {
+            SearchAlgorithm::Dijkstra => SearchAlgorithm::AStarAlgorithm {
+                weight_factor: Some(Cost::ONE),
+            }
+            .run_edge_oriented(src_id, dst_id_opt, direction, search_instance),
             SearchAlgorithm::AStarAlgorithm { weight_factor } => {
                 let search_result = a_star_algorithm::run_a_star_edge_oriented(
                     src_id,


### PR DESCRIPTION
This PR adds an optional argument for the a* algorithm. this allows the user to get dijkstra's algorithm:

```toml
[algorithm]
type = "a*"
weight_factor = 0.0
```

actually, config-wise, there is also a `dijkstra` algorithm now that is semantically equivalent:

```toml
[algorithm]
type = "dijkstra"
```

Closes #195.