### PR TITLE
Allow extra weights in Cost Model

### DIFF
--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
@@ -32,16 +32,16 @@ impl CostModelBuilder {
             .get_config_serde_optional(&"cost_aggregation", &parent_key)?
             .unwrap_or_default();
 
-        let expect_exact_weights = config
-            .get_config_serde_optional(&"expect_exact_weights", &parent_key)?
-            .unwrap_or_default();
+        let ignore_unknown_weights = config
+            .get_config_serde_optional(&"ignore_unknown_user_provided_weights", &parent_key)?
+            .unwrap_or(true);
 
         let model = CostModelService {
             vehicle_rates: Arc::new(vehicle_rates),
             network_rates: Arc::new(network_rates),
             weights: Arc::new(weights),
             cost_aggregation,
-            expect_exact_weights,
+            ignore_unknown_weights,
         };
         Ok(model)
     }

--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_builder.rs
@@ -32,11 +32,16 @@ impl CostModelBuilder {
             .get_config_serde_optional(&"cost_aggregation", &parent_key)?
             .unwrap_or_default();
 
+        let expect_exact_weights = config
+            .get_config_serde_optional(&"expect_exact_weights", &parent_key)?
+            .unwrap_or_default();
+
         let model = CostModelService {
             vehicle_rates: Arc::new(vehicle_rates),
             network_rates: Arc::new(network_rates),
             weights: Arc::new(weights),
             cost_aggregation,
+            expect_exact_weights,
         };
         Ok(model)
     }

--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
@@ -17,7 +17,7 @@ pub struct CostModelService {
     pub network_rates: Arc<HashMap<String, NetworkCostRate>>,
     pub weights: Arc<HashMap<String, f64>>,
     pub cost_aggregation: CostAggregation,
-    pub expect_exact_weights: bool,
+    pub ignore_unknown_weights: bool,
 }
 
 impl CostModelService {
@@ -67,7 +67,7 @@ impl CostModelService {
             .collect::<Vec<_>>();
 
         // validate user input, no query state variables provided that are unknown to traversal model
-        if weights.len() != query_state_indices.len() && self.expect_exact_weights {
+        if weights.len() != query_state_indices.len() && !self.ignore_unknown_weights {
             let names_lookup: HashSet<&String> =
                 query_state_indices.iter().map(|(n, _)| n).collect();
 
@@ -79,7 +79,7 @@ impl CostModelService {
                 .collect::<Vec<_>>()
                 .join(",");
 
-            let msg = format!("unknown state variables in query: [{}]", extras);
+            let msg = format!("unknown weights in query: [{}]", extras);
             return Err(CompassConfigurationError::UserConfigurationError(msg));
         }
 

--- a/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
+++ b/rust/routee-compass/src/app/compass/config/cost_model/cost_model_service.rs
@@ -17,6 +17,7 @@ pub struct CostModelService {
     pub network_rates: Arc<HashMap<String, NetworkCostRate>>,
     pub weights: Arc<HashMap<String, f64>>,
     pub cost_aggregation: CostAggregation,
+    pub expect_exact_weights: bool,
 }
 
 impl CostModelService {
@@ -66,7 +67,7 @@ impl CostModelService {
             .collect::<Vec<_>>();
 
         // validate user input, no query state variables provided that are unknown to traversal model
-        if weights.len() != query_state_indices.len() {
+        if weights.len() != query_state_indices.len() && self.expect_exact_weights {
             let names_lookup: HashSet<&String> =
                 query_state_indices.iter().map(|(n, _)| n).collect();
 


### PR DESCRIPTION
Implements #205 by adding a new configuration parameter on the cost model `expect_exact_weights`. If this is set to false, the application will allow extra weights to be passed through, opening up the possibility of doing a grid search over traversal model that have different weights.