### PR TITLE
Fix PyO3 0.21 deprecation warnings

### DIFF
--- a/docs/notebooks/open_street_maps_example.ipynb
+++ b/docs/notebooks/open_street_maps_example.ipynb
@@ -32,7 +32,14 @@
     "import json\n",
     "\n",
     "from nrel.routee.compass.io import generate_compass_dataset\n",
-    "from nrel.routee.compass import CompassApp"
+    "from nrel.routee.compass import CompassApp\n",
+    "\n",
+    "# Try importing required packages to fail sooner if absent\n",
+    "try:\n",
+    "    import rasterio\n",
+    "    from osgeo import gdal\n",
+    "except:\n",
+    "    raise ImportError(\"Not all dependencies are installed\")"
    ]
   },
   {

--- a/rust/routee-compass-macros/src/lib.rs
+++ b/rust/routee-compass-macros/src/lib.rs
@@ -65,9 +65,8 @@ pub fn pybindings(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     ))
                 })
             }
-            #[classmethod]
+            #[staticmethod]
             pub fn _from_config_toml_string(
-                _cls: &PyType,
                 config_string: String,
                 original_file_path: String,
             ) -> PyResult<#name> {

--- a/rust/routee-compass-py/src/lib.rs
+++ b/rust/routee-compass-py/src/lib.rs
@@ -6,7 +6,7 @@ use app_wrapper::CompassAppWrapper;
 use pyo3::prelude::*;
 
 #[pymodule]
-fn routee_compass_py(_py: Python, m: &PyModule) -> PyResult<()> {
+fn routee_compass_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<CompassAppWrapper>()?;
 
     Ok(())


### PR DESCRIPTION
Also add `rasterio` and `gdal` imports at the top of the OSM example notebook to fail faster (rather than waiting for grade data to download on slow PyCon wifi)

https://pyo3.rs/v0.21.2/migration#from-020-to-021

According to the above link, there are some API changes for 0.21 to remove GIL markers. This means changing the pymodule def:

```diff
#[pymodule]
- fn routee_compass_py(_py: Python, m: &PyModule) -> PyResult<()> {
+ fn routee_compass_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
```

As well as classmethod defs (though this one could be a staticmethod and it works just fine, since we don't use the pyclass):

```diff
- #[classmethod]
- pub fn _from_config_toml_string(
-     _cls: &PyType,
-     config_string: String,
-     original_file_path: String,
- ) -> PyResult<#name> {
+ #[staticmethod]
+ pub fn _from_config_toml_string(
+     config_string: String,
+     original_file_path: String,
+ ) -> PyResult<#name> {
```

Also in the OSM example I had issues with failing imports during grade data building, so I added a try/except at the top to catch those errors sooner.

Fixes #167 