### PR TITLE
Replace OSMnx graph_utils usage with truncate

### DIFF
--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -74,7 +74,7 @@ def generate_compass_dataset(
 
     # pre-process the graph
     print("processing graph topology and speeds")
-    g1 = ox.utils_graph.get_largest_component(g)
+    g1 = ox.truncate.largest_component(g)
     g1 = ox.add_edge_speeds(g1, hwy_speeds=hwy_speeds, fallback=fallback, agg=agg)
     g1 = ox.add_edge_bearings(g1)
 


### PR DESCRIPTION
Closes #217

This changeset replaces `osmnx.utils_graph.get_largest_component()` usage with `osmnx.truncate.largest_component()`