### PR TITLE
Add Ruff as a linter and formatter, replacing Black

### DIFF
--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -40,9 +40,13 @@ jobs:
       # - name: Run mypy
       #   run: mypy . --ignore-missing-imports
 
-      - name: Validate formatting
+      - name: Run linter
         run: |
-          black python --check
+          ruff check python
+
+      - name: Run formatter
+        run: |
+          ruff format python
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 keywords = ["eco routing"]
 dependencies = ["toml"]
 [project.optional-dependencies]
-dev = ["black", "pytest", "maturin", "jupyter-book", "sphinx-book-theme"]
+dev = ["pytest", "maturin", "jupyter-book", "ruff", "sphinx-book-theme"]
 
 [project.urls]
 Homepage = "https://github.com/NREL/routee-compass"

--- a/python/nrel/routee/compass/__init__.py
+++ b/python/nrel/routee/compass/__init__.py
@@ -6,3 +6,6 @@ from pathlib import Path
 
 def package_root() -> Path:
     return Path(__file__).parent
+
+
+__all__ = ("CompassApp", "generate_compass_dataset", "package_root")

--- a/python/nrel/routee/compass/io/__init__.py
+++ b/python/nrel/routee/compass/io/__init__.py
@@ -1,1 +1,3 @@
 from .generate_dataset import generate_compass_dataset
+
+__all__ = ("generate_compass_dataset",)

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -189,9 +189,9 @@ def generate_compass_dataset(
                 init_toml = toml.loads(f.read())
                 if filename == "osm_default_energy.toml":
                     if add_grade:
-                        init_toml["traversal"][
-                            "grade_table_input_input_file"
-                        ] = "edges-grade-enumerated.txt.gz"
+                        init_toml["traversal"]["grade_table_input_input_file"] = (
+                            "edges-grade-enumerated.txt.gz"
+                        )
                         init_toml["traversal"]["grade_table_grade_unit"] = "decimal"
             with open(output_directory / filename, "w") as f:
                 f.write(toml.dumps(init_toml))

--- a/python/nrel/routee/compass/plot/__init__.py
+++ b/python/nrel/routee/compass/plot/__init__.py
@@ -1,1 +1,3 @@
 from .plot_folium import plot_route_folium, plot_routes_folium
+
+__all__ = ("plot_route_folium", "plot_routes_folium")


### PR DESCRIPTION
This change adds Ruff linting and formatting to the GitHub Actions `python-build-test.yaml` workflow, replacing Black as a formatter. This change also applies the necessary linting and formatting to all existing Python files.

Closes #215.