### PR TITLE
Complete type annotations

### DIFF
--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -37,8 +37,8 @@ jobs:
         run: |
           pip install ".[dev]"
 
-      # - name: Run mypy
-      #   run: mypy . --ignore-missing-imports
+      - name: Run mypy
+        run: mypy --strict ./python/nrel
 
       - name: Validate formatting
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,17 @@ classifiers = [
 keywords = ["eco routing"]
 dependencies = ["toml"]
 [project.optional-dependencies]
-dev = ["black", "pytest", "maturin", "jupyter-book", "sphinx-book-theme"]
+dev = [
+    "black",
+    "jupyter-book",
+    "maturin",
+    "mypy",
+    "pytest",
+    "sphinx-book-theme",
+    "types-requests",
+    "types-setuptools",
+    "types-toml",
+]
 
 [project.urls]
 Homepage = "https://github.com/NREL/routee-compass"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 keywords = ["eco routing"]
-dependencies = ["toml"]
+dependencies = [
+    "folium",
+    "pandas",
+    "networkx",
+    "toml",
+]
 [project.optional-dependencies]
 dev = [
     "black",

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 from nrel.routee.compass.routee_compass_py import (
     CompassAppWrapper,
 )
@@ -30,14 +30,15 @@ class CompassApp:
         self._app = app
 
     @classmethod
-    def get_constructor(cls):
+    def get_constructor(cls) -> type:
         """
         Return the underlying constructor for the application.
         This allows a child class to inherit the CompassApp python class
         and implement its own rust based app constructor, while still using
         the original python methods.
         """
-        return CompassAppWrapper
+        # mypy does not understand that this Rust-defined type *is* a type, so we need to cast
+        return cast(type, CompassAppWrapper)
 
     @classmethod
     def from_config_file(
@@ -84,7 +85,8 @@ class CompassApp:
         """
         path_str = str(working_dir.absolute()) if working_dir is not None else ""
         toml_string = toml.dumps(config)
-        app = cls.get_constructor()._from_config_toml_string(toml_string, path_str)
+        # mypy does not know about the attribute on this Rust-defined type
+        app = cls.get_constructor()._from_config_toml_string(toml_string, path_str)  # type: ignore
         return cls(app)
 
     def run(

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -80,7 +80,7 @@ class CompassApp:
 
         Example:
             >>> from nrel.routee.compass import CompassApp
-            >>> conf = { parallelism: 2 }
+            >>> conf = { "parallelism": 2 }
             >>> app = CompassApp.from_config(conf)
         """
         path_str = str(working_dir.absolute()) if working_dir is not None else ""

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -14,7 +14,8 @@ import toml
 
 Config = Dict[str, Any]
 Query = Dict[str, Any]
-Result = List[Dict[str, Any]]
+Result = Dict[str, Any]
+Results = List[Result]
 
 
 log = logging.getLogger(__name__)
@@ -92,7 +93,7 @@ class CompassApp:
 
     def run(
         self, query: Union[Query, List[Query]], config: Optional[Config] = None
-    ) -> Result:
+    ) -> Union[Result, Results]:
         """
         Run a query (or multiple queries) against the CompassApp
 

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -69,7 +69,9 @@ class CompassApp:
         return cls.from_dict(toml_config, config_path)
 
     @classmethod
-    def from_dict(cls, config: Config, working_dir: Optional[Path] = None) -> CompassApp:
+    def from_dict(
+        cls, config: Config, working_dir: Optional[Path] = None
+    ) -> CompassApp:
         """
         Build a CompassApp from a configuration object
 

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -150,7 +150,7 @@ class CompassApp:
         Returns:
             vertex_id: the vertex id at the source of the edge
         """
-        return self._app.graph_edge_origin(edge_id)
+        return cast(int, self._app.graph_edge_origin(edge_id))
 
     def graph_edge_destination(self, edge_id: int) -> int:
         """
@@ -162,7 +162,7 @@ class CompassApp:
         Returns:
             vertex_id: the vertex id at the destination of the edge
         """
-        return self._app.graph_edge_destination(edge_id)
+        return cast(int, self._app.graph_edge_destination(edge_id))
 
     def graph_edge_distance(
         self, edge_id: int, distance_unit: Optional[str] = None
@@ -177,7 +177,7 @@ class CompassApp:
         Returns:
             dist: the distance covered by traversing the edge
         """
-        return self._app.graph_edge_distance(edge_id, distance_unit)
+        return cast(float, self._app.graph_edge_distance(edge_id, distance_unit))
 
     def graph_get_out_edge_ids(self, vertex_id: int) -> List[int]:
         """
@@ -189,7 +189,7 @@ class CompassApp:
         Returns:
             edges: the edge ids of edges departing from this vertex
         """
-        return self._app.graph_get_out_edge_ids(vertex_id)
+        return cast(List[int], self._app.graph_get_out_edge_ids(vertex_id))
 
     def graph_get_in_edge_ids(self, vertex_id: int) -> List[int]:
         """
@@ -201,4 +201,4 @@ class CompassApp:
         Returns:
             edges: the edge ids of edges arriving at this vertex
         """
-        return self._app.graph_get_in_edge_ids(vertex_id)
+        return cast(List[int], self._app.graph_get_in_edge_ids(vertex_id))

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -97,6 +97,7 @@ class CompassApp:
 
         Args:
             query: A query or list of queries to run
+            config: optional configuration
 
         Returns:
             results: A list of results (or a single result if a single query was passed)

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -48,10 +48,10 @@ class CompassApp:
         Build a CompassApp from a config file
 
         Args:
-            config_file (Union[str, Path]): Path to the config file
+            config_file: Path to the config file
 
         Returns:
-            CompassApp: A CompassApp object
+            app: A CompassApp object
 
         Example:
             >>> from nrel.routee.compass import CompassApp
@@ -71,11 +71,11 @@ class CompassApp:
         Build a CompassApp from a configuration object
 
         Args:
-            config (Dict): Configuration dictionary
-            working_dir (Path): optional path to working directory
+            config: Configuration dictionary
+            working_dir: optional path to working directory
 
         Returns:
-            CompassApp: a CompassApp object
+            app: a CompassApp object
 
         Example:
             >>> from nrel.routee.compass import CompassApp
@@ -94,10 +94,10 @@ class CompassApp:
         Run a query (or multiple queries) against the CompassApp
 
         Args:
-            query (Union[Dict[str, Any], List[Dict[str, Any]]]): A query or list of queries to run
+            query: A query or list of queries to run
 
         Returns:
-            List[Dict[str, Any]]: A list of results (or a single result if a single query was passed)
+            results: A list of results (or a single result if a single query was passed)
 
         Example:
             >>> from nrel.routee.compass import CompassApp
@@ -140,10 +140,10 @@ class CompassApp:
         get the origin vertex id for some edge
 
         Args:
-            edge_id (int): the id of the edge
+            edge_id: the id of the edge
 
         Returns:
-            int: the vertex id at the source of the edge
+            vertex_id: the vertex id at the source of the edge
         """
         return self._app.graph_edge_origin(edge_id)
 
@@ -152,10 +152,10 @@ class CompassApp:
         get the destination vertex id for some edge
 
         Args:
-            edge_id (int): the id of the edge
+            edge_id: the id of the edge
 
         Returns:
-            int: the vertex id at the destination of the edge
+            vertex_id: the vertex id at the destination of the edge
         """
         return self._app.graph_edge_destination(edge_id)
 
@@ -166,11 +166,11 @@ class CompassApp:
         get the distance for some edge
 
         Args:
-            edge_id (int): the id of the edge
-            distance_unit (Optional[str]): distance unit, by default meters
+            edge_id: the id of the edge
+            distance_unit: distance unit, by default meters
 
         Returns:
-            int: the distance covered by traversing the edge
+            dist: the distance covered by traversing the edge
         """
         return self._app.graph_edge_distance(edge_id, distance_unit)
 
@@ -179,10 +179,10 @@ class CompassApp:
         get the list of edge ids that depart from some vertex
 
         Args:
-            vertex_id (int): the id of the vertex
+            vertex_id: the id of the vertex
 
         Returns:
-            List[int]: the edge ids of edges departing from this vertex
+            edges: the edge ids of edges departing from this vertex
         """
         return self._app.graph_get_out_edge_ids(vertex_id)
 
@@ -191,9 +191,9 @@ class CompassApp:
         get the list of edge ids that arrive from some vertex
 
         Args:
-            vertex_id (int): the id of the vertex
+            vertex_id: the id of the vertex
 
         Returns:
-            List[int]: the edge ids of edges arriving at this vertex
+            edges: the edge ids of edges arriving at this vertex
         """
         return self._app.graph_get_in_edge_ids(vertex_id)

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -135,7 +135,7 @@ class CompassApp:
 
         results_json: List[str] = self._app._run_queries(queries_str, config_str)
 
-        results = list(map(json.loads, results_json))
+        results: Results = list(map(json.loads, results_json))
         if single_query and len(results) == 1:
             return results[0]
         return results

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -12,6 +12,7 @@ from nrel.routee.compass.routee_compass_py import (
 import toml
 
 
+Config = Dict[str, Any]
 Query = Dict[str, Any]
 Result = List[Dict[str, Any]]
 
@@ -67,7 +68,7 @@ class CompassApp:
         return cls.from_dict(toml_config, config_path)
 
     @classmethod
-    def from_dict(cls, config: Dict, working_dir: Optional[Path] = None) -> CompassApp:
+    def from_dict(cls, config: Config, working_dir: Optional[Path] = None) -> CompassApp:
         """
         Build a CompassApp from a configuration object
 
@@ -90,7 +91,7 @@ class CompassApp:
         return cls(app)
 
     def run(
-        self, query: Union[Query, List[Query]], config: Optional[Dict] = None
+        self, query: Union[Query, List[Query]], config: Optional[Config] = None
     ) -> Result:
         """
         Run a query (or multiple queries) against the CompassApp

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -9,6 +9,7 @@ import shutil
 
 import pandas as pd
 import networkx
+from numpy.typing import ArrayLike
 
 from nrel.routee.compass.io.utils import add_grade_to_graph
 
@@ -19,12 +20,16 @@ HIGHWAY_TYPE = str
 KM_PER_HR = float
 HIGHWAY_SPEED_MAP = dict[HIGHWAY_TYPE, KM_PER_HR]
 
+# Parameters annotated with this pass through OSMnx, then GeoPandas, then to Pandas,
+# this is a best-effort annotation since the upstream doesn't really have one
+AggFunc = Callable[[ArrayLike], ArrayLike]
+
 def generate_compass_dataset(
     g: networkx.MultiDiGraph,
     output_directory: Union[str, Path],
     hwy_speeds: Optional[HIGHWAY_SPEED_MAP] = None,
     fallback: Optional[float] = None,
-    agg: Optional[Callable] = None,
+    agg: Optional[AggFunc] = None,
     add_grade: bool = False,
     raster_resolution_arc_seconds: Union[str, int] = 1,
     default_config: bool = True,

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Callable, Dict, Optional, Union
 from pathlib import Path
 from pkg_resources import resource_filename
@@ -6,21 +7,28 @@ import importlib.resources
 import logging
 import shutil
 
+import pandas as pd
+import networkx
+
 from nrel.routee.compass.io.utils import add_grade_to_graph
 
 log = logging.getLogger(__name__)
 
 
+HIGHWAY_TYPE = str
+KM_PER_HR = float
+HIGHWAY_SPEED_MAP = dict[HIGHWAY_TYPE, KM_PER_HR]
+
 def generate_compass_dataset(
-    g,
+    g: networkx.MultiDiGraph,
     output_directory: Union[str, Path],
-    hwy_speeds: Optional[Dict] = None,
+    hwy_speeds: Optional[HIGHWAY_SPEED_MAP] = None,
     fallback: Optional[float] = None,
     agg: Optional[Callable] = None,
     add_grade: bool = False,
     raster_resolution_arc_seconds: Union[str, int] = 1,
     default_config: bool = True,
-):
+) -> None:
     """
     Processes a graph downloaded via OSMNx, generating the set of input
     files required for running RouteE Compass.
@@ -94,7 +102,7 @@ def generate_compass_dataset(
     print("processing edges")
     lookup = v.set_index("vertex_uuid")
 
-    def replace_id(vertex_uuid):
+    def replace_id(vertex_uuid: pd.Index) -> pd.Series[int]:
         return lookup.loc[vertex_uuid].vertex_id
 
     e = e.reset_index(drop=False).rename(

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -28,22 +28,22 @@ def generate_compass_dataset(
     The input graph is assumed to be the direct output of an osmnx download.
 
     Args:
-        g (MultiDiGraph): A network graph.
-        output_directory (Union[str, Path]): Directory path to use for writing new Compass files.
-        hwy_speeds (Optional[Dict], optional): OSM highway types and values = typical speeds (km per
+        g: A network graph.
+        output_directory: Directory path to use for writing new Compass files.
+        hwy_speeds: OSM highway types and values = typical speeds (km per
             hour) to assign to edges of that highway type for any edges missing
             speed data. Any edges with highway type not in `hwy_speeds` will be
             assigned the mean preexisting speed value of all edges of that highway
-            type. Defaults to None.
-        fallback (Optional[float], optional): Default speed value (km per hour) to assign to edges whose highway
+            type.
+        fallback: Default speed value (km per hour) to assign to edges whose highway
             type did not appear in `hwy_speeds` and had no preexisting speed
-            values on any edge. Defaults to None.
-        agg (Callable, optional): Aggregation function to impute missing values from observed values.
+            values on any edge.
+        agg: Aggregation function to impute missing values from observed values.
             The default is numpy.mean, but you might also consider for example
-            numpy.median, numpy.nanmedian, or your own custom function. Defaults to numpy.mean.
-        add_grade (bool, optional): If true, add grade information. Defaults to False. See add_grade_to_graph() for more info.
-        raster_resolution_arc_seconds (str, optional): If grade is added, the resolution (in arc-seconds) of the tiles to download (either 1 or 1/3). Defaults to 1.
-        default_config (bool, optional): If true, copy default configuration files into the output directory. Defaults to True.
+            numpy.median, numpy.nanmedian, or your own custom function.
+        add_grade: If true, add grade information. See add_grade_to_graph() for more info.
+        raster_resolution_arc_seconds: If grade is added, the resolution (in arc-seconds) of the tiles to download (either 1 or 1/3).
+        default_config: If true, copy default configuration files into the output directory.
 
     Example:
         >>> import osmnx as ox

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -44,7 +44,6 @@ def generate_compass_dataset(
         add_grade (bool, optional): If true, add grade information. Defaults to False. See add_grade_to_graph() for more info.
         raster_resolution_arc_seconds (str, optional): If grade is added, the resolution (in arc-seconds) of the tiles to download (either 1 or 1/3). Defaults to 1.
         default_config (bool, optional): If true, copy default configuration files into the output directory. Defaults to True.
-        energy_model (str, optional): Which trained RouteE Powertrain should we use? Defaults to "2016_TOYOTA_Camry_4cyl_2WD".
 
     Example:
         >>> import osmnx as ox

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -24,6 +24,7 @@ HIGHWAY_SPEED_MAP = dict[HIGHWAY_TYPE, KM_PER_HR]
 # this is a best-effort annotation since the upstream doesn't really have one
 AggFunc = Callable[[ArrayLike], ArrayLike]
 
+
 def generate_compass_dataset(
     g: networkx.MultiDiGraph,
     output_directory: Union[str, Path],

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -28,7 +28,7 @@ def generate_compass_dataset(
     The input graph is assumed to be the direct output of an osmnx download.
 
     Args:
-        g: A network graph.
+        g: OSMNx graph used to generate input files
         output_directory: Directory path to use for writing new Compass files.
         hwy_speeds: OSM highway types and values = typical speeds (km per
             hour) to assign to edges of that highway type for any edges missing

--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -65,7 +65,9 @@ def _lat_lon_to_tile(coord: tuple[int, int]) -> str:
     return f"{lat_prefix}{abs(lat)}{lon_prefix}{abs(lon)}"
 
 
-def _build_download_link(tile: str, resolution: TileResolution = TileResolution.ONE_ARC_SECOND) -> str:
+def _build_download_link(
+    tile: str, resolution: TileResolution = TileResolution.ONE_ARC_SECOND
+) -> str:
     base_link_fragment = "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/"
     resolution_link_fragment = f"{resolution.value}/TIFF/current/{tile}/"
     filename = f"USGS_{resolution.value}_{tile}.tif"

--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -8,6 +8,8 @@ import itertools
 import logging
 from typing import Union
 
+import networkx
+
 log = logging.getLogger(__name__)
 
 
@@ -63,7 +65,7 @@ def _lat_lon_to_tile(coord: tuple[int, int]) -> str:
     return f"{lat_prefix}{abs(lat)}{lon_prefix}{abs(lon)}"
 
 
-def _build_download_link(tile: str, resolution=TileResolution.ONE_ARC_SECOND) -> str:
+def _build_download_link(tile: str, resolution: TileResolution = TileResolution.ONE_ARC_SECOND) -> str:
     base_link_fragment = "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/"
     resolution_link_fragment = f"{resolution.value}/TIFF/current/{tile}/"
     filename = f"USGS_{resolution.value}_{tile}.tif"
@@ -75,7 +77,7 @@ def _build_download_link(tile: str, resolution=TileResolution.ONE_ARC_SECOND) ->
 def _download_tile(
     tile: str,
     output_dir: Path = Path("cache"),
-    resolution=TileResolution.ONE_ARC_SECOND,
+    resolution: TileResolution = TileResolution.ONE_ARC_SECOND,
 ) -> Path:
     try:
         import requests
@@ -105,10 +107,10 @@ def _download_tile(
 
 
 def add_grade_to_graph(
-    g,
+    g: networkx.MultiDiGraph,
     output_dir: Path = Path("cache"),
     resolution_arc_seconds: Union[str, int] = 1,
-):
+) -> networkx.MultiDiGraph:
     """
     Adds grade information to the edges of a graph.
     This will download the necessary elevation data from USGS as raster tiles and cache them in the output_dir.
@@ -120,12 +122,12 @@ def add_grade_to_graph(
     * 1/3 arc-second: 350 MB
 
     Args:
-        g (nx.MultiDiGraph): The networkx graph to add grades to.
-        output_dir (Path, optional): The directory to cache the downloaded tiles in. Defaults to Path("cache").
-        resolution_arc_seconds (str, optional): The resolution (in arc-seconds) of the tiles to download (either 1 or 1/3). Defaults to 1.
+        g: The networkx graph to add grades to.
+        output_dir: The directory to cache the downloaded tiles in.
+        resolution_arc_seconds: The resolution (in arc-seconds) of the tiles to download (either 1 or 1/3).
 
     Returns:
-        nx.MultiDiGraph: The graph with grade information added to the edges.
+        g: The graph with grade information added to the edges.
 
     Example:
         >>> import osmnx as ox

--- a/python/nrel/routee/compass/plot/plot_folium.py
+++ b/python/nrel/routee/compass/plot/plot_folium.py
@@ -3,7 +3,10 @@ from typing import Any, Callable, Optional, Union
 
 import folium
 
-from nrel.routee.compass.compass_app import Result as QueryResult, Results as QueryResults
+from nrel.routee.compass.compass_app import (
+    Result as QueryResult,
+    Results as QueryResults,
+)
 from nrel.routee.compass.plot.plot_utils import ColormapCircularIterator, rgba_to_hex
 
 
@@ -16,6 +19,7 @@ DEFAULT_LINE_KWARGS = {
 # routes should exist at a "route.path" key
 ROUTE_KEY = "route"
 PATH_KEY = "path"
+
 
 def plot_route_folium(
     result_dict: QueryResult,

--- a/python/nrel/routee/compass/plot/plot_folium.py
+++ b/python/nrel/routee/compass/plot/plot_folium.py
@@ -1,3 +1,4 @@
+import folium
 from typing import Any, Callable, Optional, Union
 from nrel.routee.compass.plot.plot_utils import ColormapCircularIterator, rgba_to_hex
 import json
@@ -22,14 +23,12 @@ def plot_route_folium(
     Plots a single route from a compass query on a folium map.
 
     Args:
-        result_dict (Dict[str, Any]): A result dictionary from a CompassApp query
-        line_kwargs (Optional[Dict[str, Any]], optional): A dictionary of keyword
-            arguments to pass to the folium Polyline
-        folium_map (folium.Map, optional): A existing folium map to plot the route on.
-            Defaults to None.
+        result_dict: A result dictionary from a CompassApp query
+        line_kwargs: A dictionary of keyword arguments to pass to the folium Polyline
+        folium_map: A existing folium map to plot the route on.
 
     Returns:
-        folium.Map: A folium map with the route plotted on it
+        folium_map: A folium map with the route plotted on it
 
     Example:
         >>> from nrel.routee.compass import CompassApp
@@ -128,16 +127,13 @@ def plot_routes_folium(
     Plot multiple routes from a CompassApp query on a folium map
 
     Args:
-        results (Union[dict, list[dict]]): A result dictionary or list of result
-            dictionaries from a CompassApp query
-        value_fn (Callable[[Dict[str, Any]], Any], optional): A function that takes a
-            result dictionary and returns a value to use for coloring the routes.
+        results: A result dictionary or list of result dictionaries from a CompassApp query
+        value_fn: A function that takes a result dictionary and returns a value to use for coloring the routes.
             Defaults to lambda r: r["request"].get("name").
-        color_map (str, optional): The name of the matplotlib colormap to use
-            for coloring the routes. Defaults to "viridis".
+        color_map: The name of the matplotlib colormap to use for coloring the routes.
 
     Returns:
-        folium.Map: A folium map with the routes plotted on it
+        folium_map: A folium map with the routes plotted on it
 
     Example:
         >>> from nrel.routee.compass import CompassApp

--- a/python/nrel/routee/compass/plot/plot_folium.py
+++ b/python/nrel/routee/compass/plot/plot_folium.py
@@ -1,7 +1,11 @@
-import folium
-from typing import Any, Callable, Optional, Union
-from nrel.routee.compass.plot.plot_utils import ColormapCircularIterator, rgba_to_hex
 import json
+from typing import Any, Callable, Optional, Union
+
+import folium
+
+from nrel.routee.compass.compass_app import Result as QueryResult, Results as QueryResults
+from nrel.routee.compass.plot.plot_utils import ColormapCircularIterator, rgba_to_hex
+
 
 DEFAULT_LINE_KWARGS = {
     "color": "blue",
@@ -13,12 +17,11 @@ DEFAULT_LINE_KWARGS = {
 ROUTE_KEY = "route"
 PATH_KEY = "path"
 
-
 def plot_route_folium(
-    result_dict: dict,
-    line_kwargs: Optional[dict] = None,
-    folium_map=None,
-):
+    result_dict: QueryResult,
+    line_kwargs: Optional[QueryResult] = None,
+    folium_map: folium.Map = None,
+) -> folium.Map:
     """
     Plots a single route from a compass query on a folium map.
 
@@ -119,10 +122,10 @@ def plot_route_folium(
 
 
 def plot_routes_folium(
-    results: Union[dict, list[dict]],
-    value_fn: Callable[[dict], Any] = lambda r: r["request"].get("name"),
+    results: Union[QueryResult, QueryResults],
+    value_fn: Callable[[QueryResult], Any] = lambda r: r["request"].get("name"),
     color_map: str = "viridis",
-):
+) -> folium.Map:
     """
     Plot multiple routes from a CompassApp query on a folium map
 

--- a/python/nrel/routee/compass/plot/plot_utils.py
+++ b/python/nrel/routee/compass/plot/plot_utils.py
@@ -1,13 +1,16 @@
+from matplotlib.colors import Colormap
+
+
 class ColormapCircularIterator:
-    def __init__(self, colormap, num_colors):
+    def __init__(self, colormap: Colormap, num_colors: int):
         self.colormap = colormap
         self.num_colors = num_colors
         self.index = 0
 
-    def __iter__(self):
+    def __iter__(self) -> "ColormapCircularIterator":
         return self
 
-    def __next__(self):
+    def __next__(self) -> str:
         if not self.colormap:
             raise StopIteration
         normalized_value = self.index / float(self.num_colors)
@@ -17,7 +20,9 @@ class ColormapCircularIterator:
         return hex_color
 
 
-def rgba_to_hex(rgba):
+RGBA_TUPLE = tuple[float, float, float, float]
+
+def rgba_to_hex(rgba: RGBA_TUPLE) -> str:
     return "#{:02x}{:02x}{:02x}".format(
         int(rgba[0] * 255), int(rgba[1] * 255), int(rgba[2] * 255)
     )

--- a/python/nrel/routee/compass/plot/plot_utils.py
+++ b/python/nrel/routee/compass/plot/plot_utils.py
@@ -22,6 +22,7 @@ class ColormapCircularIterator:
 
 RGBA_TUPLE = tuple[float, float, float, float]
 
+
 def rgba_to_hex(rgba: RGBA_TUPLE) -> str:
     return "#{:02x}{:02x}{:02x}".format(
         int(rgba[0] * 255), int(rgba[1] * 255), int(rgba[2] * 255)


### PR DESCRIPTION
Closes #214

This changeset adds a bunch of missing annotations and other fixes/workarounds to get `routee-compass` to a complete set of annotations (i.e. `mypy --strict` can be run over the whole wrapper with no errors). This also updates and re-enables the type-checking step of the test workflow (and adds the necessary type stubs to the `[dev]` extra)