### PR TITLE
Ndr/result to geopandas

### DIFF
--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -13,8 +13,9 @@ import toml
 
 
 Query = Dict[str, Any]
-Result = List[Dict[str, Any]]
-
+Result = Dict[str, Any]
+Results = List[Result]
+Route = Dict[str, Any]
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ class CompassApp:
 
     def run(
         self, query: Union[Query, List[Query]], config: Optional[Dict] = None
-    ) -> Result:
+    ) -> Union[Result, Results]:
         """
         Run a query (or multiple queries) against the CompassApp
 

--- a/python/nrel/routee/compass/io/convert_results.py
+++ b/python/nrel/routee/compass/io/convert_results.py
@@ -1,0 +1,96 @@
+from typing import Optional, Tuple, Union
+
+from nrel.routee.compass.utils.geometry import geometry_from_route
+import pandas as pd
+import geopandas as gpd
+from nrel.routee.compass.compass_app import Result, Results
+
+
+def tree_result_to_geopandas(
+    result: Result,
+) -> Optional[gpd.GeoDataFrame]:
+    """ """
+    if "error" in result:
+        raise ValueError(f"Error in result: {result['error']}")
+
+    tree = result.get("tree")
+    if tree is None:
+        return None
+    elif isinstance(tree, list):
+        raise NotImplementedError("Multiple trees are not yet supported")
+
+    tree_gdf = gpd.GeoDataFrame.from_features(tree["features"])
+
+    return tree_gdf
+
+
+def route_result_to_geopandas(
+    result: Result,
+) -> Optional[gpd.GeoDataFrame]:
+    """ """
+    if "error" in result:
+        raise ValueError(f"Error in result: {result['error']}")
+
+    route = result.get("route")
+    if route is None:
+        return None
+
+    geometry = geometry_from_route(route)
+
+    # use everything but the tree key since we are handling that separately
+    result = {k: v for k, v in result.items() if k != "tree"}
+
+    df = pd.json_normalize(result)
+    df["geometry"] = geometry
+
+    route_gdf = gpd.GeoDataFrame(df, geometry="geometry")
+
+    # if the route was a geojson format, we can drop those columns
+    if "route.path.type" in route_gdf.columns:
+        route_gdf = route_gdf.drop(columns="route.path.type")
+    if "route.path.features" in route_gdf.columns:
+        route_gdf = route_gdf.drop(columns="route.path.features")
+
+    return route_gdf
+
+
+def results_to_geopandas(
+    results: Union[Result, Results],
+) -> Union[gpd.GeoDataFrame, Tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]]:
+    """ """
+    if isinstance(results, dict):
+        results = [results]
+
+    route_constructor = []
+    tree_constructor = []
+
+    for i, result in enumerate(results):
+        if "route" in result:
+            route_gdf = route_result_to_geopandas(result)
+            route_gdf["route_id"] = i
+            route_gdf = route_gdf.set_index("route_id")
+            route_constructor.append(route_gdf)
+        if "tree" in result:
+            tree_gdf = tree_result_to_geopandas(result)
+            tree_gdf["tree_id"] = i
+            tree_gdf = tree_gdf.set_index(["tree_id", "edge_id"])
+            tree_constructor.append(tree_gdf)
+
+    if len(route_constructor) == 0:
+        full_route_gdf = None
+    else:
+        full_route_gdf = pd.concat(route_constructor)
+
+    if len(tree_constructor) == 0:
+        full_tree_gdf = None
+    else:
+        full_tree_gdf = pd.concat(tree_constructor)
+
+    if full_route_gdf is not None and full_tree_gdf is not None:
+        return full_route_gdf, full_tree_gdf
+    elif full_route_gdf is not None:
+        return full_route_gdf
+    elif full_tree_gdf is not None:
+        return full_tree_gdf
+    else:
+        raise ValueError("No route or tree results found in results")

--- a/python/nrel/routee/compass/io/convert_results.py
+++ b/python/nrel/routee/compass/io/convert_results.py
@@ -65,13 +65,14 @@ def results_to_geopandas(
     tree_constructor = []
 
     for i, result in enumerate(results):
-        if "route" in result:
-            route_gdf = route_result_to_geopandas(result)
+        route_gdf = route_result_to_geopandas(result)
+        if route_gdf is not None:
             route_gdf["route_id"] = i
             route_gdf = route_gdf.set_index("route_id")
             route_constructor.append(route_gdf)
-        if "tree" in result:
-            tree_gdf = tree_result_to_geopandas(result)
+
+        tree_gdf = tree_result_to_geopandas(result)
+        if tree_gdf is not None:
             tree_gdf["tree_id"] = i
             tree_gdf = tree_gdf.set_index(["tree_id", "edge_id"])
             tree_constructor.append(tree_gdf)

--- a/python/nrel/routee/compass/plot/plot_folium.py
+++ b/python/nrel/routee/compass/plot/plot_folium.py
@@ -274,7 +274,9 @@ def plot_routes_folium(
     results_coords = [result_dict_to_coords(result_dict) for result_dict in results]
 
     if folium_map is None:
-        folium_map = _create_empty_folium_map(fit_coords=np.concatenate(results_coords))
+        folium_map = _create_empty_folium_map(
+            fit_coords=list(np.concatenate(results_coords))
+        )
 
     for coords, value, route_color in zip(results_coords, values, colors):
         line_kwargs = {"color": route_color, "tooltip": f"{value}"}

--- a/python/nrel/routee/compass/plot/plot_folium.py
+++ b/python/nrel/routee/compass/plot/plot_folium.py
@@ -1,16 +1,13 @@
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 from nrel.routee.compass.plot.plot_utils import ColormapCircularIterator, rgba_to_hex
-import json
+
+from nrel.routee.compass.utils.geometry import ROUTE_KEY, geometry_from_route
 
 DEFAULT_LINE_KWARGS = {
     "color": "blue",
     "weight": 10,
     "opacity": 0.8,
 }
-
-# routes should exist at a "route.path" key
-ROUTE_KEY = "route"
-PATH_KEY = "path"
 
 
 def result_dict_to_coords(result_dict: dict) -> Sequence[Tuple[float, float]]:
@@ -48,27 +45,7 @@ def result_dict_to_coords(result_dict: dict) -> Sequence[Tuple[float, float]]:
             f"Could not find '{ROUTE_KEY}' in result. "
             "Make sure the geometry output plugin is activated"
         )
-    geom = route.get(PATH_KEY)
-    if geom is None:
-        raise KeyError(
-            f"Could not find '{ROUTE_KEY}.{PATH_KEY}' in result. "
-            "Make sure the geometry output plugin is activated"
-        )
-
-    if isinstance(geom, shapely.geometry.LineString):
-        linestring = geom
-    if isinstance(geom, str):
-        linestring = shapely.from_wkt(geom)
-    elif isinstance(geom, bytes):
-        linestring = shapely.from_wkb(geom)
-    elif isinstance(geom, dict) and geom.get("features") is not None:
-        # RouteE Compass can output GeoJson as a GeometryCollection
-        # and we expect we can concatenate the result as a single linestring
-        feature_collection = shapely.from_geojson(json.dumps(geom))
-        multilinestring = shapely.MultiLineString(feature_collection.geoms)
-        linestring = shapely.line_merge(multilinestring)
-    else:
-        raise ValueError("Could not parse route geometry")
+    linestring = geometry_from_route(route)
 
     if isinstance(linestring, shapely.geometry.MultiLineString):
         coords = []

--- a/python/nrel/routee/compass/resources/downtown_denver_example/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/downtown_denver_example/osm_default_energy.toml
@@ -27,6 +27,7 @@ type = "summary"
 [[plugin.output_plugins]]
 type = "traversal"
 route = "geo_json"
+tree = "geo_json"
 geometry_input_file = "edges-geometries-enumerated.txt.gz"
 
 [[plugin.output_plugins]]

--- a/python/nrel/routee/compass/utils/geometry.py
+++ b/python/nrel/routee/compass/utils/geometry.py
@@ -1,0 +1,52 @@
+from nrel.routee.compass.compass_app import Route
+import shapely
+import json
+
+# routes should exist at a "route.path" key
+ROUTE_KEY = "route"
+PATH_KEY = "path"
+
+
+def geometry_from_route(route: Route) -> shapely.geometry.LineString:
+    """
+    Parse a route dictionary and return a shapely LineString object
+
+    Args:
+        route (Route): A route dictionary from the results
+
+    Returns:
+        shapely.geometry.LineString: A LineString object representing the route geometry
+
+    Raises:
+        KeyError: If the route dictionary does not have a 'route.path' key
+        NotImplementedError: If the route dictionary has a multi-geometry
+        ValueError: If the route dictionary has an unparseable geometry
+    """
+    geom = route.get(PATH_KEY)
+    if geom is None:
+        raise KeyError(
+            f"Could not find '{ROUTE_KEY}.{PATH_KEY}' in result. "
+            "Make sure the geometry output plugin is activated"
+        )
+    elif isinstance(geom, list):
+        raise NotImplementedError(
+            "Multi-geometries are yet not supported. "
+            "Please ensure the path only has one geometry"
+        )
+
+    if isinstance(geom, shapely.geometry.LineString):
+        linestring = geom
+    if isinstance(geom, str):
+        linestring = shapely.from_wkt(geom)
+    elif isinstance(geom, bytes):
+        linestring = shapely.from_wkb(geom)
+    elif isinstance(geom, dict) and geom.get("features") is not None:
+        # RouteE Compass can output GeoJson as a GeometryCollection
+        # and we expect we can concatenate the result as a single linestring
+        feature_collection = shapely.from_geojson(json.dumps(geom))
+        multilinestring = shapely.MultiLineString(feature_collection.geoms)
+        linestring = shapely.line_merge(multilinestring)
+    else:
+        raise ValueError("Could not parse route geometry")
+
+    return linestring


### PR DESCRIPTION
Adds support for converting the results to geopandas. Now you can call the function `results_to_geopandas` and get back either a route geodataframe (if there is just a route), a tree geodatarame (if there is just a tree), or both a route and a tree geodataframe. For example:

```python
route_gdf, tree_gdf = results_to_geopandas(result)
```

Closes #211 
Closes #210 