### PR TITLE
Add OSM/Geospatial dependencies as default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,17 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 keywords = ["eco routing"]
-dependencies = ["toml"]
+dependencies = [
+    "toml",
+    "numpy",
+    "pandas",
+    "geopandas",
+    "shapely",
+    "networkx",
+    "folium",
+    "osmnx",
+]
+
 [project.optional-dependencies]
 dev = ["pytest", "maturin", "jupyter-book", "ruff", "sphinx-book-theme"]
 


### PR DESCRIPTION
Previously we only had the OSM/Geospatial dependencies required in the conda install but now that we're adding default functionality that use these dependencies (osmnx, geopandas, etc.), I've included them as required dependencies in the `pyproject.toml` file.