### PR TITLE
usgs using 0 leading numbers in their webpages

### DIFF
--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -60,7 +60,7 @@ def _lat_lon_to_tile(coord: tuple[int, int]) -> str:
     else:
         lon_prefix = "e"
 
-    return f"{lat_prefix}{abs(lat)}{lon_prefix}{abs(lon)}"
+    return f"{lat_prefix}{abs(lat):02}{lon_prefix}{abs(lon):03}"
 
 
 def _build_download_link(tile: str, resolution=TileResolution.ONE_ARC_SECOND) -> str:


### PR DESCRIPTION
Found a bug where some grade maps could not be downloaded, for ex Pittsburgh, PA as it had a two digit longitude and the website requires leading 0s in their longitudes < 100