### PR TITLE
release 0.8.0 (rust)

### DIFF
--- a/publish_crates.sh
+++ b/publish_crates.sh
@@ -12,5 +12,8 @@ cargo publish -p routee-compass-powertrain
 cargo publish -p routee-compass --dry-run
 cargo publish -p routee-compass
 
+cargo publish -p routee-compass-macros --dry-run
+cargo publish -p routee-compass-macros
+
 cargo publish -p routee-compass-py --dry-run
 cargo publish -p routee-compass-py

--- a/publish_crates.sh
+++ b/publish_crates.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # exit on failure
 set -e
 

--- a/rust/routee-compass-core/Cargo.toml
+++ b/rust/routee-compass-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 exclude = ["test/"]
 readme = "README.md"

--- a/rust/routee-compass-core/README.md
+++ b/rust/routee-compass-core/README.md
@@ -12,7 +12,7 @@ To install as a library in Rust, add routee-compass-core to your Cargo.toml file
 
 ```toml
 [dependencies]
-routee-compass-core = { version = "0.3.0" }
+routee-compass-core = { version = "0.8.0" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass-core/latest/routee_compass_core/) for usage.

--- a/rust/routee-compass-macros/Cargo.toml
+++ b/rust/routee-compass-macros/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
 name = "routee-compass-macros"
 version = "0.8.0"
+edition = "2021"
+readme = "README.md"
+license = "BSD-3-Clause"
+description = "Macros for the RouteE-Compass energy-aware routing engine"
+homepage = "https://nrel.github.io/routee-compass"
+repository = "https://github.com/NREL/routee-compass"
+documentation = "https://docs.rs/routee-compass"
+
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/rust/routee-compass-macros/Cargo.toml
+++ b/rust/routee-compass-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-macros"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/rust/routee-compass-macros/README.md
+++ b/rust/routee-compass-macros/README.md
@@ -10,7 +10,7 @@ To install as a library in Rust, add routee-compass-macros to your Cargo.toml fi
 
 ```toml
 [dependencies]
-routee-compass-macros = { version = "0.7.0" }
+routee-compass-macros = { version = "0.8.0" }
 ```
 
 This crate currently just provides a single macro for wrapping a compass application with python bindings.

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-powertrain"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/routee-compass"
 
 
 [dependencies]
-routee-compass-core = { path = "../routee-compass-core", version = "0.7.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.8.0" }
 smartcore = { version = "0.3.1", features = ["serde"] }                      # random forest
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/rust/routee-compass-powertrain/README.md
+++ b/rust/routee-compass-powertrain/README.md
@@ -12,7 +12,7 @@ To install as a library in Rust, add routee-compass-powertrain to your Cargo.tom
 
 ```toml
 [dependencies]
-routee-compass-powertrain = { version = "0.7.0" }
+routee-compass-powertrain = { version = "0.8.0" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass-powertrain/latest/routee_compass_powertrain/) for usage.

--- a/rust/routee-compass-py/Cargo.toml
+++ b/rust/routee-compass-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-py"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -10,9 +10,9 @@ repository = "https://github.com/NREL/routee-compass"
 documentation = "https://docs.rs/routee-compass"
 
 [dependencies]
-routee-compass = { path = "../routee-compass", version = "0.7.0" }
-routee-compass-core = { path = "../routee-compass-core", version = "0.7.0" }
-routee-compass-macros = { path = "../routee-compass-macros", version = "0.7.0" }
+routee-compass = { path = "../routee-compass", version = "0.8.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.8.0" }
+routee-compass-macros = { path = "../routee-compass-macros", version = "0.8.0" }
 pyo3 = { version = "0.21.0", features = ["extension-module", "serde"] }
 serde_json = { workspace = true }
 config = { workspace = true }

--- a/rust/routee-compass-py/README.md
+++ b/rust/routee-compass-py/README.md
@@ -16,7 +16,7 @@ To install as a library in Rust, add routee-compass-py to your Cargo.toml file:
 
 ```toml
 [dependencies]
-routee-compass-py = { version = "0.7.0" }
+routee-compass-py = { version = "0.8.0" }
 ```
 
 ## License

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -18,8 +18,8 @@ keywords = [
 categories = ["science", "science::geo"]
 
 [dependencies]
-routee-compass-core = { path = "../routee-compass-core", version = "0.7.0" }
-routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.7.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.8.0" }
+routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.8.0" }
 thiserror = { workspace = true }
 flate2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/rust/routee-compass/README.md
+++ b/rust/routee-compass/README.md
@@ -11,7 +11,7 @@ To install as a library in Rust, add routee-compass to your Cargo.toml file:
 
 ```toml
 [dependencies]
-routee-compass = { version = "0.3.0" }
+routee-compass = { version = "0.8.0" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass/latest/routee_compass/) for usage.


### PR DESCRIPTION
branched this from the py-0.8.0 tag and updated version references to 0.8.0 in the rust crates in order to release on crates.io as v0.8.0.