### PR TITLE
Add departure headings calculation

### DIFF
--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -6,8 +6,8 @@ import importlib.resources
 import logging
 import shutil
 import pandas as pd
-import utils
 
+from nrel.routee.compass.io import utils
 from nrel.routee.compass.io.utils import add_grade_to_graph
 
 log = logging.getLogger(__name__)

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -5,8 +5,8 @@ from pkg_resources import resource_filename
 import importlib.resources
 import logging
 import shutil
-import math
 import pandas as pd
+import utils
 
 from nrel.routee.compass.io.utils import add_grade_to_graph
 
@@ -156,7 +156,7 @@ def generate_compass_dataset(
         header=False,
     )
 
-    headings = [calculate_bearings(i) for i in e.geometry.values]
+    headings = [utils.calculate_bearings(i) for i in e.geometry.values]
     headings_df = pd.DataFrame(headings, columns = ["arrival_heading", "departure_heading"])
     headings_df.to_csv(
         output_directory / "edges-headings-enumerated.csv.gz",
@@ -206,38 +206,3 @@ def generate_compass_dataset(
             with importlib.resources.as_file(model_file) as model_path:
                 model_dst = model_output_directory / model_path.name
                 shutil.copy(model_path, model_dst)
-
-#Function written by Nick Reinicke
-def compass_heading(point1, point2):
-    lon1, lat1 = point1
-    lon2, lat2 = point2
-
-    lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
-
-    dlon = lon2 - lon1
-
-    x = math.sin(dlon) * math.cos(lat2)
-    y = math.cos(lat1) * math.sin(lat2) - (
-        math.sin(lat1) * math.cos(lat2) * math.cos(dlon)
-    )
-
-    initial_bearing = math.atan2(x, y)
-
-    initial_bearing = math.degrees(initial_bearing)
-    compass_bearing = (initial_bearing + 360) % 360
-
-    return compass_bearing
-
-#Function written by Nick Reinicke
-def calculate_bearings(geom):
-    if len(geom.coords) < 2:
-        raise ValueError("Geometry must have at least two points")
-    if len(geom.coords) == 2:
-        # start and end heading is equal
-        heading = int(compass_heading(geom.coords[0], geom.coords[1]))
-        return (heading, heading)
-    else:
-        start_heading = int(compass_heading(geom.coords[0], geom.coords[1]))
-        end_heading = int(compass_heading(geom.coords[-2], geom.coords[-1]))
-        #returns headings as a list of tuples 
-        return (start_heading, end_heading)

--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import logging
 from typing import Union, Optional
+import math
 
 log = logging.getLogger(__name__)
 
@@ -173,3 +174,37 @@ def add_grade_to_graph(
     g = ox.add_edge_grades(g)
 
     return g
+
+def compass_heading(point1, point2):
+    lon1, lat1 = point1
+    lon2, lat2 = point2
+
+    lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
+
+    dlon = lon2 - lon1
+
+    x = math.sin(dlon) * math.cos(lat2)
+    y = math.cos(lat1) * math.sin(lat2) - (
+        math.sin(lat1) * math.cos(lat2) * math.cos(dlon)
+    )
+
+    initial_bearing = math.atan2(x, y)
+
+    initial_bearing = math.degrees(initial_bearing)
+    compass_bearing = (initial_bearing + 360) % 360
+
+    return compass_bearing
+
+def calculate_bearings(geom):
+    if len(geom.coords) < 2:
+        raise ValueError("Geometry must have at least two points")
+    if len(geom.coords) == 2:
+        # start and end heading is equal
+        heading = int(compass_heading(geom.coords[0], geom.coords[1]))
+        return (heading, heading)
+    else:
+        start_heading = int(compass_heading(geom.coords[0], geom.coords[1]))
+        end_heading = int(compass_heading(geom.coords[-2], geom.coords[-1]))
+        #returns headings as a list of tuples 
+        return (start_heading, end_heading)
+    


### PR DESCRIPTION
In reference to #202:
Previously, generate_dataset would calculate the arrival heading using the preset osmnx `.bearing` method, while departure headings were set to `None`. 

This PR adds two functions written by @nreinicke:
1. `calculate_bearings`, which passes in linestrings and determines what to do with the coordinates based on the number of lat lon pairs
2. `compass_heading`, which calculates a compass bearing based on two lat lon pairs

These functions replace the osmnx method used previously, rather than using osmnx for arrival and the functions for departure. Both headings are added to the same data frame and output to edges-headings-enumerated.csv 