### PR TITLE
serialize state model with index

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [workspace.dependencies]
 serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 rayon = "1.7.0"
 geo = { version = "0.28.0", features = ["use-serde"] }
 geo-types = "0.7.12"

--- a/rust/routee-compass-core/src/model/state/state_model.rs
+++ b/rust/routee-compass-core/src/model/state/state_model.rs
@@ -423,21 +423,18 @@ impl StateModel {
 
     /// uses the built-in serialization codec to output the state model representation as a JSON object
     pub fn serialize_state_model(&self) -> serde_json::Value {
-        let x = self
-            .indexed_iter()
-            .sorted_by(|(a_i, _), (b_i, _)| Ord::cmp(a_i, b_i))
-            .map(|(i, (name, feature))| {
-                let mut f_json = json![feature];
+        let x = self.indexed_iter().map(|(i, (name, feature))| {
+            let mut f_json = json![feature];
 
-                match f_json.as_object_mut() {
-                    None => json![{}],
-                    Some(map) => {
-                        map.insert(String::from("index"), json![i]);
-                        map.insert(String::from("name"), json![name]);
-                        json![map]
-                    }
+            match f_json.as_object_mut() {
+                None => json![{}],
+                Some(map) => {
+                    map.insert(String::from("index"), json![i]);
+                    map.insert(String::from("name"), json![name]);
+                    json![map]
                 }
-            });
+            }
+        });
         json![x.collect::<Vec<_>>()]
     }
 

--- a/rust/routee-compass-core/src/model/state/state_model.rs
+++ b/rust/routee-compass-core/src/model/state/state_model.rs
@@ -422,20 +422,20 @@ impl StateModel {
     }
 
     /// uses the built-in serialization codec to output the state model representation as a JSON object
+    /// stores the result as a JSON Object (Map).
     pub fn serialize_state_model(&self) -> serde_json::Value {
-        let x = self.indexed_iter().map(|(i, (name, feature))| {
+        let mut out = serde_json::Map::new();
+        for (i, (name, feature)) in self.indexed_iter() {
             let mut f_json = json![feature];
 
-            match f_json.as_object_mut() {
-                None => json![{}],
-                Some(map) => {
-                    map.insert(String::from("index"), json![i]);
-                    map.insert(String::from("name"), json![name]);
-                    json![map]
-                }
+            if let Some(map) = f_json.as_object_mut() {
+                map.insert(String::from("index"), json![i]);
+                map.insert(String::from("name"), json![name]);
             }
-        });
-        json![x.collect::<Vec<_>>()]
+            out.insert(name.clone(), f_json);
+        }
+
+        json![out]
     }
 
     /// lists the names of the state variables in order

--- a/rust/routee-compass-core/src/model/state/state_model.rs
+++ b/rust/routee-compass-core/src/model/state/state_model.rs
@@ -423,7 +423,22 @@ impl StateModel {
 
     /// uses the built-in serialization codec to output the state model representation as a JSON object
     pub fn serialize_state_model(&self) -> serde_json::Value {
-        json![self.iter().collect::<HashMap<_, _>>()]
+        let x = self
+            .indexed_iter()
+            .sorted_by(|(a_i, _), (b_i, _)| Ord::cmp(a_i, b_i))
+            .map(|(i, (name, feature))| {
+                let mut f_json = json![feature];
+
+                match f_json.as_object_mut() {
+                    None => json![{}],
+                    Some(map) => {
+                        map.insert(String::from("index"), json![i]);
+                        map.insert(String::from("name"), json![name]);
+                        json![map]
+                    }
+                }
+            });
+        json![x.collect::<Vec<_>>()]
     }
 
     /// lists the names of the state variables in order

--- a/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
+++ b/rust/routee-compass/src/plugin/input/default/grid_search/plugin.rs
@@ -176,12 +176,12 @@ mod test {
         let plugin = GridSearchPlugin {};
         plugin.process(&mut input).unwrap();
         let expected = vec![
-            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"d1","weights":{"distance":1,"energy_electric":0,"time":0}}],
-            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"t1","weights":{"distance":0,"energy_electric":0,"time":1}}],
-            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"e1","weights":{"distance":0,"energy_electric":1,"time":0}}],
-            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"d1","weights":{"distance":1,"energy_electric":0,"time":0}}],
-            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"t1","weights":{"distance":0,"energy_electric":0,"time":1}}],
-            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"e1","weights":{"distance":0,"energy_electric":1,"time":0}}],
+            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"d1","weights":{"distance":1,"time":0,"energy_electric":0}}],
+            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"d1","weights":{"distance":1,"time":0,"energy_electric":0}}],
+            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"t1","weights":{"distance":0,"time":1,"energy_electric":0}}],
+            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"t1","weights":{"distance":0,"time":1,"energy_electric":0}}],
+            json![{"abc":123,"model_name":"2016_TOYOTA_Camry_4cyl_2WD","name":"e1","weights":{"distance":0,"time":0,"energy_electric":1}}],
+            json![{"abc":123,"model_name":"2017_CHEVROLET_Bolt","name":"e1","weights":{"distance":0,"time":0,"energy_electric":1}}],
         ];
         match input {
             serde_json::Value::Array(result) => assert_eq!(result, expected),


### PR DESCRIPTION
this PR refactors the `route.state_model` output field in order to make it clearer to the user how it relates to state tuples.

there were two ways to improve readability, with problems each:
  - keep state_model a JSON object, but add an "index" field to denote the tuple index for the feature
    - problem: order is not guaranteed, so, programmatically `.zip()`-ing the state tuple with the state_model doesn't give you what you would expect
  - change state_model to a JSON array so it structurally matches the state tuple
    - problem: we can no longer index into the state model by name: `route.state_model.energy` is no longer a key

i opted for an __array__ because i think programmatic access is probably more useful for people toying around in the JSON outputs. but, this means any existing scripting that parses outputs will be broken by this change.