### PR TITLE
Rjf/soc bug

### DIFF
--- a/rust/routee-compass-core/src/model/access/default/turn_delays/turn.rs
+++ b/rust/routee-compass-core/src/model/access/default/turn_delays/turn.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::model::access::access_model_error::AccessModelError;
 use serde::{Deserialize, Serialize};
 
@@ -14,9 +16,9 @@ pub enum Turn {
     UTurn,
 }
 
-impl ToString for Turn {
-    fn to_string(&self) -> String {
-        serde_json::to_string(self).unwrap_or_else(|_| String::from("<internal error>"))
+impl Display for Turn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap_or_default())
     }
 }
 

--- a/rust/routee-compass-core/src/model/access/default/turn_delays/turn_delay_access_model_engine.rs
+++ b/rust/routee-compass-core/src/model/access/default/turn_delays/turn_delay_access_model_engine.rs
@@ -28,7 +28,7 @@ impl TurnDelayAccessModelEngine {
                 let turn = Turn::from_angle(angle)?;
                 let delay = table.get(&turn).ok_or_else(|| {
                     let name = String::from("tabular discrete turn delay model");
-                    let error = format!("table missing entry for turn {}", turn.to_string());
+                    let error = format!("table missing entry for turn {}", turn);
                     AccessModelError::RuntimeError { name, error }
                 })?;
                 Ok((*delay, time_unit))

--- a/rust/routee-compass-core/src/model/cost/vehicle/vehicle_cost_rate.rs
+++ b/rust/routee-compass-core/src/model/cost/vehicle/vehicle_cost_rate.rs
@@ -17,7 +17,7 @@ pub enum VehicleCostRate {
     Factor {
         factor: f64,
     },
-    ///
+    /// shift a value by some amount
     Offset {
         offset: f64,
     },

--- a/rust/routee-compass-core/src/model/state/unit_codec_name.rs
+++ b/rust/routee-compass-core/src/model/state/unit_codec_name.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -9,13 +11,14 @@ pub enum UnitCodecType {
     Boolean,
 }
 
-impl ToString for UnitCodecType {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for UnitCodecType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
             UnitCodecType::FloatingPoint => String::from("floating_point"),
             UnitCodecType::SignedInteger => String::from("signed_integer"),
             UnitCodecType::UnsignedInteger => String::from("unsigned_integer"),
             UnitCodecType::Boolean => String::from("boolean"),
-        }
+        };
+        write!(f, "{}", msg)
     }
 }

--- a/rust/routee-compass-core/src/util/fs/read_utils.rs
+++ b/rust/routee-compass-core/src/util/fs/read_utils.rs
@@ -70,7 +70,7 @@ where
 /// inspects the file to determine if it should read as a raw or gzip stream.
 /// the row index (starting from zero) is passed to the deserialization op
 /// as in most cases, the row number is an id.
-pub fn read_raw_file<'a, F: AsRef<Path>, T>(
+pub fn read_raw_file<'a, F, T>(
     filepath: F,
     op: impl Fn(usize, String) -> Result<T, io::Error>,
     row_callback: Option<Box<dyn FnMut() + 'a>>,

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/bev.rs
@@ -160,7 +160,7 @@ impl VehicleType for BEV {
         }
 
         let starting_battery_energy =
-            Energy::new(starting_soc_percent * self.battery_capacity.as_f64());
+            Energy::new(0.01 * starting_soc_percent * self.battery_capacity.as_f64());
 
         let new_bev = BEV {
             name: self.name.clone(),

--- a/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/default/phev.rs
@@ -189,7 +189,7 @@ impl VehicleType for PHEV {
             ));
         }
         let starting_battery_energy =
-            Energy::new(starting_soc_percent * self.battery_capacity.as_f64());
+            Energy::new(0.01 * starting_soc_percent * self.battery_capacity.as_f64());
 
         let new_phev = PHEV {
             name: self.name.clone(),

--- a/rust/routee-compass-powertrain/src/routee/vehicle/vehicle_ops.rs
+++ b/rust/routee-compass-powertrain/src/routee/vehicle/vehicle_ops.rs
@@ -45,7 +45,7 @@ pub fn update_soc_percent(
 /// the remaining battery as a percentage [0, 100] %
 pub fn as_soc_percent(remaining_battery: &Energy, max_battery: &Energy) -> f64 {
     let percent_remaining = (remaining_battery.as_f64() / max_battery.as_f64()) * 100.0;
-    percent_remaining.max(0.0).min(100.0)
+    percent_remaining.clamp(0.0, 100.0)
 }
 
 /// a capacitated vehicle's state of charge (SOC) is the inverse of the
@@ -70,5 +70,5 @@ pub fn soc_from_battery_and_delta(
 ) -> f64 {
     let current_energy = *start_battery - *energy_used;
     let percent_remaining = (current_energy.as_f64() / max_battery.as_f64()) * 100.0;
-    percent_remaining.max(0.0).min(100.0)
+    percent_remaining.clamp(0.0, 100.0)
 }

--- a/rust/routee-compass/src/app/search/search_app_ops.rs
+++ b/rust/routee-compass/src/app/search/search_app_ops.rs
@@ -14,6 +14,7 @@ use crate::app::compass::config::config_json_extension::ConfigJsonExtensions;
 ///   1. from the traversal model
 ///   2. from the access model
 ///   3. optionally from the query itself
+///
 /// using the order above, each new source optionally overwrites any existing feature
 /// by name (tuple index 0) as long as they match in StateFeature::get_feature_name and
 /// StateFeature::get_feature_unit_name.


### PR DESCRIPTION
addresses the bug discovered in #241. it appears that:
  1. user-submitted value was correctly validated between 0 and 100
  2. **bug:** the percent value [0,100] was being used directly to scale incoming energy (multiplying it by 100)

so the energy state would always exceed 100%. how this ended up with a state model at 100% is unclear; could be because of `vehicle_ops::as_soc_percent` which clips the value between 0 and 100 again. but i'm not sure.

that said, it is working:

```json
"battery_state": {
        "type": "soc",
        "unit": "percent",
        "format": {
            "floating_point": {
                "initial": 80.0
            }
        },
        "index": 0,
        "name": "battery_state"
    },
```

Closes #241.