### PR TITLE
Rjf/bug route on empty tree

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -265,9 +265,10 @@ pub fn run_a_star_edge_oriented(
                     .get(&e2_src)
                     .ok_or_else(|| {
                         SearchError::InternalError(format!(
-                            "resulting tree missing vertex {} expected via backtrack",
-                            e2_src
-                        ))
+                        "resulting tree with {} branches missing vertex {} expected via backtrack",
+                        tree.len(),
+                        e2_src
+                    ))
                     })?
                     .edge_traversal
                     .result_state;

--- a/rust/routee-compass-core/src/algorithm/search/backtrack.rs
+++ b/rust/routee-compass-core/src/algorithm/search/backtrack.rs
@@ -15,6 +15,10 @@ pub fn vertex_oriented_route(
     target_id: VertexId,
     solution: &HashMap<VertexId, SearchTreeBranch>,
 ) -> Result<Vec<EdgeTraversal>, SearchError> {
+    if solution.is_empty() {
+        return Ok(vec![]);
+    }
+
     let mut result: Vec<EdgeTraversal> = vec![];
     let mut visited: HashSet<EdgeId> = HashSet::new();
     let mut this_vertex = target_id;
@@ -22,12 +26,13 @@ pub fn vertex_oriented_route(
         if this_vertex == source_id {
             break;
         }
-        let traversal = solution
-            .get(&this_vertex)
-            .ok_or(SearchError::InternalError(format!(
-                "resulting tree missing vertex {} expected via backtrack",
+        let traversal = solution.get(&this_vertex).ok_or_else(|| {
+            SearchError::InternalError(format!(
+                "resulting tree with {} branches missing vertex {} expected via backtrack",
+                solution.len(),
                 this_vertex
-            )))?;
+            ))
+        })?;
         let first_visit = visited.insert(traversal.edge_traversal.edge_id);
         if !first_visit {
             return Err(SearchError::InternalError(format!(


### PR DESCRIPTION
This little PR modifies the vertex backtrack function so that, when passed an empty tree, it terminates early with an empty vector. An empty tree is a valid search result for the case when the origin location and destination location match or are incident edges.