### PR TITLE
rust bump version minor

### DIFF
--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -89,7 +89,7 @@ jobs:
             rustup show
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -104,7 +104,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: wheels
           path: dist

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "wheels-${{ matrix.python-version }}"
+          name: "wheel-${{ matrix.os }}-py${{ matrix.python-version }}"
           path: dist
   upload:
     needs: build

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -65,6 +65,10 @@ jobs:
       - name: build ${{ matrix.platform || matrix.os }} binaries
         run: cibuildwheel --output-dir dist
         env:
+          # 2025-01-02: cpython 3.11 requires Mac OS 10.12 at minimum
+          MACOSX_DEPLOYMENT_TARGET: 10.12
+          
+          # CI Build Wheel Arguments
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
           CIBW_SKIP: "*-win32 *-musllinux* *i686 *ppc64le *s390x *aarch64"
           CIBW_PLATFORM: ${{ matrix.platform || matrix.os }}

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -102,24 +102,24 @@ jobs:
       url: https://pypi.org/project/nrel.routee.compass 
     permissions:
       id-token: write
-    # strategy:
-    #   fail-fast: true
-    #   matrix:
-    #     os:
-    #       - ubuntu
-    #       - macos
-    #       - windows
-    #     python-version:
-    #       - "9"
-    #       - "10"
-    #       - "11"
-    #       - "12"
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu
+          - macos
+          - windows
+        python-version:
+          - "9"
+          - "10"
+          - "11"
+          - "12"
 
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
         with:
-          name: "wheel-*"
+          name: "wheel-${{ matrix.os }}-py${{ matrix.python-version }}"
           path: dist
 
       - name: publish package

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: set up rust
         if: matrix.os != 'ubuntu'

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -102,11 +102,24 @@ jobs:
       url: https://pypi.org/project/nrel.routee.compass 
     permissions:
       id-token: write
+    # strategy:
+    #   fail-fast: true
+    #   matrix:
+    #     os:
+    #       - ubuntu
+    #       - macos
+    #       - windows
+    #     python-version:
+    #       - "9"
+    #       - "10"
+    #       - "11"
+    #       - "12"
+
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
         with:
-          name: "wheels-*"
+          name: "wheel-*"
           path: dist
 
       - name: publish package

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: "wheels-${{ matrix.python-version }}"
           path: dist
   upload:
     needs: build
@@ -106,7 +106,7 @@ jobs:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheels
+          name: "wheels-*"
           path: dist
 
       - name: publish package

--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -67,18 +67,14 @@ jobs:
         env:
           # 2025-01-02: cpython 3.11 requires Mac OS 10.12 at minimum
           MACOSX_DEPLOYMENT_TARGET: 10.12
-          
+
           # CI Build Wheel Arguments
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
           CIBW_SKIP: "*-win32 *-musllinux* *i686 *ppc64le *s390x *aarch64"
           CIBW_PLATFORM: ${{ matrix.platform || matrix.os }}
-          # CIBW_TEST_REQUIRES: "pytest"
-          # CIBW_TEST_COMMAND: "pytest {project}/tests -s"
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
           CIBW_ARCHS_MACOS: "universal2"
-          # see https://cibuildwheel.readthedocs.io/en/stable/faq/#universal2
-          # CIBW_TEST_SKIP: '*_universal2:arm64'
           CIBW_BEFORE_BUILD: >
             pip install -U maturin &&
             rustup default nightly &&
@@ -99,28 +95,27 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/nrel.routee.compass 
+      url: https://pypi.org/project/nrel.routee.compass
     permissions:
       id-token: write
-    strategy:
-      fail-fast: true
-      matrix:
-        os:
-          - ubuntu
-          - macos
-          - windows
-        python-version:
-          - "9"
-          - "10"
-          - "11"
-          - "12"
-
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
         with:
-          name: "wheel-${{ matrix.os }}-py${{ matrix.python-version }}"
-          path: dist
+          merge-multiple: true
+          path: dist/
+          pattern: wheel*
 
-      - name: publish package
+      - run: ls -1 dist/
+
+      - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nrel.routee.compass"
-version = "0.8.1.post1"
+version = "0.9.0"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"
 documentation = "nrel.github.io/routee-compass"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.9.0"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"
 documentation = "nrel.github.io/routee-compass"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 authors = [{ name = "National Renewable Energy Laboratory" }]
 license = { text = "BSD 3-Clause License Copyright (c) 2023, Alliance for Sustainable Energy, LLC" }
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.9.0"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"
 documentation = "nrel.github.io/routee-compass"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 authors = [{ name = "National Renewable Energy Laboratory" }]
 license = { text = "BSD 3-Clause License Copyright (c) 2023, Alliance for Sustainable Energy, LLC" }
 classifiers = [

--- a/rust/routee-compass-core/Cargo.toml
+++ b/rust/routee-compass-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 exclude = ["test/"]
 readme = "README.md"

--- a/rust/routee-compass-core/README.md
+++ b/rust/routee-compass-core/README.md
@@ -12,7 +12,7 @@ To install as a library in Rust, add routee-compass-core to your Cargo.toml file
 
 ```toml
 [dependencies]
-routee-compass-core = { version = "0.8.0" }
+routee-compass-core = { version = "0.9.0" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass-core/latest/routee_compass_core/) for usage.

--- a/rust/routee-compass-macros/Cargo.toml
+++ b/rust/routee-compass-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-macros"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/rust/routee-compass-macros/README.md
+++ b/rust/routee-compass-macros/README.md
@@ -10,7 +10,7 @@ To install as a library in Rust, add routee-compass-macros to your Cargo.toml fi
 
 ```toml
 [dependencies]
-routee-compass-macros = { version = "0.8.0" }
+routee-compass-macros = { version = "0.9.0" }
 ```
 
 This crate currently just provides a single macro for wrapping a compass application with python bindings.

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-powertrain"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/routee-compass"
 
 
 [dependencies]
-routee-compass-core = { path = "../routee-compass-core", version = "0.8.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.9.0" }
 smartcore = { version = "0.3.1", features = ["serde"] }                      # random forest
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/rust/routee-compass-powertrain/README.md
+++ b/rust/routee-compass-powertrain/README.md
@@ -12,7 +12,7 @@ To install as a library in Rust, add routee-compass-powertrain to your Cargo.tom
 
 ```toml
 [dependencies]
-routee-compass-powertrain = { version = "0.8.0" }
+routee-compass-powertrain = { version = "0.9.0" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass-powertrain/latest/routee_compass_powertrain/) for usage.

--- a/rust/routee-compass-py/Cargo.toml
+++ b/rust/routee-compass-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass-py"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -10,9 +10,9 @@ repository = "https://github.com/NREL/routee-compass"
 documentation = "https://docs.rs/routee-compass"
 
 [dependencies]
-routee-compass = { path = "../routee-compass", version = "0.8.0" }
-routee-compass-core = { path = "../routee-compass-core", version = "0.8.0" }
-routee-compass-macros = { path = "../routee-compass-macros", version = "0.8.0" }
+routee-compass = { path = "../routee-compass", version = "0.9.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.9.0" }
+routee-compass-macros = { path = "../routee-compass-macros", version = "0.9.0" }
 pyo3 = { version = "0.22.2", features = ["extension-module", "serde"] }
 serde_json = { workspace = true }
 config = { workspace = true }

--- a/rust/routee-compass-py/README.md
+++ b/rust/routee-compass-py/README.md
@@ -16,7 +16,7 @@ To install as a library in Rust, add routee-compass-py to your Cargo.toml file:
 
 ```toml
 [dependencies]
-routee-compass-py = { version = "0.8.0" }
+routee-compass-py = { version = "0.9.0" }
 ```
 
 ## License

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routee-compass"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -18,8 +18,8 @@ keywords = [
 categories = ["science", "science::geo"]
 
 [dependencies]
-routee-compass-core = { path = "../routee-compass-core", version = "0.8.0" }
-routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.8.0" }
+routee-compass-core = { path = "../routee-compass-core", version = "0.9.0" }
+routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.9.0" }
 thiserror = { workspace = true }
 flate2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/rust/routee-compass/README.md
+++ b/rust/routee-compass/README.md
@@ -11,7 +11,7 @@ To install as a library in Rust, add routee-compass to your Cargo.toml file:
 
 ```toml
 [dependencies]
-routee-compass = { version = "0.8.0" }
+routee-compass = { version = "0.9.0" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass/latest/routee_compass/) for usage.

--- a/rust/routee-compass/src/doc.md
+++ b/rust/routee-compass/src/doc.md
@@ -120,7 +120,7 @@ To understand how these each interact with the state model, review the documenta
 
 #### Custom Plugins
 
-Plugins have a simpler initialization process where the [InputPluginBuilder] and [OutputPluginBuilder] expose a `build` method to create the plugin.
+Plugins have a simpler initialization process where the [InputPluginBuilder] and [OutputPluginBuilder] expose a `build` method to create the plugin.g
 For examples, review the implementation of the built-in plugins:
   - [`crate::plugin::input::default`]
   - [`crate::plugin::output::default`]

--- a/rust/routee-compass/src/doc.md
+++ b/rust/routee-compass/src/doc.md
@@ -120,7 +120,7 @@ To understand how these each interact with the state model, review the documenta
 
 #### Custom Plugins
 
-Plugins have a simpler initialization process where the [InputPluginBuilder] and [OutputPluginBuilder] expose a `build` method to create the plugin.g
+Plugins have a simpler initialization process where the [InputPluginBuilder] and [OutputPluginBuilder] expose a `build` method to create the plugin.
 For examples, review the implementation of the built-in plugins:
   - [`crate::plugin::input::default`]
   - [`crate::plugin::output::default`]


### PR DESCRIPTION
here's a proposed stopping point for calling it "0.9.0" for Rust.

...should i bump the python versions too?