### PR TITLE
Upgrade ninterp to 0.2.0

### DIFF
--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -27,7 +27,7 @@ ndarray = "0.16.1"
 ort = { version = "2.0.0-alpha.4", optional = true }
 rayon = { workspace = true }
 itertools = { workspace = true }
-ninterp = { version = "0.1.0", features = ["serde"] }
+ninterp = { version = "0.2.0", features = ["serde"] }
 
 [features]
 default = []


### PR DESCRIPTION
Hey dudes

I just released ninterp v0.2.0, which has a minor syntax change to make the internal structs totally private. This changes the syntax as shown below:

Before:
```rust
let interp = Interpolator::Interp2D(
    Interp2D::new(
        ...
    )?
);
```

After:
```rust
let interp = Interpolator::new_2d(
    ...
)?;
```

Since the `Interp1D`/`Interp2D`/etc. structs are private, matching for N > 0 should be done with `..`:
```rust
match interp {
    Interp0D(value) => {},
    Interp1D(..) => {},
    Interp2D(..) => {},
    Interp3D(..) => {},
    InterpND(..) => {},
}
```

This is in response to some occurrences in FASTSim when we accidentally called e.g. `Interp2D::interpolate`, rather than the correct `Interpolator::interpolate`. This was sneakily skipping the checks on data ranges (to be handled according to `Extrapolate` selection).

I also think the new syntax is a little tidier and clearer.

This shouldn't affect routee-compass at all, but I figured having the latest syntax wouldn't hurt.