### PR TITLE
Add more energy rate distance units

### DIFF
--- a/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
@@ -28,6 +28,10 @@ impl EnergyRateUnit {
             ERU::KilowattHoursPerMile => DU::Miles,
             ERU::KilowattHoursPerKilometer => DU::Kilometers,
             ERU::KilowattHoursPerMeter => DU::Meters,
+            ERU::LitersGasolinePerKilometer => DU::Kilometers,
+            ERU::LitersDieselPerKilometer => DU::Kilometers,
+            ERU::LitersGasolinePerMeter => DU::Meters,
+            ERU::LitersDieselPerMeter => DU::Meters,
         }
     }
 
@@ -41,6 +45,10 @@ impl EnergyRateUnit {
             ERU::KilowattHoursPerMile => EU::KilowattHours,
             ERU::KilowattHoursPerKilometer => EU::KilowattHours,
             ERU::KilowattHoursPerMeter => EU::KilowattHours,
+            ERU::LitersGasolinePerKilometer => EU::LitersGasoline,
+            ERU::LitersDieselPerKilometer => EU::LitersGasoline,
+            ERU::LitersGasolinePerMeter => EU::LitersGasoline,
+            ERU::LitersDieselPerMeter => EU::LitersDiesel,
         }
     }
 }

--- a/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
@@ -11,6 +11,10 @@ pub enum EnergyRateUnit {
     KilowattHoursPerMile,
     KilowattHoursPerKilometer,
     KilowattHoursPerMeter,
+    LitersGasolinePerKilometer,
+    LitersDieselPerKilometer,
+    LitersGasolinePerMeter,
+    LitersDieselPerMeter,
 }
 
 impl EnergyRateUnit {

--- a/rust/routee-compass-core/src/model/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_unit.rs
@@ -47,7 +47,7 @@ impl EnergyUnit {
             // LG->GD: LG -> LD -> GD
             (S::LitersGasoline, S::GallonsDiesel) => *value * (0.264 * 0.866 * 3.785) * 0.264,
             // LG->KWH: LG -> GG -> KWH
-            (S::LitersGasoline, S:: KilowattHours) => *value * 0.264 * 32.26,
+            (S::LitersGasoline, S::KilowattHours) => *value * 0.264 * 32.26,
             (S::LitersDiesel, S::LitersDiesel) => *value,
             // LD->LG: LD -> GD -> GG -> LG
             (S::LitersDiesel, S::LitersGasoline) => *value * 0.264 * 1.155 * 3.785,

--- a/rust/routee-compass-core/src/model/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_unit.rs
@@ -15,12 +15,12 @@ pub enum EnergyUnit {
 
 impl EnergyUnit {
     // see https://epact.energy.gov/fuel-conversion-factors
+    // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
     pub fn convert(&self, value: &Energy, target: &EnergyUnit) -> Energy {
         use EnergyUnit as S;
         match (self, target) {
             (S::GallonsGasoline, S::GallonsGasoline) => *value,
             (S::GallonsGasoline, S::KilowattHours) => *value * 32.26,
-            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
             (S::GallonsGasoline, S::LitersGasoline) => *value * 3.785,
             // GG->LD: GG -> GD -> LD
             (S::GallonsGasoline, S::LitersDiesel) => *value * 0.866 * 3.785,
@@ -34,7 +34,6 @@ impl EnergyUnit {
             (S::GallonsDiesel, S::KilowattHours) => *value * 40.7,
             // GD->LG: GD -> GG -> LG
             (S::GallonsDiesel, S::LitersGasoline) => *value * 1.155 * 3.785,
-            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
             (S::GallonsDiesel, S::LitersDiesel) => *value * 3.785,
             (S::KilowattHours, S::GallonsDiesel) => *value * 0.02457,
             (S::GallonsDiesel, S::GallonsGasoline) => *value * 1.155,
@@ -42,7 +41,6 @@ impl EnergyUnit {
             (S::LitersGasoline, S::LitersGasoline) => *value,
             // LG->LD: LG -> GG -> GD -> LD
             (S::LitersGasoline, S::LitersDiesel) => *value * 0.866,
-            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
             (S::LitersGasoline, S::GallonsGasoline) => *value * 0.264,
             // LG->GD: LG -> LD -> GD
             (S::LitersGasoline, S::GallonsDiesel) => *value * 0.264 * 0.866,
@@ -53,7 +51,6 @@ impl EnergyUnit {
             (S::LitersDiesel, S::LitersGasoline) => *value * 1.155,
             // LD->GG: LD -> LG -> GG
             (S::LitersDiesel, S::GallonsGasoline) => *value * 0.264 * 1.155,
-            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
             (S::LitersDiesel, S::GallonsDiesel) => *value * 0.264,
             // LD->KWH: LD -> GD -> KWH
             (S::LitersDiesel, S::KilowattHours) => *value * 0.264 * 40.7,

--- a/rust/routee-compass-core/src/model/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_unit.rs
@@ -9,8 +9,11 @@ pub enum EnergyUnit {
     GallonsGasoline,
     GallonsDiesel,
     KilowattHours,
+    LitersGasoline,
+    LitersDiesel,
 }
 
+// TODO: Need to update for LitersGasoline, GallonsGasoline
 impl EnergyUnit {
     // see https://epact.energy.gov/fuel-conversion-factors
     pub fn convert(&self, value: &Energy, target: &EnergyUnit) -> Energy {
@@ -18,13 +21,43 @@ impl EnergyUnit {
         match (self, target) {
             (S::GallonsGasoline, S::GallonsGasoline) => *value,
             (S::GallonsGasoline, S::KilowattHours) => *value * 32.26,
+            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
+            (S::GallonsGasoline, S::LitersGasoline) => *value * 3.785,
+            // GG->LD: GG -> GD -> LD
+            (S::GallonsGasoline, S::LitersDiesel) => *value * 0.866 * 3.785,
             (S::KilowattHours, S::GallonsGasoline) => *value * 0.031,
             (S::KilowattHours, S::KilowattHours) => *value,
+            // KWH->LG: KWH -> GG -> LG
+            (S::KilowattHours, S::LitersGasoline) => *value * 0.031 * 3.785,
+            // KWH->LD: KWH -> GD -> LD
+            (S::KilowattHours, S::LitersDiesel) => *value * 0.02457 * 3.785,
             (S::GallonsDiesel, S::GallonsDiesel) => *value,
             (S::GallonsDiesel, S::KilowattHours) => *value * 40.7,
+            // GD->LG: GD -> GG -> LG
+            (S::GallonsDiesel, S::LitersGasoline) => *value * 1.155 * 3.785,
+            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
+            (S::GallonsDiesel, S::LitersDiesel) => *value * 3.785,
             (S::KilowattHours, S::GallonsDiesel) => *value * 0.02457,
             (S::GallonsDiesel, S::GallonsGasoline) => *value * 1.155,
             (S::GallonsGasoline, S::GallonsDiesel) => *value * 0.866,
+            (S::LitersGasoline, S::LitersGasoline) => *value,
+            // LG->LD: LG -> GG -> GD -> LD
+            (S::LitersGasoline, S::LitersDiesel) => *value * 0.264 * 0.866 * 3.785,
+            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
+            (S::LitersGasoline, S::GallonsGasoline) => *value * 0.264,
+            // LG->GD: LG -> LD -> GD
+            (S::LitersGasoline, S::GallonsDiesel) => *value * (0.264 * 0.866 * 3.785) * 0.264,
+            // LG->KWH: LG -> GG -> KWH
+            (S::LitersGasoline, S:: KilowattHours) => *value * 0.264 * 32.26,
+            (S::LitersDiesel, S::LitersDiesel) => *value,
+            // LD->LG: LD -> GD -> GG -> LG
+            (S::LitersDiesel, S::LitersGasoline) => *value * 0.264 * 1.155 * 3.785,
+            // LD->GG: LD -> LG -> GG
+            (S::LitersDiesel, S::GallonsGasoline) => *value * (0.264 * 1.155 * 3.785) * 0.264,
+            // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
+            (S::LitersDiesel, S::GallonsDiesel) => *value * 0.264,
+            // LD->KWH: LD -> GD -> KWH
+            (S::LitersDiesel, S::KilowattHours) => *value * 0.264 * 40.7,
         }
     }
 }

--- a/rust/routee-compass-core/src/model/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_unit.rs
@@ -13,7 +13,6 @@ pub enum EnergyUnit {
     LitersDiesel,
 }
 
-// TODO: Need to update for LitersGasoline, GallonsGasoline
 impl EnergyUnit {
     // see https://epact.energy.gov/fuel-conversion-factors
     pub fn convert(&self, value: &Energy, target: &EnergyUnit) -> Energy {

--- a/rust/routee-compass-core/src/model/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_unit.rs
@@ -41,18 +41,18 @@ impl EnergyUnit {
             (S::GallonsGasoline, S::GallonsDiesel) => *value * 0.866,
             (S::LitersGasoline, S::LitersGasoline) => *value,
             // LG->LD: LG -> GG -> GD -> LD
-            (S::LitersGasoline, S::LitersDiesel) => *value * 0.264 * 0.866 * 3.785,
+            (S::LitersGasoline, S::LitersDiesel) => *value * 0.866,
             // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
             (S::LitersGasoline, S::GallonsGasoline) => *value * 0.264,
             // LG->GD: LG -> LD -> GD
-            (S::LitersGasoline, S::GallonsDiesel) => *value * (0.264 * 0.866 * 3.785) * 0.264,
+            (S::LitersGasoline, S::GallonsDiesel) => *value * 0.264 * 0.866,
             // LG->KWH: LG -> GG -> KWH
             (S::LitersGasoline, S::KilowattHours) => *value * 0.264 * 32.26,
             (S::LitersDiesel, S::LitersDiesel) => *value,
             // LD->LG: LD -> GD -> GG -> LG
-            (S::LitersDiesel, S::LitersGasoline) => *value * 0.264 * 1.155 * 3.785,
+            (S::LitersDiesel, S::LitersGasoline) => *value * 1.155,
             // LD->GG: LD -> LG -> GG
-            (S::LitersDiesel, S::GallonsGasoline) => *value * (0.264 * 1.155 * 3.785) * 0.264,
+            (S::LitersDiesel, S::GallonsGasoline) => *value * 0.264 * 1.155,
             // see https://www.eia.gov/energyexplained/units-and-calculators/energy-conversion-calculators.php
             (S::LitersDiesel, S::GallonsDiesel) => *value * 0.264,
             // LD->KWH: LD -> GD -> KWH


### PR DESCRIPTION
The PR is the implementation for https://github.com/NREL/routee-compass/issues/242

I have incorporated the following changes:

1. Update the `enum EnergyRateUnit` with additional SI units:
```
  - LitersGasolinePerKilometer
  - LitersDieselPerKilometer
  - LitersGasolinePerMeter
  - LitersDieselPerMeter
```

2. Update the `enum EnergyUnit` with
```
  - LitersGasoline
  - LitersDiesel
```
4. Updated the implementation for both `EnergyRateUnit` and `EnergyUnit`
    - Calculation for match arms of Energy Units have been highlighted in the comment.

Executed the following commands: `cargo build --release` & `cargo test`

<details><summary>Detailed execution of the commands: Both executed successfully </summary>
<p>

```


(routee-compass) ashrest2-41625s:rust ashrest2$ cargo build --release
   Compiling routee-compass-core v0.9.0 (/Users/ashrest2/TETA/routee-compass/rust/routee-compass-core)
   Compiling routee-compass-powertrain v0.9.0 (/Users/ashrest2/TETA/routee-compass/rust/routee-compass-powertrain)
   Compiling routee-compass v0.9.0 (/Users/ashrest2/TETA/routee-compass/rust/routee-compass)
   Compiling routee-compass-py v0.9.0 (/Users/ashrest2/TETA/routee-compass/rust/routee-compass-py)
    Finished `release` profile [optimized] target(s) in 6.04s
(routee-compass) ashrest2-41625s:rust ashrest2$ cargo test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running unittests src/lib.rs (target/debug/deps/routee_compass-b79ea4f76c6bfd02)

running 11 tests
test app::compass::model::frontier_model::vehicle_restrictions::vehicle_restriction::test::test_deserialize ... ok
test app::compass::compass_app_ops::test::test_big_outlier ... ok
test app::compass::compass_app_ops::test::test_cycling_input ... ok
test app::compass::compass_app_ops::test::test_incremental_input ... ok
test plugin::input::default::grid_search::plugin::test::test_handle_recursion ... ok
test plugin::input::default::grid_search::plugin::test::test_grid_search_empty_parent_object ... ok
test plugin::input::default::grid_search::plugin::test::test_grid_search_persisted_parent_keys ... ok
test app::compass::compass_app_ops::test::test_uniform_input ... ok
test plugin::input::default::grid_search::plugin::test::test_grid_search_using_objects ... ok
test plugin::input::default::grid_search::plugin::test::test_nested ... ok
search: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 1893.34it/s]test app::compass::compass_app::tests::test_speeds ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running unittests src/bin/geom-app.rs (target/debug/deps/geom_app-af6365a49d7828e4)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/routee_compass-c79412511e8e228c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/routee_compass_core-9063211a9e2f74bf)

running 46 tests
test model::access::default::turn_delays::edge_heading::test::test_wrap_360 ... ok
test model::access::default::turn_delays::edge_heading::test::test_simple ... ok
test algorithm::component::scc::tests::test_all_strongly_connected_components ... ok
edge LineString geometry file: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 888888.88it/s]test model::map::geometry_model::tests::test_geometry_deserialization ... ok
test model::termination::termination_model::tests::test_combined_2_of_3 ... ok
test algorithm::component::scc::tests::test_largest_strongly_connected_component ... ok
test model::map::spatial_index::test::test_vertex_oriented_e2e ... ok
test model::termination::termination_model::tests::test_combined_3 ... ok
test model::termination::termination_model::tests::test_exceeds_runtime_limit ... ok
test model::termination::termination_model::tests::test_within_runtime_limit ... ok
test model::termination::termination_model::tests::test_size_limit ... ok
test model::network::vertex::tests::test_deserialize_csv ... ok
test model::termination::termination_model::tests::test_iterations_limit ... ok
test model::traversal::default::speed_traversal_model::tests::test_edge_cost_lookup_with_milliseconds_time_unit ... ok
test model::unit::builders::test::test_energy_ggpm_meters ... ok
test model::unit::builders::test::test_energy_ggpm_miles ... ok
test model::unit::builders::test::test_speed_calculate_base_to_mph ... ok
test model::unit::builders::test::test_speed_calculate_base_to_kph ... ok
test model::unit::builders::test::test_speed_calculate_fails ... ok
test model::unit::builders::test::test_speed_calculate_idempotent ... ok
test model::traversal::default::speed_traversal_model::tests::test_edge_cost_lookup_with_seconds_time_unit ... ok
test model::unit::builders::test::test_speed_calculate_imperial_to_si ... ok
test model::unit::builders::test::test_speed_calculate_kph_to_base ... ok
test model::unit::builders::test::test_speed_calculate_mph_to_base ... ok
test model::unit::builders::test::test_time_calculate_base_to_kph ... ok
test model::unit::builders::test::test_time_calculate_base_to_mph ... ok
test model::unit::builders::test::test_time_calculate_fails ... ok
test model::unit::builders::test::test_time_calculate_idempotent ... ok
test model::unit::builders::test::test_time_calculate_kph_to_base ... ok
test model::unit::builders::test::test_time_calculate_mph_to_base ... ok
test model::unit::distance_unit::test::test_conversions ... ok
test model::unit::grade_unit::test::test_conversions ... ok
test model::unit::internal_float::tests::test_visit ... ok
test model::unit::speed_unit::test::test_conversions ... ok
test model::unit::time_unit::test::test_conversions ... ok
test model::unit::weight_unit::test::test_conversions ... ok
test util::cache_policy::float_cache_policy::test::test_float_cache_policy ... ok
test util::compact_ordered_hash_map::test::test_replace_value_at_key ... ok
test algorithm::search::a_star::a_star_algorithm::tests::test_e2e_queries ... ok
test util::duration_extension::tests::test_duration_hhmmss ... ok
test util::compact_ordered_hash_map::test::test_inserts ... ok
test util::geo::coord::tests::test_visit ... ok
test util::geo::geo_io_utils::test::test_concat_linstrings ... ok
test util::multiset::test::test_multiset ... ok
test util::fs::read_utils::tests::test_read_raw_file ... ok
test util::fs::read_utils::tests::test_read_raw_file_gzip ... ok

test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/routee_compass_macros-9162bc9c5807d2ae)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/routee_compass_powertrain-fc09a53ab4e69cd0)

running 8 tests
test model::energy_traversal_model::tests::test_edge_cost_lookup_from_file ... ok
test model::vehicle::default::bev::tests::test_bev_energy_model_regen ... ok
test model::vehicle::default::bev::tests::test_bev_energy_model ... ok
test model::vehicle::default::bev::tests::test_bev_battery_in_bounds_upper ... ok
test model::vehicle::default::bev::tests::test_bev_battery_in_bounds_lower ... ok
test model::vehicle::default::phev::tests::test_phev_energy_model_gas_and_electric ... ok
test model::vehicle::default::phev::tests::test_phev_energy_model_just_electric ... ok
test model::prediction::interpolation::interpolation_speed_grade_model::test::test_interpolation_speed_grade_model ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s

     Running unittests src/lib.rs (target/debug/deps/routee_compass_py-a438cd65e5ac38ec)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests routee_compass

running 2 tests
test routee-compass/src/lib.rs - (line 66) ... ignored
test routee-compass/src/app/bindings.rs - app::bindings::CompassAppBindings (line 28) ... ok

test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.53s

   Doc-tests routee_compass_core

running 2 tests
test routee-compass-core/src/util/cache_policy/float_cache_policy.rs - util::cache_policy::float_cache_policy::FloatCachePolicy (line 24) ... ok
test routee-compass-core/src/util/geo/geo_io_utils.rs - util::geo::geo_io_utils::concat_linestrings (line 18) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.43s

   Doc-tests routee_compass_macros

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests routee_compass_powertrain

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```

</p>
</details> 

Also, executed the following:
```
(routee-compass) ashrest2-41625s:routee-compass ashrest2$ pip install -e ".[dev]"
...
(routee-compass) ashrest2-41625s:routee-compass ashrest2$ pytest python/tests
============================================================================================================================================ test session starts =============================================================================================================================================
platform darwin -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/ashrest2/TETA/routee-compass
configfile: pyproject.toml
plugins: anyio-4.8.0
collected 1 item                                                                                                                                                                                                                                                                                             

python/tests/test_downtown_denver_example.py .                                                                                                                                                                                                                                                         [100%]

============================================================================================================================================= 1 passed in 0.27s =============================================================================================================================================
```
