### PR TITLE
Ndr/257 max speed

### DIFF
--- a/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
@@ -13,25 +13,26 @@ use std::sync::Arc;
 pub struct SpeedTraversalModel {
     engine: Arc<SpeedTraversalEngine>,
 
-    max_speed: Option<Speed>, // max speed is converted to the speed unit of the engine
+    speed_limit: Option<(Speed, SpeedUnit)>,
 }
 
 impl SpeedTraversalModel {
     pub fn new(
         engine: Arc<SpeedTraversalEngine>,
-        max_speed: Option<(Speed, SpeedUnit)>,
+        speed_limit: Option<(Speed, SpeedUnit)>,
     ) -> SpeedTraversalModel {
-        if let Some((max_speed, max_speed_unit)) = max_speed {
+        if let Some((max_speed, max_speed_unit)) = speed_limit {
             let converted_speed = max_speed_unit.convert(&max_speed, &engine.speed_unit);
+            let converted_speed_unit = engine.speed_unit;
             return SpeedTraversalModel {
                 engine,
-                max_speed: Some(converted_speed),
+                speed_limit: Some((converted_speed, converted_speed_unit)),
             };
         }
 
         SpeedTraversalModel {
             engine,
-            max_speed: None,
+            speed_limit: None,
         }
     }
     const DISTANCE: &'static str = "distance";
@@ -49,10 +50,10 @@ impl TraversalModel for SpeedTraversalModel {
         let distance = BASE_DISTANCE_UNIT.convert(&edge.distance, &self.engine.distance_unit);
         let speed = get_speed(&self.engine.speed_table, edge.edge_id)?;
 
-        let speed = match self.max_speed {
-            Some(max_speed) => {
-                if speed > max_speed {
-                    max_speed
+        let speed = match self.speed_limit {
+            Some((speed_limit, _speed_unit)) => {
+                if speed > speed_limit {
+                    speed_limit
                 } else {
                     speed
                 }
@@ -103,8 +104,13 @@ impl TraversalModel for SpeedTraversalModel {
             return Ok(());
         }
 
+        let max_speed = match self.speed_limit {
+            Some((speed_limit, _speed_unit)) => speed_limit,
+            None => self.engine.max_speed,
+        };
+
         let estimated_time = Time::create(
-            &self.engine.max_speed,
+            &max_speed,
             &self.engine.speed_unit,
             &distance,
             &self.engine.distance_unit,
@@ -290,5 +296,80 @@ mod tests {
         // approx_eq(result.total_cost.into(), expected, 0.001);
         // approx_eq(result.updated_state[1].into(), expected, 0.001);
         approx_eq(state[1].into(), expected, 0.001);
+    }
+
+    #[test]
+    fn test_speed_limit_enforcement() {
+        let file = filepath();
+        let engine = Arc::new(
+            SpeedTraversalEngine::new(
+                &file,
+                SpeedUnit::KilometersPerHour,
+                None,
+                Some(TimeUnit::Seconds),
+            )
+            .unwrap(),
+        );
+
+        // We know from the test data that edge 0 has a speed of 10 kph, so set a limit of 5 kph
+        let speed_limit = Some((Speed::new(5.0), SpeedUnit::KilometersPerHour));
+
+        let state_model = Arc::new(
+            StateModel::empty()
+                .extend(vec![
+                    (
+                        String::from("distance"),
+                        StateFeature::Distance {
+                            distance_unit: DistanceUnit::Kilometers,
+                            initial: Distance::new(0.0),
+                        },
+                    ),
+                    (
+                        String::from("time"),
+                        StateFeature::Time {
+                            time_unit: TimeUnit::Seconds,
+                            initial: Time::new(0.0),
+                        },
+                    ),
+                ])
+                .unwrap(),
+        );
+
+        // Create model with speed limit
+        let model_with_limit = SpeedTraversalModel::new(engine.clone(), speed_limit);
+        // Create model without speed limit for comparison
+        let model_without_limit = SpeedTraversalModel::new(engine, None);
+
+        let mut state_with_limit = state_model.initial_state().unwrap();
+        let mut state_without_limit = state_model.initial_state().unwrap();
+
+        let v = mock_vertex();
+        let e = mock_edge(0);
+
+        // Traverse with speed limit
+        model_with_limit
+            .traverse_edge((&v, &e, &v), &mut state_with_limit, &state_model)
+            .unwrap();
+
+        // Traverse without speed limit
+        model_without_limit
+            .traverse_edge((&v, &e, &v), &mut state_without_limit, &state_model)
+            .unwrap();
+
+        // The time with speed limit should be about twice the time without limit
+        // because we set the limit to half the edge speed (5 kph vs 10 kph)
+        let time_with_limit: f64 = state_with_limit[1].into();
+        let time_without_limit: f64 = state_without_limit[1].into();
+
+        // 100 meters @ 5kph should take 72 seconds ((0.1/5) * 3600)
+        let expected_time_with_limit = 72.0;
+        // 100 meters @ 10kph should take 36 seconds ((0.1/10) * 3600)
+        let expected_time_without_limit = 36.0;
+
+        approx_eq(time_with_limit, expected_time_with_limit, 0.001);
+        approx_eq(time_without_limit, expected_time_without_limit, 0.001);
+
+        // Verify that time with limit is about double the time without limit
+        approx_eq(time_with_limit / time_without_limit, 2.0, 0.001);
     }
 }

--- a/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed_traversal_model.rs
@@ -51,6 +51,7 @@ impl TraversalModel for SpeedTraversalModel {
         let speed = get_speed(&self.engine.speed_table, edge.edge_id)?;
 
         let speed = match self.speed_limit {
+            // speed unit here is unused since we've already converted into the same unit as the speed model
             Some((speed_limit, _speed_unit)) => {
                 if speed > speed_limit {
                     speed_limit

--- a/rust/routee-compass-core/src/model/traversal/default/speed_traversal_service.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed_traversal_service.rs
@@ -19,42 +19,45 @@ impl TraversalModelService for SpeedLookupService {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Arc<dyn TraversalModel>, TraversalModelError> {
-        let max_speed_tuple = match parameters.get("max_speed") {
-            Some(max_speed) => {
-                let max_speed = max_speed
+        let speed_limit_tuple = match parameters.get("speed_limit") {
+            Some(speed_limit) => {
+                let speed_limit = speed_limit
                     .as_f64()
                     .ok_or_else(|| {
-                        TraversalModelError::BuildError("max_speed must be a float".to_string())
+                        TraversalModelError::BuildError(
+                            "key `speed_limit` must be a float".to_string(),
+                        )
                     })
                     .map(Speed::new)?;
-                let max_speed_unit = match parameters.get("max_speed_unit") {
+                let max_speed_unit = match parameters.get("speed_limit_unit") {
                     Some(msu) => {
                         let max_speed_unit_str = msu.as_str().ok_or_else(|| {
                             TraversalModelError::BuildError(
-                                "max_speed_unit must be a string".to_string(),
+                                "key `speed_limit_unit` must be a string".to_string(),
                             )
                         })?;
                         let max_speed_unit =
                             SpeedUnit::from_str(max_speed_unit_str).map_err(|_| {
                                 TraversalModelError::BuildError(format!(
-                                    "max_speed_unit {} is not a valid speed unit",
+                                    "key `speed_limit_unit` {} is not a valid speed unit",
                                     max_speed_unit_str
                                 ))
                             })?;
                         Ok(max_speed_unit)
                     }
                     None => Err(TraversalModelError::BuildError(
-                        "max_speed_unit must be provided if max_speed is provided".to_string(),
+                        "key `speed_limit_unit` must be provided if key `speed_limit` is provided"
+                            .to_string(),
                     )),
                 }?;
-                Some((max_speed, max_speed_unit))
+                Some((speed_limit, max_speed_unit))
             }
             None => None,
         };
 
         Ok(Arc::new(SpeedTraversalModel::new(
             self.e.clone(),
-            max_speed_tuple,
+            speed_limit_tuple,
         )))
     }
 }

--- a/rust/routee-compass-core/src/model/traversal/default/speed_traversal_service.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed_traversal_service.rs
@@ -1,11 +1,14 @@
 use super::{
     speed_traversal_engine::SpeedTraversalEngine, speed_traversal_model::SpeedTraversalModel,
 };
-use crate::model::traversal::{
-    traversal_model::TraversalModel, traversal_model_error::TraversalModelError,
-    traversal_model_service::TraversalModelService,
+use crate::model::{
+    traversal::{
+        traversal_model::TraversalModel, traversal_model_error::TraversalModelError,
+        traversal_model_service::TraversalModelService,
+    },
+    unit::{Speed, SpeedUnit},
 };
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 pub struct SpeedLookupService {
     pub e: Arc<SpeedTraversalEngine>,
@@ -14,8 +17,44 @@ pub struct SpeedLookupService {
 impl TraversalModelService for SpeedLookupService {
     fn build(
         &self,
-        _parameters: &serde_json::Value,
+        parameters: &serde_json::Value,
     ) -> Result<Arc<dyn TraversalModel>, TraversalModelError> {
-        Ok(Arc::new(SpeedTraversalModel::new(self.e.clone())))
+        let max_speed_tuple = match parameters.get("max_speed") {
+            Some(max_speed) => {
+                let max_speed = max_speed
+                    .as_f64()
+                    .ok_or_else(|| {
+                        TraversalModelError::BuildError("max_speed must be a float".to_string())
+                    })
+                    .map(Speed::new)?;
+                let max_speed_unit = match parameters.get("max_speed_unit") {
+                    Some(msu) => {
+                        let max_speed_unit_str = msu.as_str().ok_or_else(|| {
+                            TraversalModelError::BuildError(
+                                "max_speed_unit must be a string".to_string(),
+                            )
+                        })?;
+                        let max_speed_unit =
+                            SpeedUnit::from_str(max_speed_unit_str).map_err(|_| {
+                                TraversalModelError::BuildError(format!(
+                                    "max_speed_unit {} is not a valid speed unit",
+                                    max_speed_unit_str
+                                ))
+                            })?;
+                        Ok(max_speed_unit)
+                    }
+                    None => Err(TraversalModelError::BuildError(
+                        "max_speed_unit must be provided if max_speed is provided".to_string(),
+                    )),
+                }?;
+                Some((max_speed, max_speed_unit))
+            }
+            None => None,
+        };
+
+        Ok(Arc::new(SpeedTraversalModel::new(
+            self.e.clone(),
+            max_speed_tuple,
+        )))
     }
 }


### PR DESCRIPTION
Implements #257 by adding a new `speed_limit` to the speed traversal model such that a vehicle cannot exceed this speed when traversing. 