### PR TITLE
Rjf/par input plugins

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -445,13 +445,13 @@ fn apply_input_plugins(
                 })?,
         ));
 
-        let parallel_batch_size =
-            (queries_processed.len() as f64 / parallelism as f64).ceil() as usize;
+        let tasks_per_thread = queries_processed.len() as f64 / parallelism as f64;
+        let chunk_size: usize = std::cmp::max(1, tasks_per_thread.ceil() as usize);
 
         // apply this input plugin in parallel, assigning the result back to `queries_processed`
         // and tracking any errors along the way.
         let (good, bad): (Vec<Value>, Vec<Value>) = queries_processed
-            .par_chunks_mut(parallel_batch_size)
+            .par_chunks_mut(chunk_size)
             .flat_map(|qs| {
                 qs.iter_mut()
                     .flat_map(|q| {

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -432,7 +432,7 @@ fn apply_input_plugins(
         // outer_bar.set_description(format!("{}", plugin.name));  // placeholder for named plugins
         let inner_bar = Arc::new(Mutex::new(
             Bar::builder()
-                .total(queries.len())
+                .total(queries_processed.len())
                 .position(1)
                 .animation("fillup")
                 .desc(format!("applying input plugin {}", idx + 1))

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -423,6 +423,7 @@ fn apply_input_plugins(
     let mut query_errors: Vec<Value> = vec![];
     let mut outer_bar = Bar::builder()
         .total(input_plugins.len())
+        .position(0)
         .build()
         .map_err(CompassAppError::InternalError)?;
     outer_bar.set_description("input plugins"); // until we have named plugins
@@ -433,8 +434,9 @@ fn apply_input_plugins(
         let inner_bar = Arc::new(Mutex::new(
             Bar::builder()
                 .total(queries.len())
+                .position(1)
                 .animation("fillup")
-                .desc(format!("apply plugin {}", idx + 1))
+                .desc(format!("applying input plugin {}", idx + 1))
                 .build()
                 .map_err(|e| {
                     CompassAppError::InternalError(format!(
@@ -468,6 +470,8 @@ fn apply_input_plugins(
         queries_processed = good;
         query_errors.extend(bad);
     }
+    eprintln!();
+    eprintln!();
 
     // input plugins need to be flattened, and queries that fail input processing need to be
     // returned at the end.
@@ -499,7 +503,7 @@ fn apply_input_plugins(
     //         (good.into_iter().flatten().collect_vec(), bad)
     //     })
     //     .unzip();
-    eprintln!(); // end input plugin pb
+    // eprintln!(); // end input plugin pb
 
     // let result = (
     //     good.into_iter().flatten().collect_vec(),


### PR DESCRIPTION
this PR refactors input plugin processing so that the outer loop is the input plugin and the inner loop are the queries to update. the algorithm re-partitions the queries after each input plugin is run, to address when some input plugins have a large multiplexing effect, this allows for periodic rebalancing.