### PR TITLE
Rjf/unit deserializing

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,3 +12,7 @@ For more information about Compass, read about our [motivation](motivation)
 
 1. Follow the [install instructions](installation) for the python package.
 1. Follow this [example](examples/01_open_street_maps_example) to start routing over Open Street Maps data.
+
+## Configuration
+
+1. Read about the [recognized unit names](units) that can be referenced in queries and configuration files

--- a/docs/units.md
+++ b/docs/units.md
@@ -1,0 +1,28 @@
+## Unit Aliases
+
+Compass supports a variety of ways to name a unit type, including singular, plural, and abbreviated forms. Note: Compass is not case sensitive when reading aliases. 
+
+unit type | variant | aliases supported
+--- | --- | ---
+Distance | Meters | "meter", "meters"
+Distance | Kilometers | "kilometer", "kilometers", "km"
+Distance | Miles | "mile", "miles"
+Distance | Inches | "inch", "inches", "in"
+Distance | Feet | "feet", "ft"
+Time | Hours | "hour", "hours", "hr", "hrs", "h"
+Time | Minutes | "minute", "minutes", "min", "mins", "m"
+Time | Seconds | "second", "seconds", "sec", "secs", "s"
+Time | Milliseconds | "millisecond", "milliseconds", "ms"
+Speed | | forward slash-delimited as "{{Distance}}/{{Time}}"
+Grade | Percent | "percent"
+Grade | Decimal | "decimal"
+Grade | Millis | "millis"
+Energy | GallonsGasoline | "gallonsgasoline", "gas"
+Energy | GallonsDiesel | "gallonsdiesel", "diesel"
+Energy | KilowattHours | "kilowatthours", "kilowatthour", "kwh"
+Energy | LitersGasoline | "litersgasoline"
+Energy | LitersDiesel | "litersdiesel"
+EnergyRate | | forward slash-delimited as "{{Distance}}/{{Energy}}" or "{{Energy}}/{{Distance}}"
+Weight | Pounds | "pound", "pounds", "lb", "lbs"
+Weight | Tons | "ton", "tons"
+Weight | Kg | "kilogram", "kilograms", "kg", "kgs"

--- a/rust/routee-compass-core/src/model/unit/distance_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/distance_unit.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, str::FromStr};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", try_from = "String")]
 pub enum DistanceUnit {
     Meters,
     Kilometers,
@@ -77,6 +77,13 @@ impl FromStr for DistanceUnit {
             "feet" | "ft" => Ok(D::Feet),
             _ => Err(format!("unknown distance unit '{}'", s)),
         }
+    }
+}
+
+impl TryFrom<String> for DistanceUnit {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
     }
 }
 

--- a/rust/routee-compass-core/src/model/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_unit.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", try_from = "String")]
 pub enum EnergyUnit {
     /// US Gallons of gasoline fuel
     GallonsGasoline,
@@ -84,13 +84,26 @@ impl FromStr for EnergyUnit {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use EnergyUnit as E;
-        match s.trim().to_lowercase().replace("_", " ").as_str() {
-            "gallons gasoline" | "gas" => Ok(E::GallonsGasoline),
-            "gallons diesel" | "diesel" => Ok(E::GallonsDiesel),
-            "kilowathours" | "kilowatthour" | "kwh" => Ok(E::KilowattHours),
-            "liters gasoline" => Ok(E::LitersGasoline),
-            "liters diesel" => Ok(E::LitersDiesel),
+        match s
+            .trim()
+            .to_lowercase()
+            .replace("_", " ")
+            .replace(" ", "")
+            .as_str()
+        {
+            "gallonsgasoline" | "gas" => Ok(E::GallonsGasoline),
+            "gallonsdiesel" | "diesel" => Ok(E::GallonsDiesel),
+            "kilowatthours" | "kilowatthour" | "kwh" => Ok(E::KilowattHours),
+            "litersgasoline" => Ok(E::LitersGasoline),
+            "litersdiesel" => Ok(E::LitersDiesel),
             _ => Err(format!("unknown energy unit '{}'", s)),
         }
+    }
+}
+
+impl TryFrom<String> for EnergyUnit {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
     }
 }

--- a/rust/routee-compass-core/src/model/unit/energy_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_unit.rs
@@ -91,8 +91,8 @@ impl FromStr for EnergyUnit {
             .replace(" ", "")
             .as_str()
         {
-            "gallonsgasoline" | "gas" => Ok(E::GallonsGasoline),
-            "gallonsdiesel" | "diesel" => Ok(E::GallonsDiesel),
+            "gallonsgasoline" => Ok(E::GallonsGasoline),
+            "gallonsdiesel" => Ok(E::GallonsDiesel),
             "kilowatthours" | "kilowatthour" | "kwh" => Ok(E::KilowattHours),
             "litersgasoline" => Ok(E::LitersGasoline),
             "litersdiesel" => Ok(E::LitersDiesel),

--- a/rust/routee-compass-core/src/model/unit/grade_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/grade_unit.rs
@@ -48,11 +48,17 @@ impl std::fmt::Display for GradeUnit {
 
 impl FromStr for GradeUnit {
     type Err = serde_json::Error;
-
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         string_deserialize(s)
     }
 }
+
+// impl TryFrom<String> for GradeUnit {
+//     type Error = String;
+//     fn try_from(value: String) -> Result<Self, Self::Error> {
+//         Self::from_str(&value)
+//     }
+// }
 
 #[cfg(test)]
 mod test {

--- a/rust/routee-compass-core/src/model/unit/time_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/time_unit.rs
@@ -1,5 +1,5 @@
 use super::{baseunit, Convert, Time, UnitError};
-use crate::{model::unit::AsF64, util::serde::serde_ops::string_deserialize};
+use crate::model::unit::AsF64;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 

--- a/rust/routee-compass-core/src/model/unit/time_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/time_unit.rs
@@ -57,10 +57,22 @@ impl std::fmt::Display for TimeUnit {
 }
 
 impl FromStr for TimeUnit {
-    type Err = serde_json::Error;
-
+    type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        string_deserialize(s)
+        match s {
+            "hour" | "hours" | "hr" | "hrs" | "h" => Ok(TimeUnit::Hours),
+            "minute" | "minutes" | "min" | "mins" | "m" => Ok(TimeUnit::Minutes),
+            "second" | "seconds" | "sec" | "secs" | "s" => Ok(TimeUnit::Seconds),
+            "millisecond" | "milliseconds" | "ms" => Ok(TimeUnit::Milliseconds),
+            _ => Err(format!("unknown time unit '{}'", s)),
+        }
+    }
+}
+
+impl TryFrom<String> for TimeUnit {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
     }
 }
 

--- a/rust/routee-compass-core/src/model/unit/weight_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/weight_unit.rs
@@ -47,10 +47,21 @@ impl std::fmt::Display for WeightUnit {
 }
 
 impl FromStr for WeightUnit {
-    type Err = serde_json::Error;
-
+    type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        string_deserialize(s)
+        match s {
+            "pound" | "pounds" | "lb" | "lbs" => Ok(Self::Pounds),
+            "ton" | "tons" => Ok(Self::Tons),
+            "kilogram" | "kilograms" | "kg" | "kgs" => Ok(Self::Kg),
+            _ => Err(format!("unknown weight unit '{}'", s)),
+        }
+    }
+}
+
+impl TryFrom<String> for WeightUnit {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
     }
 }
 

--- a/rust/routee-compass-core/src/model/unit/weight_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/weight_unit.rs
@@ -1,5 +1,5 @@
 use super::{baseunit, Convert, UnitError, Weight};
-use crate::{model::unit::AsF64, util::serde::serde_ops::string_deserialize};
+use crate::model::unit::AsF64;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 


### PR DESCRIPTION
This PR makes sure FromStr and Deserialize behaviors match for the unit enums according to the issue described in #309. In order to unify them, the enums now use the [`try_from` container attribute](https://serde.rs/container-attrs.html#try_from) which point to the FromStr implementation via a TryFrom<String> implementation. 

Along the way,
  - some missing abbreviations/pluralizations for unit deserializing were added
  - documentation on unit abbreviations was added to the jupyterbook docs

Closes #309.