### PR TITLE
more complete serialization of state and cost at each route/tree branch

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -141,38 +141,38 @@ pub fn run_vertex_oriented(
         solution.len()
     );
 
-    #[cfg(debug_assertions)]
-    {
-        use std::io::Write;
-        use std::path::PathBuf;
+    // #[cfg(debug_assertions)]
+    // {
+    //     use std::io::Write;
+    //     use std::path::PathBuf;
 
-        log::debug!("Building flamegraph for search memory usage..");
-        let mut flamegraph = allocative::FlameGraphBuilder::default();
-        flamegraph.visit_root(&costs);
-        flamegraph.visit_root(&traversal_costs);
-        flamegraph.visit_root(&solution);
-        let output = flamegraph.finish_and_write_flame_graph();
+    //     log::debug!("Building flamegraph for search memory usage..");
+    //     let mut flamegraph = allocative::FlameGraphBuilder::default();
+    //     flamegraph.visit_root(&costs);
+    //     flamegraph.visit_root(&traversal_costs);
+    //     flamegraph.visit_root(&solution);
+    //     let output = flamegraph.finish_and_write_flame_graph();
 
-        let search_name = match target {
-            None => format!("{}_to_all", source),
-            Some(tid) => format!("{}_to_{}", source, tid),
-        };
+    //     let search_name = match target {
+    //         None => format!("{}_to_all", source),
+    //         Some(tid) => format!("{}_to_{}", source, tid),
+    //     };
 
-        let outdir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("..")
-            .join("target")
-            .join("flamegraph");
+    //     let outdir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    //         .join("..")
+    //         .join("target")
+    //         .join("flamegraph");
 
-        if !outdir.exists() {
-            std::fs::create_dir(&outdir).unwrap();
-        }
+    //     if !outdir.exists() {
+    //         std::fs::create_dir(&outdir).unwrap();
+    //     }
 
-        let mut flamegraph_file = std::fs::File::create(
-            outdir.join(format!("search_memory_flamegraph_{}.out", search_name)),
-        )
-        .unwrap();
-        flamegraph_file.write_all(output.as_bytes()).unwrap();
-    }
+    //     let mut flamegraph_file = std::fs::File::create(
+    //         outdir.join(format!("search_memory_flamegraph_{}.out", search_name)),
+    //     )
+    //     .unwrap();
+    //     flamegraph_file.write_all(output.as_bytes()).unwrap();
+    // }
 
     let result = SearchResult::new(solution, iterations);
     Ok(result)

--- a/rust/routee-compass-core/src/model/unit/speed_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/speed_unit.rs
@@ -128,12 +128,6 @@ impl SpeedUnit {
     pub fn associated_distance_unit(&self) -> DistanceUnit {
         self.0
     }
-
-    /// use as a soft "max" value for certain calculations
-    /// todo: should come from configuration, not hard-coded here
-    pub fn max_american_highway_speed(&self) -> (Speed, SpeedUnit) {
-        (Speed::from(75.0), SpeedUnit::MPH)
-    }
 }
 
 #[cfg(test)]

--- a/rust/routee-compass-powertrain/src/model/bev_energy_model.rs
+++ b/rust/routee-compass-powertrain/src/model/bev_energy_model.rs
@@ -162,6 +162,7 @@ impl TraversalModel for BevEnergyModel {
             state_model,
             self.prediction_model_record.clone(),
             (&self.battery_capacity.0, &self.battery_capacity.1),
+            false,
         )
     }
 
@@ -176,6 +177,7 @@ impl TraversalModel for BevEnergyModel {
             state_model,
             self.prediction_model_record.clone(),
             (&self.battery_capacity.0, &self.battery_capacity.1),
+            true,
         )
     }
 }
@@ -183,8 +185,9 @@ impl TraversalModel for BevEnergyModel {
 fn bev_traversal(
     state: &mut [StateVariable],
     state_model: &StateModel,
-    prediction_model_record: Arc<PredictionModelRecord>,
+    record: Arc<PredictionModelRecord>,
     battery_capacity: (&Energy, &EnergyUnit),
+    estimate: bool,
 ) -> Result<(), TraversalModelError> {
     let (distance, distance_unit) =
         state_model.get_distance(state, fieldname::EDGE_DISTANCE, None)?;
@@ -192,11 +195,18 @@ fn bev_traversal(
     let (grade, grade_unit) = state_model.get_grade(state, fieldname::EDGE_GRADE, None)?;
     let soc = state_model.get_custom_f64(state, fieldname::TRIP_SOC)?;
 
-    let (energy, energy_unit) = prediction_model_record.predict(
-        (speed, speed_unit),
-        (grade, grade_unit),
-        (distance, distance_unit),
-    )?;
+    let (energy, energy_unit) = if estimate {
+        Energy::create(
+            (&distance, &distance_unit),
+            (&record.ideal_energy_rate, &record.energy_rate_unit),
+        )?
+    } else {
+        record.predict(
+            (speed, speed_unit),
+            (grade, grade_unit),
+            (distance, distance_unit),
+        )?
+    };
     let end_soc =
         energy_model_ops::update_soc_percent(&soc, (&energy, &energy_unit), battery_capacity)?;
 
@@ -232,6 +242,7 @@ mod tests {
             &state_model,
             record.clone(),
             (&bat_cap, &bat_unit),
+            false,
         )
         .unwrap();
 
@@ -268,6 +279,7 @@ mod tests {
             &state_model,
             record.clone(),
             (&bat_cap, &bat_unit),
+            false,
         )
         .unwrap();
 
@@ -305,6 +317,7 @@ mod tests {
             &state_model,
             record.clone(),
             (&bat_cap, &bat_unit),
+            false,
         )
         .unwrap();
 
@@ -332,6 +345,7 @@ mod tests {
             &state_model,
             record.clone(),
             (&bat_cap, &bat_unit),
+            false,
         )
         .unwrap();
 

--- a/rust/routee-compass-powertrain/src/model/bev_energy_model.rs
+++ b/rust/routee-compass-powertrain/src/model/bev_energy_model.rs
@@ -197,7 +197,7 @@ fn bev_traversal(
 
     let (energy, energy_unit) = if estimate {
         Energy::create(
-            (&distance, &distance_unit),
+            (&distance, distance_unit),
             (&record.ideal_energy_rate, &record.energy_rate_unit),
         )?
     } else {

--- a/rust/routee-compass-powertrain/src/model/phev_energy_model.rs
+++ b/rust/routee-compass-powertrain/src/model/phev_energy_model.rs
@@ -301,17 +301,17 @@ fn depleting_only_traversal(
     state_model.set_energy(
         state,
         fieldname::EDGE_ENERGY_ELECTRIC,
-        &est_edge_elec,
+        est_edge_elec,
         battery_unit,
     )?;
     state_model.add_energy(
         state,
         fieldname::TRIP_ENERGY_ELECTRIC,
-        &est_edge_elec,
+        est_edge_elec,
         battery_unit,
     )?;
     // update trip energy in GGE
-    let gge = accumulate_gge(&[(&est_edge_elec, battery_unit)])?;
+    let gge = accumulate_gge(&[(est_edge_elec, battery_unit)])?;
     state_model.set_energy(
         state,
         fieldname::EDGE_ENERGY,
@@ -326,7 +326,7 @@ fn depleting_only_traversal(
     )?;
     let end_soc = energy_model_ops::update_soc_percent(
         &start_soc,
-        (&est_edge_elec, battery_unit),
+        (est_edge_elec, battery_unit),
         (battery_capacity, battery_unit),
     )?;
     state_model.set_custom_f64(state, fieldname::TRIP_SOC, &end_soc)?;
@@ -351,13 +351,13 @@ fn mixed_traversal(
     state_model.set_energy(
         state,
         fieldname::EDGE_ENERGY_ELECTRIC,
-        &edge_start_elec,
+        edge_start_elec,
         battery_unit,
     )?;
     state_model.add_energy(
         state,
         fieldname::TRIP_ENERGY_ELECTRIC,
-        &edge_start_elec,
+        edge_start_elec,
         battery_unit,
     )?;
     state_model.set_custom_f64(state, fieldname::TRIP_SOC, &0.0)?;
@@ -395,7 +395,7 @@ fn mixed_traversal(
     )?;
     // update trip energy in GGE from both depleting and sustaining phases
     let gge = accumulate_gge(&[
-        (&edge_start_elec, battery_unit),
+        (edge_start_elec, battery_unit),
         (&remaining_energy, &remaining_unit),
     ])?;
     state_model.set_energy(

--- a/rust/routee-compass-powertrain/src/model/phev_energy_model.rs
+++ b/rust/routee-compass-powertrain/src/model/phev_energy_model.rs
@@ -249,7 +249,7 @@ fn phev_traversal(
     // estimate remaining energy if we travel this distance
     let (est_edge_elec, est_elec_unit) = if estimate {
         Energy::create(
-            (&distance, &distance_unit),
+            (&distance, distance_unit),
             (&depleting.ideal_energy_rate, &depleting.energy_rate_unit),
         )?
     } else {
@@ -275,16 +275,16 @@ fn phev_traversal(
             state,
             fieldname::EDGE_ENERGY_ELECTRIC,
             &est_edge_elec,
-            &battery_unit,
+            battery_unit,
         )?;
         state_model.add_energy(
             state,
             fieldname::TRIP_ENERGY_ELECTRIC,
             &est_edge_elec,
-            &battery_unit,
+            battery_unit,
         )?;
         // update trip energy in GGE
-        let gge = accumulate_gge(&[(&est_edge_elec, &battery_unit)])?;
+        let gge = accumulate_gge(&[(&est_edge_elec, battery_unit)])?;
         state_model.set_energy(
             state,
             fieldname::EDGE_ENERGY,
@@ -299,7 +299,7 @@ fn phev_traversal(
         )?;
         let end_soc = energy_model_ops::update_soc_percent(
             &start_soc,
-            (&est_edge_elec, &battery_unit),
+            (&est_edge_elec, battery_unit),
             (battery_capacity.0, battery_capacity.1),
         )?;
         state_model.set_custom_f64(state, fieldname::TRIP_SOC, &end_soc)?;
@@ -309,13 +309,13 @@ fn phev_traversal(
             state,
             fieldname::EDGE_ENERGY_ELECTRIC,
             &edge_start_elec,
-            &battery_unit,
+            battery_unit,
         )?;
         state_model.add_energy(
             state,
             fieldname::TRIP_ENERGY_ELECTRIC,
             &edge_start_elec,
-            &battery_unit,
+            battery_unit,
         )?;
         state_model.set_custom_f64(state, fieldname::TRIP_SOC, &0.0)?;
 
@@ -329,7 +329,7 @@ fn phev_traversal(
         // estimate remaining energy if we travel this distance
         let (remaining_energy, remaining_unit) = if estimate {
             Energy::create(
-                (&remaining_dist, &distance_unit),
+                (&remaining_dist, distance_unit),
                 (&sustaining.ideal_energy_rate, &sustaining.energy_rate_unit),
             )?
         } else {
@@ -356,7 +356,7 @@ fn phev_traversal(
         )?;
         // update trip energy in GGE from both depleting and sustaining phases
         let gge = accumulate_gge(&[
-            (&edge_start_elec, &battery_unit),
+            (&edge_start_elec, battery_unit),
             (&remaining_energy, &remaining_unit),
         ])?;
         state_model.set_energy(

--- a/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/plugin.rs
@@ -72,7 +72,12 @@ impl OutputPlugin for TraversalPlugin {
                 .iter()
                 .map(|tree| {
                     // tree_args.generate_tree_output(tree, &self.geoms)
-                    tree_args.generate_tree_output(tree, si.map_model.clone())
+                    tree_args.generate_tree_output(
+                        tree,
+                        si.map_model.clone(),
+                        si.state_model.clone(),
+                        si.cost_model.clone(),
+                    )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             let trees_json = match trees_serialized.as_slice() {
@@ -97,7 +102,12 @@ fn construct_route_output(
         .last()
         .ok_or_else(|| String::from("cannot find result route state when route is empty"))?;
     let path_json = output_format
-        .generate_route_output(route, si.map_model.clone())
+        .generate_route_output(
+            route,
+            si.map_model.clone(),
+            si.state_model.clone(),
+            si.cost_model.clone(),
+        )
         .map_err(|e| e.to_string())?;
     let traversal_summary = si.state_model.serialize_state(&last_edge.result_state);
     let state_model = si.state_model.serialize_state_model();

--- a/rust/routee-compass/src/plugin/output/default/traversal/traversal_ops.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/traversal_ops.rs
@@ -5,15 +5,20 @@ use geojson::feature::Id;
 use geojson::{Feature, FeatureCollection};
 use routee_compass_core::algorithm::search::EdgeTraversal;
 use routee_compass_core::algorithm::search::SearchTreeBranch;
+use routee_compass_core::model::cost::CostModel;
 use routee_compass_core::model::map::MapModel;
 use routee_compass_core::model::network::vertex_id::VertexId;
+use routee_compass_core::model::state::StateModel;
 use routee_compass_core::util::geo::geo_io_utils;
+use serde_json::{json, Map};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub fn create_tree_geojson(
     tree: &HashMap<VertexId, SearchTreeBranch>,
     map_model: Arc<MapModel>,
+    state_model: Arc<StateModel>,
+    cost_model: Arc<CostModel>,
 ) -> Result<serde_json::Value, OutputPluginError> {
     let features = tree
         .values()
@@ -27,7 +32,14 @@ pub fn create_tree_geojson(
                         e
                     ))
                 })
-                .and_then(|g| create_geojson_feature(&t.edge_traversal, g));
+                .and_then(|g| {
+                    create_geojson_feature(
+                        &t.edge_traversal,
+                        g,
+                        state_model.clone(),
+                        cost_model.clone(),
+                    )
+                });
 
             row_result
         })
@@ -45,6 +57,8 @@ pub fn create_tree_geojson(
 pub fn create_route_geojson(
     route: &[EdgeTraversal],
     map_model: Arc<MapModel>,
+    state_model: Arc<StateModel>,
+    cost_model: Arc<CostModel>,
 ) -> Result<serde_json::Value, OutputPluginError> {
     let features = route
         .iter()
@@ -58,7 +72,9 @@ pub fn create_route_geojson(
                         e
                     ))
                 })
-                .and_then(|g| create_geojson_feature(t, g));
+                .and_then(|g| {
+                    create_geojson_feature(t, g, state_model.clone(), cost_model.clone())
+                });
 
             row_result
         })
@@ -76,15 +92,31 @@ pub fn create_route_geojson(
 pub fn create_geojson_feature(
     t: &EdgeTraversal,
     g: LineString<f32>,
+    state_model: Arc<StateModel>,
+    cost_model: Arc<CostModel>,
 ) -> Result<Feature, OutputPluginError> {
-    let props = match serde_json::to_value(t).map(|v| v.as_object().cloned()) {
+    let serialized_state = state_model.serialize_state(&t.result_state);
+    let serialized_cost = cost_model
+        .serialize_cost(&t.result_state, state_model.clone())
+        .map_err(|e| {
+            OutputPluginError::OutputPluginFailed(format!(
+                "failure serializing cost for geojson feature: {}",
+                e
+            ))
+        })?;
+
+    let serialized_traversal = match serde_json::to_value(t).map(|v| v.as_object().cloned()) {
+        Ok(Some(obj)) => Ok(json![obj]),
         Ok(None) => Err(OutputPluginError::InternalError(format!(
             "serialized EdgeTraversal was not a JSON object for {}",
             t
         ))),
-        Ok(Some(obj)) => Ok(obj),
         Err(err) => Err(OutputPluginError::JsonError { source: err }),
     }?;
+    let mut properties = Map::new();
+    properties.insert(String::from("traversal"), serialized_traversal);
+    properties.insert(String::from("state"), serialized_state);
+    properties.insert(String::from("cost"), serialized_cost);
 
     let id = Id::Number(serde_json::Number::from(t.edge_id.0));
     let geometry = geojson::Geometry::from(&g);
@@ -92,7 +124,7 @@ pub fn create_geojson_feature(
         bbox: None,
         geometry: Some(geometry),
         id: Some(id),
-        properties: Some(props),
+        properties: Some(properties),
         foreign_members: None,
     };
     Ok(feature)

--- a/rust/routee-compass/src/plugin/output/default/traversal/traversal_ops.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/traversal_ops.rs
@@ -63,20 +63,15 @@ pub fn create_route_geojson(
     let features = route
         .iter()
         .map(|t| {
-            let row_result = map_model
-                .get(&t.edge_id)
-                .cloned()
-                .map_err(|e| {
-                    OutputPluginError::OutputPluginFailed(format!(
-                        "failure building route geojson: {}",
-                        e
-                    ))
-                })
-                .and_then(|g| {
-                    create_geojson_feature(t, g, state_model.clone(), cost_model.clone())
-                });
-
-            row_result
+            let g = map_model.get(&t.edge_id).cloned().map_err(|e| {
+                OutputPluginError::OutputPluginFailed(format!(
+                    "failure building route geojson: {}",
+                    e
+                ))
+            })?;
+            let geojson_feature =
+                create_geojson_feature(t, g, state_model.clone(), cost_model.clone())?;
+            Ok(geojson_feature)
         })
         .collect::<Result<Vec<_>, OutputPluginError>>()?;
     // let result_json = serde_json::to_value(features)?;/

--- a/rust/routee-compass/src/plugin/output/default/traversal/traversal_output_format.rs
+++ b/rust/routee-compass/src/plugin/output/default/traversal/traversal_output_format.rs
@@ -5,7 +5,7 @@ use crate::plugin::output::OutputPluginError;
 use geo::{CoordFloat, Geometry, TryConvert};
 use routee_compass_core::{
     algorithm::search::{EdgeTraversal, SearchTreeBranch},
-    model::{map::MapModel, network::vertex_id::VertexId},
+    model::{cost::CostModel, map::MapModel, network::vertex_id::VertexId, state::StateModel},
 };
 use serde::{Deserialize, Serialize};
 use wkt::ToWkt;
@@ -30,6 +30,8 @@ impl TraversalOutputFormat {
         &self,
         route: &Vec<EdgeTraversal>,
         map_model: Arc<MapModel>,
+        state_model: Arc<StateModel>,
+        cost_model: Arc<CostModel>,
     ) -> Result<serde_json::Value, OutputPluginError> {
         match self {
             TraversalOutputFormat::Wkt => {
@@ -48,7 +50,7 @@ impl TraversalOutputFormat {
                 Ok(result)
             }
             TraversalOutputFormat::GeoJson => {
-                let result = ops::create_route_geojson(route, map_model.clone())?;
+                let result = ops::create_route_geojson(route, map_model, state_model, cost_model)?;
                 Ok(result)
             }
             TraversalOutputFormat::EdgeId => {
@@ -64,6 +66,8 @@ impl TraversalOutputFormat {
         &self,
         tree: &HashMap<VertexId, SearchTreeBranch>,
         map_model: Arc<MapModel>,
+        state_model: Arc<StateModel>,
+        cost_model: Arc<CostModel>,
     ) -> Result<serde_json::Value, OutputPluginError> {
         match self {
             TraversalOutputFormat::Wkt => {
@@ -82,7 +86,7 @@ impl TraversalOutputFormat {
                 Ok(result)
             }
             TraversalOutputFormat::GeoJson => {
-                let result = ops::create_tree_geojson(tree, map_model)?;
+                let result = ops::create_tree_geojson(tree, map_model, state_model, cost_model)?;
                 Ok(result)
             }
             TraversalOutputFormat::EdgeId => {


### PR DESCRIPTION
added some improvements here to route + tree serialization so they now serialize using the state model and cost model to add those sections to each link in a route or tree, like this:

```json
        "properties": {
          "traversal": {
            "edge_id": 7563,
            "access_cost": 0.008333333384705321,
            "traversal_cost": 0.05487432604079934,
            "result_state": [
              0.2613151025581488,
              0.10974865208159863,
              0.6234684593965638,
              0.06473915841810438,
              0.01360034135298995,
              99.89210140263648,
              48.3,
              0.0,
              0.05489683033149421
            ]
          },
          "state": {
            "trip_time": 0.6234684593965638,
            "trip_energy": 0.06473915841810438,
            "trip_soc": 99.89210140263648,
            "trip_distance": 0.2613151025581488
          },
          "cost": {
            "total_cost": 0.4906643208840419,
            "trip_energy": 0.007768699010172525,
            "trip_distance": 0.17116139217558748,
            "trip_time": 0.3117342296982819
          }
```

this allows me to develop plots that include tree and route.