### PR TITLE
open constructors for TimeTraversalModel

### DIFF
--- a/rust/routee-compass-core/src/model/traversal/default/time/mod.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/time/mod.rs
@@ -5,5 +5,6 @@ mod time_configuration;
 mod time_traversal_builder;
 mod time_traversal_model;
 
+pub use time_configuration::TimeConfiguration;
 pub use time_traversal_builder::TimeTraversalBuilder;
 pub use time_traversal_model::TimeTraversalModel;

--- a/rust/routee-compass-core/src/model/traversal/default/time/time_traversal_builder.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/time/time_traversal_builder.rs
@@ -16,7 +16,7 @@ impl TraversalModelBuilder for TimeTraversalBuilder {
                     e
                 ))
             })?;
-        let service = Arc::new(TimeTraversalModel::new(&config));
+        let service = Arc::new(TimeTraversalModel::from(&config));
         Ok(service)
     }
 }

--- a/rust/routee-compass-core/src/model/traversal/default/time/time_traversal_model.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/time/time_traversal_model.rs
@@ -14,11 +14,19 @@ use std::{borrow::Cow, sync::Arc};
 
 #[derive(Clone, Debug)]
 pub struct TimeTraversalModel {
-    time_unit: TimeUnit,
+    pub time_unit: TimeUnit,
 }
 
 impl TimeTraversalModel {
-    pub fn new(config: &TimeConfiguration) -> TimeTraversalModel {
+    pub fn new(time_unit: &TimeUnit) -> TimeTraversalModel {
+        TimeTraversalModel {
+            time_unit: *time_unit,
+        }
+    }
+}
+
+impl From<&TimeConfiguration> for TimeTraversalModel {
+    fn from(config: &TimeConfiguration) -> Self {
         TimeTraversalModel {
             time_unit: config.time_unit,
         }


### PR DESCRIPTION
i discovered that the TimeTraveresalModel cannot be constructed outside of using a `TimeTraversalBuilder` build method, and this PR simply
  - gives it a new method to build from a TimeUnit
  - gives it a From method to build from a TimeConfiguration
  - makes TimeConfiguration public
  - makes the TimeTraversalModel::time_unit struct public