### PR TITLE
Rjf/vehicle params bug

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -54,7 +54,7 @@ pub fn run_vertex_oriented(
         si.termination_model
             .test(&start_time, solution.len(), iterations)?;
 
-        let current_vertex_id = match advance_search(&mut costs, source, target)? {
+        let current_vertex_id = match advance_search(&mut costs, source, target, &solution)? {
             None => break,
             Some(id) => id,
         };
@@ -258,7 +258,7 @@ pub fn run_edge_oriented(
                 } = run_vertex_oriented(e1_dst, Some(e2_src), direction, weight_factor, si)?;
 
                 if tree.is_empty() {
-                    return Err(SearchError::NoPathExistsBetweenVertices(e1_dst, e2_src));
+                    return Err(SearchError::NoPathExistsBetweenVertices(e1_dst, e2_src, 0));
                 }
 
                 let final_state = &tree
@@ -321,11 +321,13 @@ fn advance_search(
     cost: &mut InternalPriorityQueue<VertexId, ReverseCost>,
     source: VertexId,
     target: Option<VertexId>,
+    solution: &HashMap<VertexId, SearchTreeBranch>,
 ) -> Result<Option<VertexId>, SearchError> {
     match (cost.pop(), target) {
         (None, Some(target_vertex_id)) => Err(SearchError::NoPathExistsBetweenVertices(
             source,
             target_vertex_id,
+            solution.len(),
         )),
         (None, None) => Ok(None),
         (Some((current_v, _)), Some(target_v)) if current_v == target_v => Ok(None),

--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -257,7 +257,7 @@ pub fn run_edge_oriented(
                 } = alg.run_vertex_oriented(e1_dst, Some(e2_src), query, direction, si)?;
 
                 if trees.is_empty() {
-                    return Err(SearchError::NoPathExistsBetweenVertices(e1_dst, e2_src));
+                    return Err(SearchError::NoPathExistsBetweenVertices(e1_dst, e2_src, 0));
                 }
 
                 // it is possible that the search already found these vertices. one major edge

--- a/rust/routee-compass-core/src/algorithm/search/search_error.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_error.rs
@@ -49,10 +49,10 @@ pub enum SearchError {
     },
     #[error("query terminated due to {0}")]
     QueryTerminated(String),
-    #[error("no path exists between vertices {0} and {1}")]
-    NoPathExistsBetweenVertices(VertexId, VertexId),
-    #[error("no path exists between edges {0} and {1}")]
-    NoPathExistsBetweenEdges(EdgeId, EdgeId),
+    #[error("no path exists between vertices {0} and {1} after searching {2} edges")]
+    NoPathExistsBetweenVertices(VertexId, VertexId, usize),
+    #[error("no path exists between edges {0} and {1} after searching {2} edges")]
+    NoPathExistsBetweenEdges(EdgeId, EdgeId, usize),
     #[error("error accessing shared read-only dataset: {0}")]
     ReadOnlyPoisonError(String),
     #[error("internal error due to search logic: {0}")]

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/comparison_operation.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/comparison_operation.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use super::VehicleParameter;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub enum ComparisonOperation {

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/comparison_operation.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/comparison_operation.rs
@@ -30,13 +30,18 @@ impl std::fmt::Display for ComparisonOperation {
 }
 
 impl ComparisonOperation {
-    pub fn compare_parameters(&self, a: &VehicleParameter, b: &VehicleParameter) -> bool {
-        match (self, a, b) {
-            (ComparisonOperation::LessThan, a, b) => a < b,
-            (ComparisonOperation::GreaterThan, a, b) => a > b,
-            (ComparisonOperation::Equal, a, b) => a == b,
-            (ComparisonOperation::LessThanOrEqual, a, b) => a <= b,
-            (ComparisonOperation::GreaterThanOrEqual, a, b) => a >= b,
+    /// leverage the PartialCmp implementation for VehicleParameter to test if a particular comparison is true.
+    pub fn compare_parameters(
+        &self,
+        query: &VehicleParameter,
+        restriction: &VehicleParameter,
+    ) -> bool {
+        match (self, query, restriction) {
+            (ComparisonOperation::LessThan, q, r) => q < r,
+            (ComparisonOperation::GreaterThan, q, r) => q > r,
+            (ComparisonOperation::Equal, q, r) => q == r,
+            (ComparisonOperation::LessThanOrEqual, q, r) => q <= r,
+            (ComparisonOperation::GreaterThanOrEqual, q, r) => q >= r,
         }
     }
 }

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/mod.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/mod.rs
@@ -1,5 +1,6 @@
 mod comparison_operation;
 mod vehicle_parameter;
+mod vehicle_parameter_type;
 mod vehicle_restriction;
 mod vehicle_restriction_builder;
 mod vehicle_restriction_model;
@@ -8,6 +9,7 @@ mod vehicle_restriction_service;
 
 pub use comparison_operation::ComparisonOperation;
 pub use vehicle_parameter::VehicleParameter;
+pub use vehicle_parameter_type::VehicleParameterType;
 pub use vehicle_restriction::VehicleRestriction;
 pub use vehicle_restriction_builder::VehicleRestrictionBuilder;
 pub use vehicle_restriction_model::VehicleRestrictionFrontierModel;

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
@@ -52,92 +52,47 @@ impl PartialOrd for VehicleParameter {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match (self, other) {
             (
-                VehicleParameter::Height {
-                    value: a,
-                    unit: a_unit,
-                },
-                VehicleParameter::Height {
-                    value: b,
-                    unit: b_unit,
-                },
-            ) => {
-                let mut b_convert = Cow::Borrowed(b);
-                b_unit.convert(&mut b_convert, a_unit).ok()?;
-                a.partial_cmp(b_convert.as_ref())
-            }
+                VehicleParameter::Height { value: a, unit: au },
+                VehicleParameter::Height { value: b, unit: bu },
+            ) => cmp_params(a, au, b, bu),
             (
-                VehicleParameter::Width {
-                    value: a,
-                    unit: a_unit,
-                },
-                VehicleParameter::Width {
-                    value: b,
-                    unit: b_unit,
-                },
-            ) => {
-                let mut b_convert = Cow::Borrowed(b);
-                b_unit.convert(&mut b_convert, a_unit).ok()?;
-                a.partial_cmp(b_convert.as_ref())
-            }
+                VehicleParameter::Width { value: a, unit: au },
+                VehicleParameter::Width { value: b, unit: bu },
+            ) => cmp_params(a, au, b, bu),
             (
-                VehicleParameter::TotalLength {
-                    value: a,
-                    unit: a_unit,
-                },
-                VehicleParameter::TotalLength {
-                    value: b,
-                    unit: b_unit,
-                },
-            ) => {
-                let mut b_convert = Cow::Borrowed(b);
-                b_unit.convert(&mut b_convert, a_unit).ok()?;
-                a.partial_cmp(b_convert.as_ref())
-            }
+                VehicleParameter::TotalLength { value: a, unit: au },
+                VehicleParameter::TotalLength { value: b, unit: bu },
+            ) => cmp_params(a, au, b, bu),
             (
-                VehicleParameter::TrailerLength {
-                    value: a,
-                    unit: a_unit,
-                },
-                VehicleParameter::TrailerLength {
-                    value: b,
-                    unit: b_unit,
-                },
-            ) => {
-                let mut b_convert = Cow::Borrowed(b);
-                b_unit.convert(&mut b_convert, a_unit).ok()?;
-                a.partial_cmp(b_convert.as_ref())
-            }
+                VehicleParameter::TrailerLength { value: a, unit: au },
+                VehicleParameter::TrailerLength { value: b, unit: bu },
+            ) => cmp_params(a, au, b, bu),
             (
-                VehicleParameter::TotalWeight {
-                    value: a,
-                    unit: a_unit,
-                },
-                VehicleParameter::TotalWeight {
-                    value: b,
-                    unit: b_unit,
-                },
-            ) => {
-                let mut b_convert = Cow::Borrowed(b);
-                b_unit.convert(&mut b_convert, a_unit).ok()?;
-                a.partial_cmp(b_convert.as_ref())
-            }
+                VehicleParameter::TotalWeight { value: a, unit: au },
+                VehicleParameter::TotalWeight { value: b, unit: bu },
+            ) => cmp_params(a, au, b, bu),
             (
-                VehicleParameter::WeightPerAxle {
-                    value: a,
-                    unit: a_unit,
-                },
-                VehicleParameter::WeightPerAxle {
-                    value: b,
-                    unit: b_unit,
-                },
-            ) => {
-                let mut b_convert = Cow::Borrowed(b);
-                b_unit.convert(&mut b_convert, a_unit).ok()?;
-                a.partial_cmp(b_convert.as_ref())
+                VehicleParameter::WeightPerAxle { value: a, unit: au },
+                VehicleParameter::WeightPerAxle { value: b, unit: bu },
+            ) => cmp_params(a, au, b, bu),
+            _ => {
+                // invalid comparison when enum variant of self != variant of other
+                None
             }
-            _ => None,
         }
     }
+}
+
+/// compares two matching parameter variants, first ensuring their unit types match, then
+/// using the quantity's comparison operator.
+fn cmp_params<Q, U>(a: &Q, au: &U, b: &Q, bu: &U) -> Option<std::cmp::Ordering>
+where
+    Q: Clone + PartialOrd + ?Sized,
+    U: Convert<Q>,
+{
+    let mut b_cmp = Cow::Borrowed(b);
+    bu.convert(&mut b_cmp, au).ok()?;
+    a.partial_cmp(b_cmp.as_ref())
 }
 
 #[cfg(test)]

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
@@ -1,9 +1,8 @@
+use super::VehicleParameterType;
 use routee_compass_core::model::unit::Convert;
 use routee_compass_core::model::unit::{Distance, DistanceUnit, Weight, WeightUnit};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-
-use crate::app::compass::model::frontier_model::vehicle_restrictions::vehicle_parameter_type::VehicleParameterType;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
@@ -89,7 +89,7 @@ impl PartialOrd for VehicleParameter {
 /// using the quantity's comparison operator.
 fn cmp_params<Q, U>(a: &Q, au: &U, b: &Q, bu: &U) -> Option<std::cmp::Ordering>
 where
-    Q: Clone + PartialOrd + ?Sized,
+    Q: Clone + PartialOrd,
     U: Convert<Q>,
 {
     let mut b_cmp = Cow::Borrowed(b);

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter.rs
@@ -3,6 +3,8 @@ use routee_compass_core::model::unit::{Distance, DistanceUnit, Weight, WeightUni
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
+use crate::app::compass::model::frontier_model::vehicle_restrictions::vehicle_parameter_type::VehicleParameterType;
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum VehicleParameter {
@@ -15,14 +17,15 @@ pub enum VehicleParameter {
 }
 
 impl VehicleParameter {
-    pub fn name(&self) -> String {
+    pub fn vehicle_parameter_type(&self) -> &VehicleParameterType {
+        use VehicleParameterType as VPT;
         match self {
-            VehicleParameter::Height { .. } => "height".to_string(),
-            VehicleParameter::Width { .. } => "width".to_string(),
-            VehicleParameter::TotalLength { .. } => "total_length".to_string(),
-            VehicleParameter::TrailerLength { .. } => "trailer_length".to_string(),
-            VehicleParameter::TotalWeight { .. } => "total_weight".to_string(),
-            VehicleParameter::WeightPerAxle { .. } => "weight_per_axle".to_string(),
+            VehicleParameter::Height { .. } => &VPT::Height,
+            VehicleParameter::Width { .. } => &VPT::Width,
+            VehicleParameter::TotalLength { .. } => &VPT::TotalLength,
+            VehicleParameter::TrailerLength { .. } => &VPT::TrailerLength,
+            VehicleParameter::TotalWeight { .. } => &VPT::TotalWeight,
+            VehicleParameter::WeightPerAxle { .. } => &VPT::WeightPerAxle,
         }
     }
 }

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_type.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_type.rs
@@ -1,6 +1,5 @@
-use std::str::FromStr;
-
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_type.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_type.rs
@@ -1,0 +1,44 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum VehicleParameterType {
+    Height,
+    Width,
+    TotalLength,
+    TrailerLength,
+    TotalWeight,
+    WeightPerAxle,
+}
+
+impl std::fmt::Display for VehicleParameterType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Height => "height".to_string(),
+            Self::Width => "width".to_string(),
+            Self::TotalLength => "total_length".to_string(),
+            Self::TrailerLength => "trailer_length".to_string(),
+            Self::TotalWeight => "total_weight".to_string(),
+            Self::WeightPerAxle => "weight_per_axle".to_string(),
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl FromStr for VehicleParameterType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "height" => Ok(Self::Height),
+            "width" => Ok(Self::Width),
+            "total_length" => Ok(Self::TotalLength),
+            "trailer_length" => Ok(Self::TrailerLength),
+            "total_weight" => Ok(Self::TotalWeight),
+            "weight_per_axle" => Ok(Self::WeightPerAxle),
+            _ => Err(format!("unknown VehicleParameterType {}", s)),
+        }
+    }
+}

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_type.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_type.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum VehicleParameterType {
     Height,
     Width,

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction.rs
@@ -1,13 +1,10 @@
-use std::{fmt::Display, str::FromStr};
-
-use crate::app::compass::model::frontier_model::vehicle_restrictions::vehicle_parameter_type::VehicleParameterType;
-
-use super::{ComparisonOperation, RestrictionRow, VehicleParameter};
+use super::{ComparisonOperation, RestrictionRow, VehicleParameter, VehicleParameterType};
 use routee_compass_core::model::{
     frontier::FrontierModelError,
     unit::{Distance, DistanceUnit, Weight, WeightUnit},
 };
 use serde::{Deserialize, Serialize};
+use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VehicleRestriction {

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 use super::{ComparisonOperation, RestrictionRow, VehicleParameter};
 use routee_compass_core::model::{
@@ -15,11 +15,11 @@ pub struct VehicleRestriction {
 
 impl VehicleRestriction {
     pub fn new(
-        vehicle_parameter: VehicleParameter,
+        restriction_parameter: VehicleParameter,
         comparison_operation: ComparisonOperation,
     ) -> Self {
         VehicleRestriction {
-            restriction_parameter: vehicle_parameter,
+            restriction_parameter,
             comparison_operation,
         }
     }
@@ -28,6 +28,8 @@ impl VehicleRestriction {
         self.restriction_parameter.name()
     }
 
+    /// compares this restriction against some query-time vehicle parameter using
+    /// this comparison operator
     pub fn validate_parameters(&self, query_parameter: &VehicleParameter) -> bool {
         self.comparison_operation
             .compare_parameters(query_parameter, &self.restriction_parameter)
@@ -103,5 +105,16 @@ impl TryFrom<&RestrictionRow> for VehicleRestriction {
             restriction_parameter: vehicle_parameter,
             comparison_operation,
         })
+    }
+}
+
+impl Display for VehicleRestriction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "query parameter is {} link restrictions matching {}",
+            self.comparison_operation,
+            self.restriction_parameter.name()
+        )
     }
 }

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Display, str::FromStr};
 
+use crate::app::compass::model::frontier_model::vehicle_restrictions::vehicle_parameter_type::VehicleParameterType;
+
 use super::{ComparisonOperation, RestrictionRow, VehicleParameter};
 use routee_compass_core::model::{
     frontier::FrontierModelError,
@@ -24,8 +26,8 @@ impl VehicleRestriction {
         }
     }
 
-    pub fn name(&self) -> String {
-        self.restriction_parameter.name()
+    pub fn vehicle_parameter_type(&self) -> &VehicleParameterType {
+        self.restriction_parameter.vehicle_parameter_type()
     }
 
     /// compares this restriction against some query-time vehicle parameter using
@@ -114,7 +116,7 @@ impl Display for VehicleRestriction {
             f,
             "query parameter is {} link restrictions matching {}",
             self.comparison_operation,
-            self.restriction_parameter.name()
+            self.restriction_parameter.vehicle_parameter_type()
         )
     }
 }

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_builder.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_builder.rs
@@ -1,3 +1,5 @@
+use crate::app::compass::model::frontier_model::vehicle_restrictions::vehicle_parameter_type::VehicleParameterType;
+
 use super::VehicleRestriction;
 use super::{
     vehicle_restriction_row::RestrictionRow,
@@ -48,8 +50,10 @@ impl FrontierModelBuilder for VehicleRestrictionBuilder {
 
 pub fn vehicle_restriction_lookup_from_file(
     vehicle_restriction_input_file: &PathBuf,
-) -> Result<HashMap<EdgeId, CompactOrderedHashMap<String, VehicleRestriction>>, FrontierModelError>
-{
+) -> Result<
+    HashMap<EdgeId, CompactOrderedHashMap<VehicleParameterType, VehicleRestriction>>,
+    FrontierModelError,
+> {
     let rows: Vec<RestrictionRow> = read_utils::from_csv(
         &vehicle_restriction_input_file,
         true,
@@ -66,18 +70,18 @@ pub fn vehicle_restriction_lookup_from_file(
 
     let mut vehicle_restriction_lookup: HashMap<
         EdgeId,
-        CompactOrderedHashMap<String, VehicleRestriction>,
+        CompactOrderedHashMap<VehicleParameterType, VehicleRestriction>,
     > = HashMap::new();
     for row in rows {
         let restriction = VehicleRestriction::try_from(&row)?;
         match vehicle_restriction_lookup.get_mut(&row.edge_id) {
             None => {
                 let mut restrictions = CompactOrderedHashMap::empty();
-                restrictions.insert(restriction.name(), restriction);
+                restrictions.insert(restriction.vehicle_parameter_type().clone(), restriction);
                 vehicle_restriction_lookup.insert(row.edge_id, restrictions);
             }
             Some(restrictions) => {
-                restrictions.insert(restriction.name(), restriction);
+                restrictions.insert(restriction.vehicle_parameter_type().clone(), restriction);
             }
         }
     }

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_builder.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_builder.rs
@@ -1,9 +1,5 @@
-use crate::app::compass::model::frontier_model::vehicle_restrictions::vehicle_parameter_type::VehicleParameterType;
-
-use super::VehicleRestriction;
 use super::{
-    vehicle_restriction_row::RestrictionRow,
-    vehicle_restriction_service::VehicleRestrictionFrontierService,
+    RestrictionRow, VehicleParameterType, VehicleRestriction, VehicleRestrictionFrontierService,
 };
 use kdam::Bar;
 use routee_compass_core::config::{CompassConfigurationField, ConfigJsonExtensions};

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_model.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_model.rs
@@ -35,10 +35,12 @@ fn validate_edge(
     model: &VehicleRestrictionFrontierModel,
     edge: &Edge,
 ) -> Result<bool, FrontierModelError> {
-    // check if there are any restrictions for this edge
-    let restrictions = match model.service.vehicle_restriction_lookup.get(&edge.edge_id) {
-        None => return Ok(true),
-        Some(vehicle_restrictions) => vehicle_restrictions,
+    // if there are no parameters or restrictions, the edge is valid
+    let restriction_map_option = model.service.vehicle_restriction_lookup.get(&edge.edge_id);
+    let restrictions = match (restriction_map_option, model.vehicle_parameters.as_slice()) {
+        (None, _) => return Ok(true),
+        (_, []) => return Ok(true),
+        (Some(vehicle_restrictions), _) => vehicle_restrictions,
     };
 
     // for each parameter of this frontier model, test if the parameter is valid for any matching restriction

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_model.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_model.rs
@@ -45,7 +45,7 @@ fn validate_edge(
     for p in model.vehicle_parameters.iter() {
         let p_type = p.vehicle_parameter_type();
         match restrictions.get(p_type) {
-            Some(r) if !r.validate_parameters(&p) => {
+            Some(r) if !r.validate_parameters(p) => {
                 return Ok(false);
             }
             _ => {}

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_model.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_model.rs
@@ -38,8 +38,8 @@ fn validate_edge(
     // if there are no parameters or restrictions, the edge is valid
     let restriction_map_option = model.service.vehicle_restriction_lookup.get(&edge.edge_id);
     let restrictions = match (restriction_map_option, model.vehicle_parameters.as_slice()) {
-        (None, _) => return Ok(true),
-        (_, []) => return Ok(true),
+        (None, _) => return Ok(true), // no restrictions on edge
+        (_, []) => return Ok(true),   // no vehicle parameters on query
         (Some(vehicle_restrictions), _) => vehicle_restrictions,
     };
 
@@ -47,7 +47,7 @@ fn validate_edge(
     for p in model.vehicle_parameters.iter() {
         let p_type = p.vehicle_parameter_type();
         match restrictions.get(p_type) {
-            Some(r) if !r.validate_parameters(p) => {
+            Some(r) if !r.within_restriction(p) => {
                 return Ok(false);
             }
             _ => {}

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_row.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_row.rs
@@ -1,11 +1,11 @@
-use super::ComparisonOperation;
+use super::{ComparisonOperation, VehicleParameterType};
 use routee_compass_core::model::network::edge_id::EdgeId;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RestrictionRow {
     pub edge_id: EdgeId,
-    pub name: String,
+    pub name: VehicleParameterType,
     pub value: f64,
     pub operation: ComparisonOperation,
     pub unit: String,

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_service.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_restriction_service.rs
@@ -1,6 +1,6 @@
 use super::{
-    vehicle_parameter::VehicleParameter,
-    vehicle_restriction_model::VehicleRestrictionFrontierModel, VehicleRestriction,
+    vehicle_restriction_model::VehicleRestrictionFrontierModel, VehicleParameter,
+    VehicleParameterType, VehicleRestriction,
 };
 use routee_compass_core::{
     model::{
@@ -15,7 +15,7 @@ use std::{collections::HashMap, sync::Arc};
 #[derive(Clone)]
 pub struct VehicleRestrictionFrontierService {
     pub vehicle_restriction_lookup:
-        Arc<HashMap<EdgeId, CompactOrderedHashMap<String, VehicleRestriction>>>,
+        Arc<HashMap<EdgeId, CompactOrderedHashMap<VehicleParameterType, VehicleRestriction>>>,
 }
 
 impl FrontierModelService for VehicleRestrictionFrontierService {


### PR DESCRIPTION
here are some proposed changes made while exploring a possible logic error resulting in the bug described in #331. these are code style changes for the most part in an attempt to weed out any buggy logic:

  - use a common function within `VehicleParameter::PartialOrd` for comparison
  - use an enum for `VehicleParameterType`s in place of String keys to improve memory performance of the `FrontierModelService`'s stored HashMaps
  - replace `String` with `VehicleParameterType` on `VehicleRestrictionRow` to remove a string match on the `VehicleRestriction::TryFrom` implementation
  - explicit fast returns in `FrontierModel` implementation when no vehicle parameters are provided
  - rewrite `FrontierModel` with simpler validation logic using for loop
  - check comparison logic, test cases

since i didn't find anything that could explain my bug, i'm going to go back and test for the bug again with this branch to see if it magically disappeared or if it was mis-reported in the first place.