### PR TITLE
fix the add grade step for cases with only one elevation tile

### DIFF
--- a/docs/examples/01_open_street_maps_example.py
+++ b/docs/examples/01_open_street_maps_example.py
@@ -312,7 +312,7 @@ Here's a list of all the different sections that get returned:
 
 def print_keys(d, indent=0):
     for k in sorted(d.keys()):
-        print(f"{' '*indent} - {k}")
+        print(f"{' ' * indent} - {k}")
         if isinstance(d[k], dict):
             print_keys(d[k], indent + 2)
 

--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -100,7 +100,8 @@ def _download_tile(
         except requests.exceptions.HTTPError as e:
             raise ValueError(
                 f"Failed to download USGS tile {tile} from {url}. "
-                "If this road network is outside of the US, consider re-running with `grade=False`."
+                "If this road network is outside of the US, consider re-running without "
+                "GeneratePipelinePhase.GRADE in the `phases` argument."
             ) from e
 
         destination.parent.mkdir(exist_ok=True)
@@ -179,7 +180,7 @@ def add_grade_to_graph(
         if len(files) == 0:
             raise ValueError(
                 "No USGS tiles were downloaded. "
-                "If this road network is outside of the US, consider re-running with `grade=False`."
+                "If this road network is outside of the US, consider re-running without `grade` in your ."
             )
         elif len(files) == 1:
             filepath: Union[Path, list[Path]] = files[

--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -174,9 +174,21 @@ def add_grade_to_graph(
             downloaded_file = _download_tile(
                 tile, output_dir=output_dir, resolution=resolution
             )
-            files.append(str(downloaded_file))
+            files.append(downloaded_file)
 
-        g = ox.add_node_elevations_raster(g, files)
+        if len(files) == 0:
+            raise ValueError(
+                "No USGS tiles were downloaded. "
+                "If this road network is outside of the US, consider re-running with `grade=False`."
+            )
+        elif len(files) == 1:
+            filepath: Union[Path, list[Path]] = files[
+                0
+            ]  # if only one file, pass it directly
+        else:
+            filepath = files
+
+        g = ox.add_node_elevations_raster(g, filepath)
     else:
         g = ox.add_node_elevations_google(g, api_key=api_key)
     g = ox.add_edge_grades(g)

--- a/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
@@ -1099,9 +1099,9 @@ interpolate.underlying_model_type = "smartcore"
 interpolate.feature_bounds.edge_speed.lower_bound = 0
 interpolate.feature_bounds.edge_speed.upper_bound = 100
 interpolate.feature_bounds.edge_speed.num_bins = 101
-interpolate.feature_bounds.edgeGrade.lower_bound = -20
-interpolate.feature_bounds.edgeGrade.upper_bound = 20
-interpolate.feature_bounds.edgeGrade.num_bins = 41
+interpolate.feature_bounds.edge_grade.lower_bound = -20
+interpolate.feature_bounds.edge_grade.upper_bound = 20
+interpolate.feature_bounds.edge_grade.num_bins = 41
 
 [[traversal.models.vehicles]]
 name = "2022_Tesla_Model_Y_RWD"
@@ -1127,9 +1127,9 @@ interpolate.underlying_model_type = "smartcore"
 interpolate.feature_bounds.edge_speed.lower_bound = 0
 interpolate.feature_bounds.edge_speed.upper_bound = 100
 interpolate.feature_bounds.edge_speed.num_bins = 101
-interpolate.feature_bounds.edgeGrade.lower_bound = -20
-interpolate.feature_bounds.edgeGrade.upper_bound = 20
-interpolate.feature_bounds.edgeGrade.num_bins = 41
+interpolate.feature_bounds.edge_grade.lower_bound = -20
+interpolate.feature_bounds.edge_grade.upper_bound = 20
+interpolate.feature_bounds.edge_grade.num_bins = 41
 
 [[traversal.models.vehicles]]
 name = "2022_Toyota_Yaris_Hybrid_Mid"

--- a/rust/routee-compass-powertrain/src/model/prediction/interpolation/interpolation_model.rs
+++ b/rust/routee-compass-powertrain/src/model/prediction/interpolation/interpolation_model.rs
@@ -57,8 +57,8 @@ impl InterpolationModel {
         for (feature_name, _input_feature) in input_features.iter() {
             let feature_bounds = feature_bounds.get(feature_name).ok_or_else(|| {
                 TraversalModelError::BuildError(format!(
-                    "Missing feature bounds for {}",
-                    feature_name
+                    "Missing feature bounds for {}, got: {:?}",
+                    feature_name, feature_bounds
                 ))
             })?;
 


### PR DESCRIPTION
There are cases when we need to download just one raster tile for a location and if we pass a list of length one to osmnx, this breaks when it tries to create a virtual raster file. To fix this, we just pass the filepath directly if there is only one tile to use.

Also fixes some mistakes in the default osm config file with all vehicles. 