### PR TITLE
UnitCodecType enum as clone/debug/eq/hash

### DIFF
--- a/rust/routee-compass-core/src/model/state/unit_codec_type.rs
+++ b/rust/routee-compass-core/src/model/state/unit_codec_type.rs
@@ -1,8 +1,7 @@
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum UnitCodecType {
     FloatingPoint,


### PR DESCRIPTION
Super small change. UnitCodecType is _not_ Clone, Debug, PartialEq, Eq, Hash, and this makes it unusable downstream in BAMBAM as a HashMap key and field of a deserializable/cloneable enum variant. 