### PR TITLE
minor fixes to elevation traversal model

### DIFF
--- a/python/nrel/routee/compass/resources/downtown_denver_example/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/downtown_denver_example/osm_default_energy.toml
@@ -63,9 +63,13 @@ type = "time"
 time_unit = "minutes"
 
 [[traversal.models]]
+type = "elevation"
+distance_unit = "feet"
+
+[[traversal.models]]
 type = "grade"
 grade_unit = "decimal"
-grade_table_input_file = "edges-grade-enumerated.txt.gz"
+grade_input_file = "edges-grade-enumerated.txt.gz"
 [[traversal.models]]
 type = "energy"
 [[traversal.models.vehicles]]

--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -54,6 +54,10 @@ type = "distance"
 distance_unit = "miles"
 
 [[traversal.models]]
+type = "elevation"
+distance_unit = "feet"
+
+[[traversal.models]]
 type = "speed"
 speed_table_input_file = "edges-posted-speed-enumerated.txt.gz"
 speed_unit = "kph"
@@ -65,7 +69,7 @@ time_unit = "minutes"
 [[traversal.models]]
 type = "grade"
 grade_unit = "decimal"
-grade_table_input_file = "edges-grade-enumerated.txt.gz"
+grade_input_file = "edges-grade-enumerated.txt.gz"
 [[traversal.models]]
 type = "energy"
 [[traversal.models.vehicles]]

--- a/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
@@ -83,7 +83,7 @@ time_unit = "minutes"
 [[traversal.models]]
 type = "grade"
 grade_unit = "decimal"
-grade_table_input_file = "edges-grade-enumerated.txt.gz"
+grade_input_file = "edges-grade-enumerated.txt.gz"
 
 [[traversal.models]]
 type = "energy"

--- a/rust/routee-compass-core/src/model/traversal/default/elevation/elevation_traversal_model.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/elevation/elevation_traversal_model.rs
@@ -4,7 +4,7 @@ use crate::model::{
     network::{Edge, Vertex},
     state::{InputFeature, OutputFeature, StateModel, StateVariable},
     traversal::{default::fieldname, TraversalModel, TraversalModelError, TraversalModelService},
-    unit::{Distance, DistanceUnit, Grade, GradeUnit},
+    unit::{Distance, DistanceUnit},
 };
 
 use super::{ElevationChange, ElevationConfiguration};
@@ -57,9 +57,9 @@ impl TraversalModel for ElevationTraversalModel {
             ),
             (
                 String::from(fieldname::TRIP_ELEVATION_LOSS),
-                OutputFeature::Grade {
-                    grade_unit: GradeUnit::Decimal,
-                    initial: Grade::ZERO,
+                OutputFeature::Distance {
+                    distance_unit: self.distance_unit,
+                    initial: Distance::ZERO,
                     accumulator: true,
                 },
             ),

--- a/rust/routee-compass-core/src/model/traversal/default/grade/grade_configuration.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/grade/grade_configuration.rs
@@ -5,10 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GradeConfiguration {
     /// file with dense mapping from edge id to grade value
-    /// note: this is optional as a stop-gap to allow for loading energy models that do not require grade.
-    /// this is because we currently cannot define input features that are _optional_, and so
-    /// if a dummy grade model were not provided, energy models would fail to build.
-    pub grade_input_file: Option<String>,
+    pub grade_input_file: String,
     /// type of grade values in file
     pub grade_unit: GradeUnit,
 }

--- a/rust/routee-compass-core/src/model/traversal/default/grade/grade_traversal_engine.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/grade/grade_traversal_engine.rs
@@ -19,34 +19,26 @@ impl GradeTraversalEngine {
     /// builds a grade lookup table from the input file, or, if not provided, stubs a
     /// grade engine that always returns 0.
     pub fn new(config: &GradeConfiguration) -> Result<GradeTraversalEngine, TraversalModelError> {
-        match &config.grade_input_file {
-            None => Ok(Self {
-                grade_by_edge_id: None,
-                grade_unit: config.grade_unit,
-            }),
-            Some(grade_input_file) => {
-                let grade_table: Box<[Grade]> = read_utils::read_raw_file(
-                    grade_input_file,
-                    read_decoders::default,
-                    Some(Bar::builder().desc("link grades")),
-                    None,
-                )
-                .map_err(|e| {
-                    TraversalModelError::BuildError(format!(
-                        "failure reading grade table {} due to {}",
-                        grade_input_file.clone(),
-                        e
-                    ))
-                })?;
+        let grade_table: Box<[Grade]> = read_utils::read_raw_file(
+            config.grade_input_file.clone(),
+            read_decoders::default,
+            Some(Bar::builder().desc("link grades")),
+            None,
+        )
+        .map_err(|e| {
+            TraversalModelError::BuildError(format!(
+                "failure reading grade table {} due to {}",
+                config.grade_input_file.clone(),
+                e
+            ))
+        })?;
 
-                let engine = GradeTraversalEngine {
-                    grade_by_edge_id: Some(Arc::new(grade_table)),
-                    grade_unit: config.grade_unit,
-                };
+        let engine = GradeTraversalEngine {
+            grade_by_edge_id: Some(Arc::new(grade_table)),
+            grade_unit: config.grade_unit,
+        };
 
-                Ok(engine)
-            }
-        }
+        Ok(engine)
     }
 
     pub fn get_grade(&self, edge_id: EdgeId) -> Result<Grade, TraversalModelError> {


### PR DESCRIPTION
When testing the elevation traversal model I was finding that the elevation gain and loss was always zero. This applies some minor fixes to get the trip elevation working:

 - update the grade input file key (it was just giving zero grades since the input path wasn't found)
 - update trip elevation loss to be distance base rather than grade based

I also made the grade model input required since it would prevent this silent error in the future. 

Lastly, this sets up our default energy configs to use the elevation traversal model