### PR TITLE
tag "type" for deserialization

### DIFF
--- a/rust/routee-compass-core/src/model/state/custom_feature_format.rs
+++ b/rust/routee-compass-core/src/model/state/custom_feature_format.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// for example, if the user selects esoteric integer values that are not well-represented
 /// in floating point, then an encode -> decode roundtrip may not be idempotent.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum CustomFeatureFormat {
     FloatingPoint { initial: OrderedFloat<f64> },
     SignedInteger { initial: i64 },


### PR DESCRIPTION
another small edit allowing a CustomFeatureFormat variant to be selected via a "type" tag, allowing:
```toml
format = { type = "floating_point", initial = 0.0 }
```