### PR TITLE
Update osm_default_energy_all_vehicles.toml

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
@@ -86,6 +86,10 @@ grade_unit = "decimal"
 grade_input_file = "edges-grade-enumerated.txt.gz"
 
 [[traversal.models]]
+type = "elevation"
+distance_unit = "feet"
+
+[[traversal.models]]
 type = "energy"
 [[traversal.models.vehicles]]
 name = "2010_Mazda_3_i-Stop"


### PR DESCRIPTION
A teeny tiny change to add elevation traversal model as default for osm default config with all vehicles.