### PR TITLE
Benchmark CI

### DIFF
--- a/.github/workflows/rust-bench.yaml
+++ b/.github/workflows/rust-bench.yaml
@@ -1,0 +1,39 @@
+name: Rust Benchmark
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+        - "docs/**"
+        - "**.md"
+
+permissions:
+    contents: write
+    deployments: write
+
+jobs:
+  benchmark:
+    name: Rust Performance Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-criterion
+        run: cargo install cargo-criterion
+
+      - name: Run benchmark with criterion
+        working-directory: ./rust
+        run: cargo criterion --output-format bencher --benches 2>&1 | tee output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Rust Benchmark
+          tool: 'cargo'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@nreinicke @robfitzgerald'

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -48,3 +48,11 @@ ordered-float = { workspace = true }
 allocative = { workspace = true }
 indoc = { workspace = true }
 ordered_hash_map = { version = "0.4.0", features = ["serde"] }
+
+[dev-dependencies]
+criterion = "0.6.0"
+tempfile = "3.20.0"
+
+[[bench]]
+name = "denver_bench"
+harness = false

--- a/rust/routee-compass/benches/README.md
+++ b/rust/routee-compass/benches/README.md
@@ -1,0 +1,16 @@
+# RouteE-Compass Benchmarks
+
+RouteE-Compass Benchmarks using `criterion` and `github-action-benchmark`.
+
+The results from the benchmark workflow are saved in the repository on the `gh-pages` branch. The results are added to the `dev/bench/` folder after each workflow run. The benchmarks are plotted at `nrel.github.io/routee-compass/dev/bench`. See the [rust-bench](../../../.github/workflows/rust-bench.yaml) workflow and [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) for more details.
+
+
+To run the benchmarks manually
+```
+cd rust/
+cargo criterion
+```
+> [cargo-criterion](https://github.com/bheisler/cargo-criterion) is used to provide machine-readable output.
+
+## A note about relative paths with `cargo criterion`
+ `cargo-criterion` finds relative paths based on the current working directory, while the command `cargo bench` finds the relative paths based on the package location.

--- a/rust/routee-compass/benches/denver_bench.rs
+++ b/rust/routee-compass/benches/denver_bench.rs
@@ -1,0 +1,72 @@
+//! Benchmark the performance of the downtown denver example
+//!
+//! ```
+//! cd rust/
+//! cargo criterion
+//! ```
+//!
+//! If you use the command `cargo bench`, then you will have to change the `config_file` to
+//! ```
+//! // this path is relative to `routee-compass/rust/routee-compass`
+//! config_file: String::from(
+//!     "../../python/nrel/routee/compass/resources/downtown_denver_example/osm_default_speed.toml",
+//! ),
+//! ```
+
+use std::{hint::black_box, io::Write};
+
+use routee_compass::app::cli::cli_args::CliArgs;
+use routee_compass::app::cli::run;
+use routee_compass::app::compass::CompassAppBuilder;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use tempfile::NamedTempFile;
+
+/// Run the query on the downtown denver example config file
+fn downtown_denver_example(query_file: String) {
+    let args = CliArgs {
+        // this path is relative to `routee-compass/rust`
+        config_file: String::from(
+            "../python/nrel/routee/compass/resources/downtown_denver_example/osm_default_speed.toml",
+        ),
+        query_file: query_file,
+        chunksize: None,
+        newline_delimited: false,
+    };
+    let builder = CompassAppBuilder::default();
+    match run::command_line_runner(&args, Some(builder), None) {
+        Ok(_) => {}
+        Err(e) => {
+            println!("{}", e)
+        }
+    }
+}
+
+/// Benchmark the downtown denver example using criterion
+fn bench_example(c: &mut Criterion) {
+    let mut group = c.benchmark_group("routee-compass");
+
+    let query = "{
+        \"origin_name\": \"NREL\",
+        \"destination_name\": \"Comrade Brewing Company\",
+        \"destination_y\": 39.62627481432341,
+        \"destination_x\": -104.99460207519721,
+        \"origin_y\": 39.798311884359094,
+        \"origin_x\": -104.86796368632217
+    }";
+
+    let mut tmp_file = NamedTempFile::new().unwrap();
+    tmp_file.write_all(query.as_bytes()).unwrap();
+    let tmp_path = tmp_file.into_temp_path();
+
+    group.bench_with_input("downtown denver example", &tmp_path, |b, input| {
+        b.iter(|| {
+            black_box(downtown_denver_example(black_box(
+                input.to_str().unwrap().to_string(),
+            )))
+        })
+    });
+}
+
+criterion_group!(benches, bench_example);
+criterion_main!(benches);


### PR DESCRIPTION
Create a simple benchmark case suggested in #336 and create CI benchmarking workflow.

After the last discussion with @robfitzgerald, we might need to switch `secrets.GITHUB_TOKEN` to a different name.

closes #336 