### PR TITLE
fix failing GA

### DIFF
--- a/.github/workflows/rust-bench.yaml
+++ b/.github/workflows/rust-bench.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           name: Rust Benchmark
           tool: 'cargo'
-          output-file-path: output.txt
+          output-file-path: rust/output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           alert-threshold: '200%'


### PR DESCRIPTION
`output.txt` is created in the `./rust` working directory, so this PR specifies the correct output file path.