### PR TITLE
fix: switch benchmark running tool

### DIFF
--- a/.github/workflows/rust-bench.yaml
+++ b/.github/workflows/rust-bench.yaml
@@ -18,12 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install cargo-criterion
-        run: cargo install cargo-criterion
-
       - name: Run benchmark with criterion
         working-directory: ./rust
-        run: cargo criterion --output-format bencher --benches 2>&1 | tee output.txt
+        run: cargo bench -p routee-compass -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -56,3 +56,16 @@ tempfile = "3.20.0"
 [[bench]]
 name = "denver_bench"
 harness = false
+
+[lib]
+bench = false
+
+[[bin]]
+name = "routee-compass"
+path = "src/main.rs"
+bench = false
+
+[[bin]]
+name = "geom-app"
+path = "src/bin/geom-app.rs"
+bench = false

--- a/rust/routee-compass/benches/README.md
+++ b/rust/routee-compass/benches/README.md
@@ -8,9 +8,7 @@ The results from the benchmark workflow are saved in the repository on the `gh-p
 To run the benchmarks manually
 ```
 cd rust/
-cargo criterion
+cargo bench
 ```
-> [cargo-criterion](https://github.com/bheisler/cargo-criterion) is used to provide machine-readable output.
 
-## A note about relative paths with `cargo criterion`
- `cargo-criterion` finds relative paths based on the current working directory, while the command `cargo bench` finds the relative paths based on the package location.
+> Note passing many command-line arguments requires disabling bench building in the `Cargo.toml`. See [criterion docs](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options) for more information.

--- a/rust/routee-compass/benches/denver_bench.rs
+++ b/rust/routee-compass/benches/denver_bench.rs
@@ -2,15 +2,7 @@
 //!
 //! ```
 //! cd rust/
-//! cargo criterion
-//! ```
-//!
-//! If you use the command `cargo bench`, then you will have to change the `config_file` to
-//! ```
-//! // this path is relative to `routee-compass/rust/routee-compass`
-//! config_file: String::from(
-//!     "../../python/nrel/routee/compass/resources/downtown_denver_example/osm_default_speed.toml",
-//! ),
+//! cargo bench
 //! ```
 
 use std::{hint::black_box, io::Write};
@@ -25,9 +17,8 @@ use tempfile::NamedTempFile;
 /// Run the query on the downtown denver example config file
 fn downtown_denver_example(query_file: String) {
     let args = CliArgs {
-        // this path is relative to `routee-compass/rust`
         config_file: String::from(
-            "../python/nrel/routee/compass/resources/downtown_denver_example/osm_default_speed.toml",
+            "../../python/nrel/routee/compass/resources/downtown_denver_example/osm_default_speed.toml",
         ),
         query_file: query_file,
         chunksize: None,


### PR DESCRIPTION
Instead of using `cargo criterion`, which fails due to our progress bars,  I switched to `cargo bench` with the added `--output-format bencher` argument. As noted on the [criterion docs](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options) as well as this [rust issue](https://github.com/rust-lang/rust/issues/47241#issuecomment-1462725509), I had to either specify the benchmark test or disable benchmark building in the `Cargo.toml`. I was not sure which option to go with, so I decided to modify the `Cargo.toml` to save us from having to edit the GitHub actions command if we ever create more benchmark files, but please let me know if you have different opinions. The drawback of disabling bench building in cargo.toml is you can no longer use the unstable rust benchmarking such as `#[bench]`.