### PR TITLE
Implemented option to return a compressed file when the provided filename ends in `.gz`

### DIFF
--- a/rust/routee-compass-core/src/model/traversal/default/speed/speed_traversal_service.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed/speed_traversal_service.rs
@@ -49,7 +49,8 @@ impl TraversalModelService for SpeedLookupService {
             }
             None => None,
         };
-        let speed_limit = speed_limit_tuple.map(|(speed_limit, max_speed_unit)| max_speed_unit.to_uom(speed_limit));
+        let speed_limit = speed_limit_tuple
+            .map(|(speed_limit, max_speed_unit)| max_speed_unit.to_uom(speed_limit));
 
         let model = SpeedTraversalModel::new(self.e.clone(), speed_limit)?;
         Ok(Arc::new(model))

--- a/rust/routee-compass-core/src/model/traversal/default/speed/speed_traversal_service.rs
+++ b/rust/routee-compass-core/src/model/traversal/default/speed/speed_traversal_service.rs
@@ -49,10 +49,7 @@ impl TraversalModelService for SpeedLookupService {
             }
             None => None,
         };
-        let speed_limit = match speed_limit_tuple {
-            Some((speed_limit, max_speed_unit)) => Some(max_speed_unit.to_uom(speed_limit)),
-            None => None,
-        };
+        let speed_limit = speed_limit_tuple.map(|(speed_limit, max_speed_unit)| max_speed_unit.to_uom(speed_limit));
 
         let model = SpeedTraversalModel::new(self.e.clone(), speed_limit)?;
         Ok(Arc::new(model))

--- a/rust/routee-compass-powertrain/src/model/prediction/prediction_model_record.rs
+++ b/rust/routee-compass-powertrain/src/model/prediction/prediction_model_record.rs
@@ -83,7 +83,7 @@ impl PredictionModelRecord {
         for input_feature in &self.input_features {
             let state_variable_f64: f64 = match input_feature {
                 InputFeature::Speed { name, unit } => {
-                    let speed = state_model.get_speed(state, &name)?;
+                    let speed = state_model.get_speed(state, name)?;
                     match unit {
                         None => {
                             return Err(TraversalModelError::TraversalModelFailure(format!(

--- a/rust/routee-compass/benches/denver_bench.rs
+++ b/rust/routee-compass/benches/denver_bench.rs
@@ -52,9 +52,7 @@ fn bench_example(c: &mut Criterion) {
 
     group.bench_with_input("downtown denver example", &tmp_path, |b, input| {
         b.iter(|| {
-            downtown_denver_example(black_box(
-                input.to_str().unwrap().to_string(),
-            ));
+            downtown_denver_example(black_box(input.to_str().unwrap().to_string()));
             black_box(())
         })
     });

--- a/rust/routee-compass/benches/denver_bench.rs
+++ b/rust/routee-compass/benches/denver_bench.rs
@@ -20,7 +20,7 @@ fn downtown_denver_example(query_file: String) {
         config_file: String::from(
             "../../python/nrel/routee/compass/resources/downtown_denver_example/osm_default_speed.toml",
         ),
-        query_file: query_file,
+        query_file,
         chunksize: None,
         newline_delimited: false,
     };
@@ -52,9 +52,10 @@ fn bench_example(c: &mut Criterion) {
 
     group.bench_with_input("downtown denver example", &tmp_path, |b, input| {
         b.iter(|| {
-            black_box(downtown_denver_example(black_box(
+            downtown_denver_example(black_box(
                 input.to_str().unwrap().to_string(),
-            )))
+            ));
+            black_box(())
         })
     });
 }

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -366,6 +366,7 @@ impl CompassApp {
             )?,
         };
         eprintln!();
+        response_writer.close()?;
 
         // combine successful runs along with any error rows for response
         let run_result = run_query_result

--- a/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_config.rs
+++ b/rust/routee-compass/src/app/compass/model/frontier_model/vehicle_restrictions/vehicle_parameter_config.rs
@@ -14,9 +14,9 @@ pub enum VehicleParameterConfig {
     WeightPerAxle { value: f64, unit: WeightUnit },
 }
 
-impl Into<VehicleParameter> for VehicleParameterConfig {
-    fn into(self) -> VehicleParameter {
-        match self {
+impl From<VehicleParameterConfig> for VehicleParameter {
+    fn from(val: VehicleParameterConfig) -> Self {
+        match val {
             VehicleParameterConfig::Height { value, unit } => VehicleParameter::Height {
                 value: unit.to_uom(value),
             },

--- a/rust/routee-compass/src/app/compass/response/internal_writer.rs
+++ b/rust/routee-compass/src/app/compass/response/internal_writer.rs
@@ -37,7 +37,10 @@ impl InternalWriter {
                 // Subsequent attempts to write to this file will panic!
                 let _ = encoder.flush();
                 encoder.try_finish().map_err(|e| {
-                    CompassAppError::InternalError(format!("failure finishing encoded output {}", e))
+                    CompassAppError::InternalError(format!(
+                        "failure finishing encoded output {}",
+                        e
+                    ))
                 })?;
                 Ok(())
             }

--- a/rust/routee-compass/src/app/compass/response/internal_writer.rs
+++ b/rust/routee-compass/src/app/compass/response/internal_writer.rs
@@ -1,0 +1,46 @@
+use flate2::write::GzEncoder;
+use std::{fs::File, io::Result, io::Write};
+
+use crate::app::compass::CompassAppError;
+
+pub enum InternalWriter {
+    File { file: File },
+    GzippedFile { encoder: GzEncoder<File> },
+}
+
+impl InternalWriter {
+    pub fn finish(&mut self) -> core::result::Result<(), CompassAppError> {
+        match self {
+            InternalWriter::File { ref mut file } => {
+                file.flush().map_err(|e| {
+                    CompassAppError::InternalError(format!("failure flushing output {}", e))
+                })?;
+                Ok(())
+            }
+            InternalWriter::GzippedFile { ref mut encoder } => {
+                // NOTE: Because GzEncoder::finish requires ownership, we use try_finish instead.
+                // Subsequent attempts to write to this file will panic!
+                encoder.try_finish().map_err(|e| {
+                    CompassAppError::InternalError(format!("failure finishig encoded output {}", e))
+                })?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Write for InternalWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        match self {
+            InternalWriter::File { file } => file.write(buf),
+            InternalWriter::GzippedFile { encoder } => encoder.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        match self {
+            InternalWriter::File { file } => file.flush(),
+            InternalWriter::GzippedFile { encoder } => encoder.flush(),
+        }
+    }
+}

--- a/rust/routee-compass/src/app/compass/response/internal_writer.rs
+++ b/rust/routee-compass/src/app/compass/response/internal_writer.rs
@@ -1,7 +1,9 @@
 use flate2::write::GzEncoder;
 use std::{fs::File, io::Result, io::Write};
 
-use crate::app::compass::{response::response_output_format::ResponseOutputFormat, CompassAppError};
+use crate::app::compass::{
+    response::response_output_format::ResponseOutputFormat, CompassAppError,
+};
 
 pub enum InternalWriter {
     File { file: File },
@@ -9,14 +11,17 @@ pub enum InternalWriter {
 }
 
 impl InternalWriter {
-    pub fn write_header(&mut self, format: &ResponseOutputFormat) -> core::result::Result<(), CompassAppError> {
+    pub fn write_header(
+        &mut self,
+        format: &ResponseOutputFormat,
+    ) -> core::result::Result<(), CompassAppError> {
         let header = format
             .initial_file_contents()
             .unwrap_or_else(|| String::from(""));
 
-        self.write(header.as_bytes())
-            .map(|_| {})
-            .map_err(|e| CompassAppError::InternalError(format!("Failure writing header to file: {}", e)))
+        self.write(header.as_bytes()).map(|_| {}).map_err(|e| {
+            CompassAppError::InternalError(format!("Failure writing header to file: {}", e))
+        })
     }
 
     pub fn finish(&mut self) -> core::result::Result<(), CompassAppError> {

--- a/rust/routee-compass/src/app/compass/response/internal_writer.rs
+++ b/rust/routee-compass/src/app/compass/response/internal_writer.rs
@@ -37,7 +37,7 @@ impl InternalWriter {
                 // Subsequent attempts to write to this file will panic!
                 let _ = encoder.flush();
                 encoder.try_finish().map_err(|e| {
-                    CompassAppError::InternalError(format!("failure finishig encoded output {}", e))
+                    CompassAppError::InternalError(format!("failure finishing encoded output {}", e))
                 })?;
                 Ok(())
             }

--- a/rust/routee-compass/src/app/compass/response/mod.rs
+++ b/rust/routee-compass/src/app/compass/response/mod.rs
@@ -1,4 +1,5 @@
 pub mod csv;
+pub mod internal_writer;
 pub mod response_output_format;
 pub mod response_output_format_json;
 pub mod response_output_policy;

--- a/rust/routee-compass/src/app/compass/response/response_output_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_policy.rs
@@ -39,16 +39,18 @@ impl ResponseOutputPolicy {
                 // write_mode,
             } => {
                 let output_file_path = PathBuf::from(filename);
-                let file = WriteMode::Append.open_file(&output_file_path, format)?;
-
+                
                 // Optionally wrap file in GzEncoder
-                let wrapped_file = if filename.ends_with(".gz") {
+                let mut wrapped_file = if filename.ends_with(".gz") {
+                    let file = WriteMode::Overwrite.open_file(&output_file_path)?;
                     InternalWriter::GzippedFile {
                         encoder: GzEncoder::new(file, Compression::default()),
                     }
                 } else {
+                    let file = WriteMode::Append.open_file(&output_file_path)?;
                     InternalWriter::File { file }
                 };
+                wrapped_file.write_header(format)?;
 
                 // wrap the file in a mutex so we can share it between threads
                 let file_shareable = Arc::new(Mutex::new(wrapped_file));

--- a/rust/routee-compass/src/app/compass/response/response_output_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_policy.rs
@@ -47,7 +47,7 @@ impl ResponseOutputPolicy {
                         encoder: GzEncoder::new(file, Compression::default()),
                     }
                 } else {
-                    InternalWriter::File { file: file }
+                    InternalWriter::File { file }
                 };
 
                 // wrap the file in a mutex so we can share it between threads

--- a/rust/routee-compass/src/app/compass/response/response_output_policy.rs
+++ b/rust/routee-compass/src/app/compass/response/response_output_policy.rs
@@ -39,7 +39,7 @@ impl ResponseOutputPolicy {
                 // write_mode,
             } => {
                 let output_file_path = PathBuf::from(filename);
-                
+
                 // Optionally wrap file in GzEncoder
                 let mut wrapped_file = if filename.ends_with(".gz") {
                     let file = WriteMode::Overwrite.open_file(&output_file_path)?;

--- a/rust/routee-compass/src/app/compass/response/response_sink.rs
+++ b/rust/routee-compass/src/app/compass/response/response_sink.rs
@@ -1,16 +1,14 @@
 use super::response_output_format::ResponseOutputFormat;
+use crate::app::compass::response::internal_writer::InternalWriter;
 use crate::app::compass::CompassAppError;
 use std::io::prelude::*;
-use std::{
-    fs::File,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 pub enum ResponseSink {
     None,
     File {
         filename: String,
-        file: Arc<Mutex<File>>,
+        file: Arc<Mutex<InternalWriter>>,
         format: ResponseOutputFormat,
         delimiter: Option<String>,
         iterations_per_flush: u64,
@@ -103,7 +101,7 @@ impl ResponseSink {
                         filename, e
                     ))
                 })?;
-
+                file_attained.finish()?;
                 Ok(filename.clone())
             }
             ResponseSink::Combined(policies) => {

--- a/rust/routee-compass/src/app/compass/response/write_mode.rs
+++ b/rust/routee-compass/src/app/compass/response/write_mode.rs
@@ -15,10 +15,7 @@ pub enum WriteMode {
 }
 
 impl WriteMode {
-    pub fn open_file(
-        &self,
-        path: &Path
-    ) -> Result<File, CompassAppError> {
+    pub fn open_file(&self, path: &Path) -> Result<File, CompassAppError> {
         match self {
             WriteMode::Append => {
                 if !path.exists() {
@@ -56,7 +53,8 @@ fn open_append(path: &Path) -> Result<File, CompassAppError> {
     })
 }
 
-fn create_file(path: &Path) -> Result<File, CompassConfigurationError>{
-    File::create(path).map_err(|e| 
-        CompassConfigurationError::UserConfigurationError(format!("Could not create file: {}", e)))
+fn create_file(path: &Path) -> Result<File, CompassConfigurationError> {
+    File::create(path).map_err(|e| {
+        CompassConfigurationError::UserConfigurationError(format!("Could not create file: {}", e))
+    })
 }


### PR DESCRIPTION
In order to reduce the size of the output, it will be compressed using `flate2` if the filename ends in `.gz`. Since `GzEncoder<File>` implements `Write`, most of the code can still be used. The primary challenge of using `GzEncoder` instead of `File` is that the former needs a call to `finish()` when the writing is done. Therefore, my solution implements the `InternalWriter` enum which wraps `File` and `GzEncoder` and implements `finish`. `ResponseSink` now receives an `Arc<Mutex<InternalWriter>>` and calls `finish` in the `close` method.

One important caveat with this solution is that after calling `finish` on `InternalWriter::GzippedFile`, subsequent write attempts will panic. This is due to `GzEncoder<File>::try_finish()`, yet I couldn't find a way to use `GzEncoder<File>::finish()` because it requires ownership, which is an issue when using `Arc`.

I'm happy to discuss this further.

closes #170 