### PR TITLE
Use spatial index to map stations at build time

### DIFF
--- a/python/nrel/routee/compass/io/charging_station_ops.py
+++ b/python/nrel/routee/compass/io/charging_station_ops.py
@@ -370,5 +370,8 @@ def download_ev_charging_stations_for_polygon(
     # Filter to stations within the polygon
     within_polygon = stations_gdf[stations_gdf.within(polygon)]
 
-    # Return as regular DataFrame
+    # Create x and y columns from geometry
+    within_polygon.loc[:, "x"] = within_polygon.geometry.x
+    within_polygon.loc[:, "y"] = within_polygon.geometry.y
+
     return within_polygon

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -286,14 +286,8 @@ def generate_compass_dataset(
             )
             return
 
-        # join the charging stations with the vertices
-        charging_gdf = charging_gdf.to_crs("EPSG:3857").sjoin_nearest(
-            vertex_gdf.to_crs("EPSG:3857"), how="left"
-        )
-
         out_df = charging_gdf[
             [
-                "vertex_id",
                 "power_type",
                 "power_kw",
                 "cost_per_kwh",

--- a/python/nrel/routee/compass/resources/osm_default_charging.toml
+++ b/python/nrel/routee/compass/resources/osm_default_charging.toml
@@ -82,6 +82,7 @@ time_unit = "minutes"
 [[traversal.models]]
 type = "simple_charging"
 charging_station_input_file = "charging-stations.csv.gz"
+vertex_input_file = "vertices-compass.csv.gz"
 
 [[traversal.models]]
 type = "grade"

--- a/rust/routee-compass-core/src/model/map/mod.rs
+++ b/rust/routee-compass-core/src/model/map/mod.rs
@@ -17,6 +17,7 @@ pub use map_error::MapError;
 pub use map_json_extensions::MapJsonExtensions;
 pub use map_json_key::MapJsonKey;
 pub use map_model::MapModel;
+pub use map_model_config::DistanceTolerance;
 pub use map_model_config::MapModelConfig;
 pub use map_vertex_rtree_object::MapVertexRTreeObject;
 pub use matching_type::{MapInputResult, MatchingType};


### PR DESCRIPTION
Hoping to slip in this implementation of #335 before our 0.12.0 release to make it much simpler for a user to supply their own charging station input file. Now, instead of requiring the charging station file to have a pre-mapped vertex_id column, we'll use the existing vertex file and the vertex based spatial index to map the station to the graph at build time. 

Future work would be to support edge based stations. 