### PR TITLE
fix: deploy-docs and rust-bench GA no longer conflict

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -33,6 +33,15 @@ jobs:
           python examples/_convert_examples_to_notebooks.py
           jupyter-book build .
 
+      - name: Checkout benchmark results
+        uses: actions/checkout@v4
+        with:
+          ref: bench
+          path: bench_checkout
+
+      - name: Move benchmark results to build folder
+        run: mv bench_checkout/dev ./docs/_build/html
+
       # Push the book's HTML to github-pages
       - name: GitHub Pages action
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/rust-bench.yaml
+++ b/.github/workflows/rust-bench.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
     contents: write
-    deployments: write
 
 jobs:
   benchmark:
@@ -28,6 +27,7 @@ jobs:
           name: Rust Benchmark
           tool: 'cargo'
           output-file-path: rust/output.txt
+          gh-pages-branch: bench
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           alert-threshold: '200%'


### PR DESCRIPTION
This changes the `deploy-docs.yaml` and `rust-bench.yaml`. I also created the new branch `bench`, which is based on nothing and has the 4 benchmark results that we lost from the overwriting conflict.

* `deploy-docs`:  checks out the `bench` branch and moves its contents into `./docs/_build/html` before the GitHub Pages action.
* `rust-bench`: remove deploy privileges and write the output to `bench` branch.

closes #362 