### PR TITLE
hold smartcore at =0.4.0

### DIFF
--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["test", "**/.DS_Store", "target/"]
 
 [dependencies]
 routee-compass-core = { path = "../routee-compass-core", version = "0.12.0" }
-smartcore = { version = "0.4.0", features = ["serde"] }                       # random forest
+smartcore = { version = "=0.4.0", features = ["serde"] }                      # random forest
 thiserror = { workspace = true }
 log = { workspace = true }
 geo = { workspace = true }


### PR DESCRIPTION
this PR holds the smartcore library dependency at exactly "=0.4.0". out-of-the-blue, dependency resolution for smartcore = "0.4.0" was found to install version 0.4.2 and that version has a breaking change on working with our serialized powertrain models, leading to [this CI failure](https://github.com/NREL/routee-compass/pull/365#issuecomment-3109955567) and failure to compile any version of compass not locked to 0.4.0.