### PR TITLE
fix release action to build sdist; bump to v0.12.1

### DIFF
--- a/.github/workflows/python-release.yaml
+++ b/.github/workflows/python-release.yaml
@@ -75,7 +75,7 @@ jobs:
         run: pip install -U maturin wheel twine cibuildwheel
 
       - name: build sdist
-        if: matrix.os == 'ubuntu' && matrix.python-version == '9'
+        if: matrix.os == 'ubuntu' && matrix.python-version == '11'
         run: |
           pip install -U maturin
           maturin build --sdist --out dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nrel.routee.compass"
-version = "0.12.0"
+version = "0.12.1"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"
 documentation = "nrel.github.io/routee-compass"


### PR DESCRIPTION
When we published v0.12.0, we dropped python 3.9 support but our github workflow was only building the source distribution if it saw python 3.9. So, for v0.12.0 there was no sdist released and therefore no conda release associated with that version. This fixes that and bumps the patch version. 