### PR TITLE
Fix diesel unit deserialization

### DIFF
--- a/python/nrel/routee/compass/resources/osm_default_energy.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy.toml
@@ -44,6 +44,10 @@ left = 2.5
 sharp_left = 3.5
 u_turn = 9.5
 
+# Used for restricting travel after the battery is depleted.
+[frontier]
+type = "battery_frontier"
+
 [traversal]
 type = "combined"
 

--- a/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
+++ b/python/nrel/routee/compass/resources/osm_default_energy_all_vehicles.toml
@@ -64,6 +64,10 @@ left = 2.5
 sharp_left = 3.5
 u_turn = 9.5
 
+# Used for restricting travel after the battery is depleted.
+[frontier]
+type = "battery_frontier"
+
 [traversal]
 type = "combined"
 

--- a/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
@@ -20,7 +20,7 @@ impl std::fmt::Display for EnergyRateUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EnergyRateUnit::GGPM => write!(f, "gallons gasoline/mile"),
-            EnergyRateUnit::GDPM => write!(f, "gallons diesel/kilometer"),
+            EnergyRateUnit::GDPM => write!(f, "gallons diesel/mile"),
             EnergyRateUnit::KWHPM => write!(f, "kilowatt hour/mile"),
             EnergyRateUnit::KWHPKM => write!(f, "kilowatt hour/kilometer"),
         }
@@ -33,7 +33,7 @@ impl FromStr for EnergyRateUnit {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.split("/").collect_vec()[..] {
             ["gallons gasoline", "mile"] => Ok(EnergyRateUnit::GGPM),
-            ["gallons diesel", "kilometer"] => Ok(EnergyRateUnit::GDPM),
+            ["gallons diesel", "mile"] => Ok(EnergyRateUnit::GDPM),
             ["kilowatt hour", "mile"] => Ok(EnergyRateUnit::KWHPM),
             ["kilowatt hour", "kilometer"] => Ok(EnergyRateUnit::KWHPKM),
             ["kWh", "mile"] => Ok(EnergyRateUnit::KWHPM),


### PR DESCRIPTION
A tiny fix to correct how we were de-serializing the energy rate unit "gallons diesel/mile".

Also proposes adding the battery frontier model as default behavior. 