### PR TITLE
test case for gal diesel/mile type

### DIFF
--- a/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
+++ b/rust/routee-compass-core/src/model/unit/energy_rate_unit.rs
@@ -102,6 +102,13 @@ mod tests {
     }
 
     #[test]
+    fn test_gdpm_from_str() {
+        let result = ERU::from_str("gallons diesel/mile");
+        let expected = ERU::GDPM;
+        assert_eq!(result, Ok(expected))
+    }
+
+    #[test]
     fn test_gpm_from_json() {
         let result: Result<ERU, String> =
             sj::from_value(json!("gallons gasoline/mile")).map_err(|e| e.to_string());


### PR DESCRIPTION
created this test case while :brain: was forgetting [this happened](https://github.com/NREL/routee-compass/pull/370)