### PR TITLE
Rjf/fix mul

### DIFF
--- a/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/search_algorithm.rs
@@ -270,7 +270,7 @@ pub fn run_edge_oriented(
                     routes: vec![route],
                     iterations: 1,
                 };
-                return Ok(result);
+                Ok(result)
             } else {
                 // run a search and append source/target edges to result
                 let SearchAlgorithmResult {

--- a/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
@@ -46,37 +46,49 @@ mod test {
 
     #[test]
     fn test_agg_sum_empty() {
-        let result = CostAggregation::Sum.aggregate(&[]).expect("sum should not fail over any real numbers");
+        let result = CostAggregation::Sum
+            .aggregate(&[])
+            .expect("sum should not fail over any real numbers");
         assert_eq!(result, Cost::ZERO)
     }
 
     #[test]
     fn test_agg_sum_singleton() {
-        let result = CostAggregation::Sum.aggregate(&[("a", Cost::new(1.0))]).expect("sum should not fail over any real numbers");
+        let result = CostAggregation::Sum
+            .aggregate(&[("a", Cost::new(1.0))])
+            .expect("sum should not fail over any real numbers");
         assert_eq!(result, Cost::ONE)
     }
 
     #[test]
     fn test_agg_sum_pair() {
-        let result = CostAggregation::Sum.aggregate(&[("a", Cost::new(0.5)),("b", Cost::new(0.5))]).expect("sum should not fail over any real numbers");
+        let result = CostAggregation::Sum
+            .aggregate(&[("a", Cost::new(0.5)), ("b", Cost::new(0.5))])
+            .expect("sum should not fail over any real numbers");
         assert_eq!(result, Cost::ONE)
     }
 
-#[test]
+    #[test]
     fn test_agg_mul_empty() {
-        let result = CostAggregation::Mul.aggregate(&[]).expect("mul should not fail over any real numbers");
+        let result = CostAggregation::Mul
+            .aggregate(&[])
+            .expect("mul should not fail over any real numbers");
         assert_eq!(result, Cost::ZERO)
     }
 
     #[test]
     fn test_agg_mul_singleton() {
-        let result = CostAggregation::Mul.aggregate(&[("a", Cost::new(1.0))]).expect("mul should not fail over any real numbers");
+        let result = CostAggregation::Mul
+            .aggregate(&[("a", Cost::new(1.0))])
+            .expect("mul should not fail over any real numbers");
         assert_eq!(result, Cost::ONE)
     }
 
     #[test]
     fn test_agg_mul_pair() {
-        let result = CostAggregation::Mul.aggregate(&[("a", Cost::new(0.5)),("b", Cost::new(0.5))]).expect("mul should not fail over any real numbers");
+        let result = CostAggregation::Mul
+            .aggregate(&[("a", Cost::new(0.5)), ("b", Cost::new(0.5))])
+            .expect("mul should not fail over any real numbers");
         assert_eq!(result, Cost::new(0.25))
     }
 }

--- a/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_aggregation.rs
@@ -6,13 +6,16 @@ use super::cost_model_error::CostModelError;
 #[derive(Deserialize, Serialize, Clone, Copy, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CostAggregation {
+    /// sums all costs together
     #[default]
     Sum,
+    /// multiplies all costs together
     Mul,
 }
 
 impl CostAggregation {
-    pub fn aggregate(&self, costs: &[(&String, Cost)]) -> Result<Cost, CostModelError> {
+    /// aggregates the costs found in a collection of pairs (state_feature_name, cost_value)
+    pub fn aggregate(&self, costs: &[(&str, Cost)]) -> Result<Cost, CostModelError> {
         match self {
             CostAggregation::Sum => {
                 let mut sum = Cost::ZERO;
@@ -22,7 +25,7 @@ impl CostAggregation {
                 Ok(sum)
             }
             CostAggregation::Mul => {
-                // test if the iterator is empty
+                // exit early if the iterator is empty
                 if costs.is_empty() {
                     return Ok(Cost::ZERO);
                 }
@@ -34,5 +37,46 @@ impl CostAggregation {
                 Ok(product)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::model::{cost::CostAggregation, unit::Cost};
+
+    #[test]
+    fn test_agg_sum_empty() {
+        let result = CostAggregation::Sum.aggregate(&[]).expect("sum should not fail over any real numbers");
+        assert_eq!(result, Cost::ZERO)
+    }
+
+    #[test]
+    fn test_agg_sum_singleton() {
+        let result = CostAggregation::Sum.aggregate(&[("a", Cost::new(1.0))]).expect("sum should not fail over any real numbers");
+        assert_eq!(result, Cost::ONE)
+    }
+
+    #[test]
+    fn test_agg_sum_pair() {
+        let result = CostAggregation::Sum.aggregate(&[("a", Cost::new(0.5)),("b", Cost::new(0.5))]).expect("sum should not fail over any real numbers");
+        assert_eq!(result, Cost::ONE)
+    }
+
+#[test]
+    fn test_agg_mul_empty() {
+        let result = CostAggregation::Mul.aggregate(&[]).expect("mul should not fail over any real numbers");
+        assert_eq!(result, Cost::ZERO)
+    }
+
+    #[test]
+    fn test_agg_mul_singleton() {
+        let result = CostAggregation::Mul.aggregate(&[("a", Cost::new(1.0))]).expect("mul should not fail over any real numbers");
+        assert_eq!(result, Cost::ONE)
+    }
+
+    #[test]
+    fn test_agg_mul_pair() {
+        let result = CostAggregation::Mul.aggregate(&[("a", Cost::new(0.5)),("b", Cost::new(0.5))]).expect("mul should not fail over any real numbers");
+        assert_eq!(result, Cost::new(0.25))
     }
 }

--- a/rust/routee-compass-core/src/model/cost/cost_model_builder.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_model_builder.rs
@@ -1,7 +1,7 @@
 use super::cost_model_service::CostModelService;
-use crate::config::{CompassConfigurationError, CompassConfigurationField, ConfigJsonExtensions};
-use crate::model::cost::{network::NetworkCostRate, CostAggregation, VehicleCostRate};
-use std::{collections::HashMap, sync::Arc};
+use crate::config::{CompassConfigurationError};
+use crate::model::cost::{CostModelConfig};
+use std::{sync::Arc};
 
 pub struct CostModelBuilder {}
 
@@ -10,31 +10,13 @@ impl CostModelBuilder {
         &self,
         config: &serde_json::Value,
     ) -> Result<CostModelService, CompassConfigurationError> {
-        let parent_key = CompassConfigurationField::Cost.to_string();
-        let vehicle_rates: HashMap<String, VehicleCostRate> = config
-            .get_config_serde_optional(&"vehicle_rates", &parent_key)?
-            .unwrap_or_default();
-        let network_rates: HashMap<String, NetworkCostRate> = config
-            .get_config_serde_optional(&"network_rates", &parent_key)?
-            .unwrap_or_default();
-
-        let weights: HashMap<String, f64> = config
-            .get_config_serde_optional(&"weights", &parent_key)?
-            .unwrap_or_default();
-        let cost_aggregation: CostAggregation = config
-            .get_config_serde_optional(&"cost_aggregation", &parent_key)?
-            .unwrap_or_default();
-
-        let ignore_unknown_weights = config
-            .get_config_serde_optional(&"ignore_unknown_user_provided_weights", &parent_key)?
-            .unwrap_or(true);
-
+        let conf: CostModelConfig = serde_json::from_value(config.clone())?;
         let model = CostModelService {
-            vehicle_rates: Arc::new(vehicle_rates),
-            network_rates: Arc::new(network_rates),
-            weights: Arc::new(weights),
-            cost_aggregation,
-            ignore_unknown_weights,
+            vehicle_rates: Arc::new(conf.get_vehicle_rates()),
+            network_rates: Arc::new(conf.get_network_rates()),
+            weights: Arc::new(conf.get_weights()),
+            cost_aggregation: conf.get_cost_aggregation(),
+            ignore_unknown_weights: conf.get_ignore_policy(),
         };
         Ok(model)
     }

--- a/rust/routee-compass-core/src/model/cost/cost_model_builder.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_model_builder.rs
@@ -1,7 +1,7 @@
 use super::cost_model_service::CostModelService;
-use crate::config::{CompassConfigurationError};
-use crate::model::cost::{CostModelConfig};
-use std::{sync::Arc};
+use crate::config::CompassConfigurationError;
+use crate::model::cost::CostModelConfig;
+use std::sync::Arc;
 
 pub struct CostModelBuilder {}
 

--- a/rust/routee-compass-core/src/model/cost/cost_model_config.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_model_config.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use crate::model::cost::{network::NetworkCostRate, CostAggregation, VehicleCostRate};
+
+/// configuration for a cost model set at app initialization time.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct CostModelConfig {
+    pub vehicle_rates: Option<HashMap<String, VehicleCostRate>>,
+    pub network_rates: Option<HashMap<String, NetworkCostRate>>,
+    pub weights: Option<HashMap<String, f64>>,
+    pub cost_aggregation: Option<CostAggregation>,
+    pub ignore_unknown_user_provided_weights: Option<bool>
+}
+
+impl CostModelConfig {
+    pub fn get_vehicle_rates(&self) -> HashMap<String, VehicleCostRate> {
+        self.vehicle_rates.clone().unwrap_or_default()
+    }
+    pub fn get_network_rates(&self) -> HashMap<String, NetworkCostRate> {
+        self.network_rates.clone().unwrap_or_default()
+    }
+    pub fn get_weights(&self) -> HashMap<String, f64> {
+        self.weights.clone().unwrap_or_default()
+    }
+    pub fn get_cost_aggregation(&self) -> CostAggregation {
+        self.cost_aggregation.unwrap_or_default()
+    }
+    pub fn get_ignore_policy(&self) -> bool {
+        self.ignore_unknown_user_provided_weights.unwrap_or(true)
+    }
+}

--- a/rust/routee-compass-core/src/model/cost/cost_model_config.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_model_config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
 use crate::model::cost::{network::NetworkCostRate, CostAggregation, VehicleCostRate};
+use serde::{Deserialize, Serialize};
 
 /// configuration for a cost model set at app initialization time.
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -10,7 +10,7 @@ pub struct CostModelConfig {
     pub network_rates: Option<HashMap<String, NetworkCostRate>>,
     pub weights: Option<HashMap<String, f64>>,
     pub cost_aggregation: Option<CostAggregation>,
-    pub ignore_unknown_user_provided_weights: Option<bool>
+    pub ignore_unknown_user_provided_weights: Option<bool>,
 }
 
 impl CostModelConfig {

--- a/rust/routee-compass-core/src/model/cost/cost_ops.rs
+++ b/rust/routee-compass-core/src/model/cost/cost_ops.rs
@@ -16,7 +16,7 @@ pub fn calculate_vehicle_costs(
     cost_aggregation: &CostAggregation,
 ) -> Result<Cost, CostModelError> {
     let (prev_state, next_state) = state_sequence;
-    let mut costs: Vec<(&String, Cost)> = vec![];
+    let mut costs: Vec<(&str, Cost)> = vec![];
     for (name, state_idx) in indices.iter() {
         // compute delta
         let prev_state_var = prev_state
@@ -54,7 +54,7 @@ pub fn calculate_network_traversal_costs(
     cost_aggregation: &CostAggregation,
 ) -> Result<Cost, CostModelError> {
     let (prev_state, next_state) = state_sequence;
-    let mut costs: Vec<(&String, Cost)> = vec![];
+    let mut costs: Vec<(&str, Cost)> = vec![];
     for (name, state_idx) in indices.iter() {
         let prev_state_var = prev_state
             .get(*state_idx)
@@ -88,7 +88,7 @@ pub fn calculate_network_access_costs(
 ) -> Result<Cost, CostModelError> {
     let (prev_state, next_state) = state_sequence;
     let (prev_edge, next_edge) = edge_sequence;
-    let mut costs: Vec<(&String, Cost)> = vec![];
+    let mut costs: Vec<(&str, Cost)> = vec![];
     for (name, idx) in indices.iter() {
         if let Some(m) = rates.get(*idx) {
             let prev_state_var = prev_state

--- a/rust/routee-compass-core/src/model/cost/mod.rs
+++ b/rust/routee-compass-core/src/model/cost/mod.rs
@@ -6,7 +6,9 @@ pub mod cost_model_service;
 pub mod cost_ops;
 pub mod network;
 mod vehicle;
+mod cost_model_config;
 
+pub use cost_model_config::CostModelConfig;
 pub use cost_aggregation::CostAggregation;
 pub use cost_model::CostModel;
 pub use cost_model_error::CostModelError;

--- a/rust/routee-compass-core/src/model/cost/mod.rs
+++ b/rust/routee-compass-core/src/model/cost/mod.rs
@@ -1,15 +1,15 @@
 mod cost_aggregation;
 mod cost_model;
 pub mod cost_model_builder;
+mod cost_model_config;
 mod cost_model_error;
 pub mod cost_model_service;
 pub mod cost_ops;
 pub mod network;
 mod vehicle;
-mod cost_model_config;
 
-pub use cost_model_config::CostModelConfig;
 pub use cost_aggregation::CostAggregation;
 pub use cost_model::CostModel;
+pub use cost_model_config::CostModelConfig;
 pub use cost_model_error::CostModelError;
 pub use vehicle::vehicle_cost_rate::VehicleCostRate;

--- a/rust/routee-compass-core/src/util/compact_ordered_hash_map.rs
+++ b/rust/routee-compass-core/src/util/compact_ordered_hash_map.rs
@@ -391,7 +391,7 @@ impl<K, V> CompactOrderedHashMap<K, V> {
                         (k, IndexedEntry::new(v, 4)),
                     ]);
 
-                    std::mem::swap(self, &mut CompactOrderedHashMap::NEntries(five));
+                    *self = CompactOrderedHashMap::NEntries(five);
                     None
                 }
             }


### PR DESCRIPTION
This PR set out to address the bug ticket #363 which was concerned about the implementation of multiplicative cost aggregation. tests were provided which demonstrate the expected behavior for cost vectors of size 0, 1, and 2 for both sum and mul variants. 

along the way, applied our config modernization strategy to the CostModelBuilder, extracting deserialization from the build method and into a serde record type (CostModelConfig).

Closes #363.