### PR TITLE
Rjf/inventory

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 ]
 
 [workspace.dependencies]
+inventory = { version = "0.3.21" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 rayon = "1.10.0"

--- a/rust/routee-compass-py/src/app_wrapper.rs
+++ b/rust/routee-compass-py/src/app_wrapper.rs
@@ -17,7 +17,7 @@ impl CompassAppBindings for CompassAppWrapper {
     where
         Self: Sized,
     {
-        let builder = CompassAppBuilder::default();
+        let builder = CompassAppBuilder::new()?;
         let app =
             CompassApp::try_from_config_toml_string(config_string, original_file_path, &builder)?;
         Ok(CompassAppWrapper { app })

--- a/rust/routee-compass-py/src/app_wrapper.rs
+++ b/rust/routee-compass-py/src/app_wrapper.rs
@@ -1,6 +1,6 @@
 use routee_compass::app::{
     bindings::CompassAppBindings,
-    compass::{compass_app::CompassApp, CompassBuilderInventory, CompassAppError},
+    compass::{compass_app::CompassApp, CompassAppError, CompassBuilderInventory},
 };
 use routee_compass_macros::pybindings;
 

--- a/rust/routee-compass-py/src/app_wrapper.rs
+++ b/rust/routee-compass-py/src/app_wrapper.rs
@@ -1,6 +1,6 @@
 use routee_compass::app::{
     bindings::CompassAppBindings,
-    compass::{compass_app::CompassApp, CompassAppBuilder, CompassAppError},
+    compass::{compass_app::CompassApp, CompassBuilderInventory, CompassAppError},
 };
 use routee_compass_macros::pybindings;
 
@@ -17,7 +17,7 @@ impl CompassAppBindings for CompassAppWrapper {
     where
         Self: Sized,
     {
-        let builder = CompassAppBuilder::new()?;
+        let builder = CompassBuilderInventory::new()?;
         let app =
             CompassApp::try_from_config_toml_string(config_string, original_file_path, &builder)?;
         Ok(CompassAppWrapper { app })

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -48,6 +48,7 @@ ordered-float = { workspace = true }
 allocative = { workspace = true }
 indoc = { workspace = true }
 ordered_hash_map = { version = "0.4.0", features = ["serde"] }
+inventory = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.6.0"

--- a/rust/routee-compass/benches/denver_bench.rs
+++ b/rust/routee-compass/benches/denver_bench.rs
@@ -9,7 +9,7 @@ use std::{hint::black_box, io::Write};
 
 use routee_compass::app::cli::cli_args::CliArgs;
 use routee_compass::app::cli::run;
-use routee_compass::app::compass::CompassAppBuilder;
+use routee_compass::app::compass::CompassBuilderInventory;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use tempfile::NamedTempFile;
@@ -24,7 +24,7 @@ fn downtown_denver_example(query_file: String) {
         chunksize: None,
         newline_delimited: false,
     };
-    let builder = CompassAppBuilder::new().expect("failed to load compass app builder");
+    let builder = CompassBuilderInventory::new().expect("failed to load compass app builder");
     match run::command_line_runner(&args, Some(builder), None) {
         Ok(_) => {}
         Err(e) => {

--- a/rust/routee-compass/benches/denver_bench.rs
+++ b/rust/routee-compass/benches/denver_bench.rs
@@ -24,7 +24,7 @@ fn downtown_denver_example(query_file: String) {
         chunksize: None,
         newline_delimited: false,
     };
-    let builder = CompassAppBuilder::default();
+    let builder = CompassAppBuilder::new().expect("failed to load compass app builder");
     match run::command_line_runner(&args, Some(builder), None) {
         Ok(_) => {}
         Err(e) => {

--- a/rust/routee-compass/src/app/bindings.rs
+++ b/rust/routee-compass/src/app/bindings.rs
@@ -46,7 +46,7 @@ use std::str::FromStr;
 ///     where
 ///         Self: Sized,
 ///     {
-///         let mut builder = CompassBuilderInventory::new();
+///         let mut builder = CompassBuilderInventory::new()?;
 ///
 ///         // inject custom traversal model here like:
 ///

--- a/rust/routee-compass/src/app/bindings.rs
+++ b/rust/routee-compass/src/app/bindings.rs
@@ -29,7 +29,7 @@ use std::str::FromStr;
 /// use routee_compass::app::bindings::CompassAppBindings;
 /// use routee_compass::app::compass::compass_app::CompassApp;
 /// use routee_compass::app::compass::CompassAppError;
-/// use routee_compass::app::compass::CompassAppBuilder;
+/// use routee_compass::app::compass::CompassBuilderInventory;
 ///
 /// //use routee_compass_macros::pybindings;
 ///
@@ -46,7 +46,7 @@ use std::str::FromStr;
 ///     where
 ///         Self: Sized,
 ///     {
-///         let mut builder = CompassAppBuilder::default();
+///         let mut builder = CompassBuilderInventory::new();
 ///
 ///         // inject custom traversal model here like:
 ///

--- a/rust/routee-compass/src/app/cli/run.rs
+++ b/rust/routee-compass/src/app/cli/run.rs
@@ -1,7 +1,7 @@
 use super::cli_args::CliArgs;
 use crate::app::compass::compass_app_ops as ops;
 use crate::app::compass::{
-    compass_app::CompassApp, compass_json_extensions::CompassJsonExtensions, CompassAppBuilder,
+    compass_app::CompassApp, compass_json_extensions::CompassJsonExtensions, CompassBuilderInventory,
     CompassAppError,
 };
 use itertools::{Either, Itertools};
@@ -24,7 +24,7 @@ use std::{fs::File, io::BufReader, path::Path};
 /// Any user errors are logged and optionally written to an output file depending on the file io policy.
 pub fn command_line_runner(
     args: &CliArgs,
-    builder: Option<CompassAppBuilder>,
+    builder: Option<CompassBuilderInventory>,
     run_config: Option<&Value>,
 ) -> Result<(), CompassAppError> {
     args.validate()?;
@@ -32,7 +32,7 @@ pub fn command_line_runner(
     // build the app
     let builder_or_default = match builder {
         Some(b) => b,
-        None => CompassAppBuilder::new()?,
+        None => CompassBuilderInventory::new()?,
     };
     let config_path = Path::new(&args.config_file);
     let config = ops::read_config_from_file(config_path)?;

--- a/rust/routee-compass/src/app/cli/run.rs
+++ b/rust/routee-compass/src/app/cli/run.rs
@@ -30,10 +30,13 @@ pub fn command_line_runner(
     args.validate()?;
 
     // build the app
-    let builder_or_default = builder.unwrap_or_default();
+    let builder_or_default = match builder {
+        Some(b) => b,
+        None => CompassAppBuilder::new()?,
+    };
     let config_path = Path::new(&args.config_file);
     let config = ops::read_config_from_file(config_path)?;
-    let compass_app = match CompassApp::try_from((&config, &builder_or_default)) {
+    let compass_app = match CompassApp::new(&config, &builder_or_default) {
         Ok(app) => app,
         Err(e) => {
             error!("Could not build CompassApp from config file: {e}");

--- a/rust/routee-compass/src/app/cli/run.rs
+++ b/rust/routee-compass/src/app/cli/run.rs
@@ -16,7 +16,7 @@ use std::{fs::File, io::BufReader, path::Path};
 ///
 /// # Arguments
 /// * `args`       - command line arguments for this run
-/// * `builder`    - optional builder instance to overwrite the default. see CompassAppBuilder for explanation.
+/// * `builder`    - optional builder instance to overwrite the default. see CompassBuilderInventory for explanation.
 /// * `run_config` - optional CompassApp configuration overrides
 ///
 /// # Returns

--- a/rust/routee-compass/src/app/cli/run.rs
+++ b/rust/routee-compass/src/app/cli/run.rs
@@ -1,8 +1,8 @@
 use super::cli_args::CliArgs;
 use crate::app::compass::compass_app_ops as ops;
 use crate::app::compass::{
-    compass_app::CompassApp, compass_json_extensions::CompassJsonExtensions, CompassBuilderInventory,
-    CompassAppError,
+    compass_app::CompassApp, compass_json_extensions::CompassJsonExtensions, CompassAppError,
+    CompassBuilderInventory,
 };
 use itertools::{Either, Itertools};
 use log::{debug, error};

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -98,7 +98,6 @@ impl TryFrom<&Path> for CompassApp {
 }
 
 impl CompassApp {
-
     /// Builds a CompassApp from configuration and a (possibly customized) CompassAppBuilder.
     /// Builds all modules such as the DirectedGraph, TraversalModel, and SearchAlgorithm.
     /// Also builds the input and output plugins.
@@ -117,7 +116,6 @@ impl CompassApp {
     ///
     /// * an instance of [`CompassApp`], or an error if load failed.
     pub fn new(config: &Config, builder: &CompassAppBuilder) -> Result<Self, CompassAppError> {
-
         // Get the root config path so we can resolve paths relative
         // to where the config file is located.
         let root_config_path =

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -1,7 +1,7 @@
 use super::compass_app_configuration::CompassAppConfiguration;
 use super::response::response_output_policy::ResponseOutputPolicy;
 use super::response::response_sink::ResponseSink;
-use super::{compass_app_ops as ops, CompassAppBuilder};
+use super::{compass_app_ops as ops, CompassBuilderInventory};
 use crate::app::compass::response::response_persistence_policy::ResponsePersistencePolicy;
 use crate::{
     app::{
@@ -62,7 +62,7 @@ impl CompassApp {
     pub fn try_from_config_toml_string(
         config_string: String,
         original_file_path: String,
-        builder: &CompassAppBuilder,
+        builder: &CompassBuilderInventory,
     ) -> Result<Self, CompassAppError> {
         let config = ops::read_config_from_string(
             config_string.clone(),
@@ -91,7 +91,7 @@ impl TryFrom<&Path> for CompassApp {
     /// * an instance of [`CompassApp`], or an error if load failed.
     fn try_from(conf_file: &Path) -> Result<Self, Self::Error> {
         let config = ops::read_config_from_file(conf_file)?;
-        let builder = CompassAppBuilder::new()?;
+        let builder = CompassBuilderInventory::new()?;
         let compass_app = CompassApp::new(&config, &builder)?;
         Ok(compass_app)
     }
@@ -115,7 +115,7 @@ impl CompassApp {
     /// # Returns
     ///
     /// * an instance of [`CompassApp`], or an error if load failed.
-    pub fn new(config: &Config, builder: &CompassAppBuilder) -> Result<Self, CompassAppError> {
+    pub fn new(config: &Config, builder: &CompassBuilderInventory) -> Result<Self, CompassAppError> {
         // Get the root config path so we can resolve paths relative
         // to where the config file is located.
         let root_config_path =

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -48,13 +48,13 @@ pub struct CompassApp {
 }
 
 impl CompassApp {
-    /// Builds a CompassApp from a configuration TOML string, using a custom CompassAppBuilder.
+    /// Builds a CompassApp from a configuration TOML string, using a custom CompassBuilderInventory.
     ///
     /// # Arguments
     ///
     /// * `config_string` - a string containing the configuration in TOML format
     /// * `original_file_path` - the original file path of the TOML
-    /// * `builder` - a custom CompassAppBuilder instance
+    /// * `builder` - a custom CompassBuilderInventory instance
     ///
     /// # Returns
     ///
@@ -77,7 +77,7 @@ impl CompassApp {
 impl TryFrom<&Path> for CompassApp {
     type Error = CompassAppError;
 
-    /// Builds a CompassApp from a configuration filepath, using the default CompassAppBuilder.
+    /// Builds a CompassApp from a configuration filepath, using the default CompassBuilderInventory.
     /// Builds all components such as the DirectedGraph, TraversalModel, and SearchAlgorithm.
     /// Also builds the input and output plugins.
     /// Returns a persistent application that can run user queries in parallel.
@@ -98,7 +98,7 @@ impl TryFrom<&Path> for CompassApp {
 }
 
 impl CompassApp {
-    /// Builds a CompassApp from configuration and a (possibly customized) CompassAppBuilder.
+    /// Builds a CompassApp from configuration and a (possibly customized) CompassBuilderInventory.
     /// Builds all modules such as the DirectedGraph, TraversalModel, and SearchAlgorithm.
     /// Also builds the input and output plugins.
     /// Returns a persistent application that can run user queries in parallel.
@@ -110,7 +110,7 @@ impl CompassApp {
     /// # Arguments
     ///
     /// * `pair` - a tuple containing a config object (such as a parsed TOML file) and
-    ///   a [`super::config::compass_app_builder::CompassAppBuilder`] instance
+    ///   a [`super::config::compass_app_builder::CompassBuilderInventory`] instance
     ///
     /// # Returns
     ///

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -69,7 +69,7 @@ impl CompassApp {
             config::FileFormat::Toml,
             original_file_path,
         )?;
-        let app = CompassApp::try_from((&config, builder))?;
+        let app = CompassApp::new(&config, builder)?;
         Ok(app)
     }
 }
@@ -91,14 +91,13 @@ impl TryFrom<&Path> for CompassApp {
     /// * an instance of [`CompassApp`], or an error if load failed.
     fn try_from(conf_file: &Path) -> Result<Self, Self::Error> {
         let config = ops::read_config_from_file(conf_file)?;
-        let builder = CompassAppBuilder::default();
-        let compass_app = CompassApp::try_from((&config, &builder))?;
+        let builder = CompassAppBuilder::new()?;
+        let compass_app = CompassApp::new(&config, &builder)?;
         Ok(compass_app)
     }
 }
 
-impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
-    type Error = CompassAppError;
+impl CompassApp {
 
     /// Builds a CompassApp from configuration and a (possibly customized) CompassAppBuilder.
     /// Builds all modules such as the DirectedGraph, TraversalModel, and SearchAlgorithm.
@@ -117,8 +116,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
     /// # Returns
     ///
     /// * an instance of [`CompassApp`], or an error if load failed.
-    fn try_from(pair: (&Config, &CompassAppBuilder)) -> Result<Self, Self::Error> {
-        let (config, builder) = pair;
+    pub fn new(config: &Config, builder: &CompassAppBuilder) -> Result<Self, CompassAppError> {
 
         // Get the root config path so we can resolve paths relative
         // to where the config file is located.
@@ -261,9 +259,7 @@ impl TryFrom<(&Config, &CompassAppBuilder)> for CompassApp {
             configuration,
         })
     }
-}
 
-impl CompassApp {
     /// runs a set of queries via this instance of CompassApp. this
     ///   1. processes each input query based on the InputPlugins
     ///   2. runs the search algorithm with each query via SearchApp

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -115,7 +115,10 @@ impl CompassApp {
     /// # Returns
     ///
     /// * an instance of [`CompassApp`], or an error if load failed.
-    pub fn new(config: &Config, builder: &CompassBuilderInventory) -> Result<Self, CompassAppError> {
+    pub fn new(
+        config: &Config,
+        builder: &CompassBuilderInventory,
+    ) -> Result<Self, CompassAppError> {
         // Get the root config path so we can resolve paths relative
         // to where the config file is located.
         let root_config_path =

--- a/rust/routee-compass/src/app/compass/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_builder.rs
@@ -1,4 +1,4 @@
-use crate::plugin::{
+use crate::{plugin::{
     input::{
         default::{
             debug::DebugInputPluginBuilder, grid_search::GridSearchBuilder,
@@ -13,7 +13,7 @@ use crate::plugin::{
         },
         OutputPlugin, OutputPluginBuilder,
     },
-};
+}};
 use itertools::Itertools;
 use routee_compass_core::model::{
     access::{
@@ -58,15 +58,54 @@ use routee_compass_powertrain::model::{
     EnergyModelBuilder,
 };
 use std::{collections::HashMap, rc::Rc, sync::Arc};
-
+use inventory;
 use super::CompassComponentError;
+
+/// provides a plugin API for downstream libraries to inject values into the CompassAppBuilder.
+/// for details, see the [`inventory`] crate.
+pub struct PluginRegistration(pub fn(&mut CompassAppBuilder) -> Result<(), CompassConfigurationError>);
+inventory::collect!(PluginRegistration);
+
+
+// this macro will register the default set of builders with inventory. these are iterated through in the CompassAppBuilder::new method
+// along with any plugins registered by downstream libraries.
+inventory::submit! {
+    PluginRegistration(|builder| {
+        builder.add_traversal_model(String::from("distance"),  Rc::new(DistanceTraversalBuilder {}));
+        builder.add_traversal_model("speed".to_string(), Rc::new(SpeedTraversalBuilder {}));
+        builder.add_traversal_model("time".to_string(), Rc::new(TimeTraversalBuilder {}));
+        builder.add_traversal_model("grade".to_string(), Rc::new(GradeTraversalBuilder {}));
+        builder.add_traversal_model("elevation".to_string(), Rc::new(ElevationTraversalBuilder {}));
+        builder.add_traversal_model("energy".to_string(), Rc::new(EnergyModelBuilder {}));
+        builder.add_traversal_model("simple_charging".to_string(), Rc::new(SimpleChargingBuilder::default()));
+        builder.add_traversal_model("custom".to_string(), Rc::new(CustomTraversalBuilder {}));
+        builder.add_access_model("no_access_model".to_string(),Rc::new(NoAccessModel {}));
+        builder.add_access_model("turn_delay".to_string(),Rc::new(TurnDelayAccessModelBuilder {}));
+        builder.add_frontier_model("no_restriction".to_string(), Rc::new(NoRestrictionBuilder {}));
+        builder.add_frontier_model("road_class".to_string(), Rc::new(RoadClassBuilder {}));
+        builder.add_frontier_model("turn_restriction".to_string(), Rc::new(TurnRestrictionBuilder {}));
+        builder.add_frontier_model("battery_frontier".to_string(), Rc::new(BatteryFrontierBuilder::default()));
+        builder.add_frontier_model("vehicle_restriction".to_string(), Rc::new(VehicleRestrictionBuilder {}));
+        builder.add_label_model("vertex_label".to_string(), Rc::new(VertexLabelModelBuilder));
+        builder.add_label_model("soc_label".to_string(), Rc::new(SOCLabelModelBuilder));
+        builder.add_input_plugin("grid_search".to_string(), Rc::new(GridSearchBuilder {}));
+        builder.add_input_plugin("load_balancer".to_string(), Rc::new(LoadBalancerBuilder {}));
+        builder.add_input_plugin("inject".to_string(), Rc::new(InjectPluginBuilder {}));
+        builder.add_input_plugin("debug".to_string(), Rc::new(DebugInputPluginBuilder {}));
+        builder.add_output_plugin("traversal".to_string(), Rc::new(TraversalPluginBuilder {}));
+        builder.add_output_plugin("summary".to_string(), Rc::new(SummaryOutputPluginBuilder {}));
+        builder.add_output_plugin("uuid".to_string(), Rc::new(UUIDOutputPluginBuilder {}));
+        Ok(())
+    })
+}
+
 
 /// Upstream component factory of [`crate::app::compass::compass_app::CompassApp`]
 /// that builds components when constructing a CompassApp instance.
 ///
 /// A [`CompassAppBuilder`] instance is typically created via the [`CompassAppBuilder::default']
 /// method, which provides builders for commonly-used components.
-/// Alternatively, there is a [`CompassAppBuilder::new'] method to build an empty instance.
+/// Alternatively, there is a [`CompassAppBuilder::new'] method to build an empty instance
 /// Custom builder types can be added to an instance of CompassAppBuilder and
 /// then loaded into a CompassApp when the configuration TOML input provides a `type` argument
 /// signaling the key associated with the builder below.
@@ -76,34 +115,31 @@ use super::CompassComponentError;
 /// It is only once these are referenced during CompassApp construction that files and models
 /// will be loaded and CPU/RAM impacted.
 ///
-/// # Arguments
-///
-/// * `tm_builders` - a mapping of TraversalModel `type` names to builders
-/// * `frontier_builders` - a mapping of FrontierModel `type` names to builders
-/// * `input_plugin_builders` - a mapping of InputPlugin `type` names to builders
-/// * `output_plugin_builders` - a mapping of OutputPlugin `type` names to builders
-///
 pub struct CompassAppBuilder {
-    pub traversal_model_builders: HashMap<String, Rc<dyn TraversalModelBuilder>>,
-    pub access_model_builders: HashMap<String, Rc<dyn AccessModelBuilder>>,
-    pub frontier_model_builders: HashMap<String, Rc<dyn FrontierModelBuilder>>,
-    pub label_model_builders: HashMap<String, Rc<dyn LabelModelBuilder>>,
-    pub input_plugin_builders: HashMap<String, Rc<dyn InputPluginBuilder>>,
-    pub output_plugin_builders: HashMap<String, Rc<dyn OutputPluginBuilder>>,
+    traversal_model_builders: HashMap<String, Rc<dyn TraversalModelBuilder>>,
+    access_model_builders: HashMap<String, Rc<dyn AccessModelBuilder>>,
+    frontier_model_builders: HashMap<String, Rc<dyn FrontierModelBuilder>>,
+    label_model_builders: HashMap<String, Rc<dyn LabelModelBuilder>>,
+    input_plugin_builders: HashMap<String, Rc<dyn InputPluginBuilder>>,
+    output_plugin_builders: HashMap<String, Rc<dyn OutputPluginBuilder>>,
 }
 
+
+
 impl CompassAppBuilder {
-    /// Build an empty [`CompassAppBuilder`] instance.
+    /// Build an empty [`CompassAppBuilder`] instance. does not inject any builders
+    /// submitted by this or downstream libraries using [`inventory::submit!`].
+    /// 
     /// If no additional builders are added, this will be unable to create
     /// components for a [`crate::app::compass::compass_app::CompassApp`],
-    /// so this method is only useful is seeking a blank page for customizing.
-    /// the [`CompassAppBuilder::default`] method provides the default builder set and is a better
-    /// starting point.
+    /// so this method is only useful is seeking a blank slate for customizing.
+    /// the [`CompassAppBuilder::default`] method provides the default builder set and is
+    /// the preferred method.
     ///
     /// # Returns
     ///
     /// * an instance of a CompassAppBuilder that can be used to build a CompassApp
-    pub fn new() -> CompassAppBuilder {
+    pub fn empty() -> CompassAppBuilder {
         CompassAppBuilder {
             traversal_model_builders: HashMap::new(),
             access_model_builders: HashMap::new(),
@@ -112,6 +148,21 @@ impl CompassAppBuilder {
             input_plugin_builders: HashMap::new(),
             output_plugin_builders: HashMap::new(),
         }
+    }
+
+    /// creates a new [`CompassAppBuilder`] with all registered builder objects injected from any [`inventory`] submissions.
+    ///
+    /// # Returns
+    ///
+    /// * an instance of a [`CompassAppBuilder`] with all injected builders
+    pub fn new() -> Result<CompassAppBuilder, CompassConfigurationError> {
+        let mut builder = Self::empty();
+
+        // Iterate through all registered plugins
+        for plugin_reg in inventory::iter::<PluginRegistration> {
+            (plugin_reg.0)(&mut builder)?;
+        }
+        Ok(builder)
     }
 
     pub fn add_traversal_model(&mut self, name: String, builder: Rc<dyn TraversalModelBuilder>) {
@@ -299,101 +350,3 @@ impl CompassAppBuilder {
     }
 }
 
-impl Default for CompassAppBuilder {
-    /// Builds the default builder.
-    /// All components present in the routee-compass library are injected here
-    /// into a builder instance with their expected `type` keys.
-    ///
-    /// The Combined variants which allow stringing together multiple models of
-    /// the same type are automatically made available when constructing an instance of CompassApp.
-    ///
-    /// # Returns
-    ///
-    /// * an instance of a CompassAppBuilder that can be used to build a CompassApp
-    fn default() -> Self {
-        // Traversal model builders
-        let distance: Rc<dyn TraversalModelBuilder> = Rc::new(DistanceTraversalBuilder {});
-        let speed: Rc<dyn TraversalModelBuilder> = Rc::new(SpeedTraversalBuilder {});
-        let time: Rc<dyn TraversalModelBuilder> = Rc::new(TimeTraversalBuilder {});
-        let grade: Rc<dyn TraversalModelBuilder> = Rc::new(GradeTraversalBuilder {});
-        let elevation: Rc<dyn TraversalModelBuilder> = Rc::new(ElevationTraversalBuilder {});
-        let energy: Rc<dyn TraversalModelBuilder> = Rc::new(EnergyModelBuilder {});
-        let simple_charging = Rc::new(SimpleChargingBuilder::default());
-        let custom: Rc<dyn TraversalModelBuilder> = Rc::new(CustomTraversalBuilder {});
-        let traversal_model_builders: HashMap<String, Rc<dyn TraversalModelBuilder>> =
-            HashMap::from([
-                (String::from("distance"), distance),
-                (String::from("speed"), speed),
-                (String::from("time"), time),
-                (String::from("grade"), grade),
-                (String::from("elevation"), elevation),
-                (String::from("energy"), energy),
-                (String::from("simple_charging"), simple_charging),
-                (String::from("custom"), custom),
-            ]);
-
-        // Access model builders
-        let no_access_model: Rc<dyn AccessModelBuilder> = Rc::new(NoAccessModel {});
-        let turn_delay: Rc<dyn AccessModelBuilder> = Rc::new(TurnDelayAccessModelBuilder {});
-        let access_model_builders: HashMap<String, Rc<dyn AccessModelBuilder>> = HashMap::from([
-            (String::from("no_access_model"), no_access_model),
-            (String::from("turn_delay"), turn_delay),
-        ]);
-
-        // Frontier model builders
-        let no_restriction: Rc<dyn FrontierModelBuilder> = Rc::new(NoRestrictionBuilder {});
-        let road_class: Rc<dyn FrontierModelBuilder> = Rc::new(RoadClassBuilder {});
-        let turn_restriction: Rc<dyn FrontierModelBuilder> = Rc::new(TurnRestrictionBuilder {});
-        let battery_frontier: Rc<dyn FrontierModelBuilder> =
-            Rc::new(BatteryFrontierBuilder::default());
-        let vehicle_restriction: Rc<dyn FrontierModelBuilder> =
-            Rc::new(VehicleRestrictionBuilder {});
-        let frontier_model_builders: HashMap<String, Rc<dyn FrontierModelBuilder>> =
-            HashMap::from([
-                (String::from("no_restriction"), no_restriction),
-                (String::from("road_class"), road_class),
-                (String::from("turn_restriction"), turn_restriction),
-                (String::from("vehicle_restriction"), vehicle_restriction),
-                (String::from("battery_frontier"), battery_frontier),
-            ]);
-
-        // Label model builders
-        let vertex_label: Rc<dyn LabelModelBuilder> = Rc::new(VertexLabelModelBuilder);
-        let soc_label = Rc::new(SOCLabelModelBuilder);
-        let label_model_builders: HashMap<String, Rc<dyn LabelModelBuilder>> = HashMap::from([
-            (String::from("vertex"), vertex_label),
-            (String::from("soc"), soc_label),
-        ]);
-
-        // Input plugin builders
-        let grid_search: Rc<dyn InputPluginBuilder> = Rc::new(GridSearchBuilder {});
-        let load_balancer: Rc<dyn InputPluginBuilder> = Rc::new(LoadBalancerBuilder {});
-        let inject: Rc<dyn InputPluginBuilder> = Rc::new(InjectPluginBuilder {});
-        let debug: Rc<dyn InputPluginBuilder> = Rc::new(DebugInputPluginBuilder {});
-        let input_plugin_builders = HashMap::from([
-            (String::from("grid_search"), grid_search),
-            (String::from("load_balancer"), load_balancer),
-            (String::from("inject"), inject),
-            (String::from("debug"), debug),
-        ]);
-
-        // Output plugin builders
-        let traversal: Rc<dyn OutputPluginBuilder> = Rc::new(TraversalPluginBuilder {});
-        let summary: Rc<dyn OutputPluginBuilder> = Rc::new(SummaryOutputPluginBuilder {});
-        let uuid: Rc<dyn OutputPluginBuilder> = Rc::new(UUIDOutputPluginBuilder {});
-        let output_plugin_builders = HashMap::from([
-            (String::from("traversal"), traversal),
-            (String::from("summary"), summary),
-            (String::from("uuid"), uuid),
-        ]);
-
-        CompassAppBuilder {
-            traversal_model_builders,
-            access_model_builders,
-            frontier_model_builders,
-            label_model_builders,
-            input_plugin_builders,
-            output_plugin_builders,
-        }
-    }
-}

--- a/rust/routee-compass/src/app/compass/compass_app_builder.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_builder.rs
@@ -1,4 +1,5 @@
-use crate::{plugin::{
+use super::CompassComponentError;
+use crate::plugin::{
     input::{
         default::{
             debug::DebugInputPluginBuilder, grid_search::GridSearchBuilder,
@@ -13,7 +14,8 @@ use crate::{plugin::{
         },
         OutputPlugin, OutputPluginBuilder,
     },
-}};
+};
+use inventory;
 use itertools::Itertools;
 use routee_compass_core::model::{
     access::{
@@ -58,14 +60,13 @@ use routee_compass_powertrain::model::{
     EnergyModelBuilder,
 };
 use std::{collections::HashMap, rc::Rc, sync::Arc};
-use inventory;
-use super::CompassComponentError;
 
 /// provides a plugin API for downstream libraries to inject values into the CompassAppBuilder.
 /// for details, see the [`inventory`] crate.
-pub struct PluginRegistration(pub fn(&mut CompassAppBuilder) -> Result<(), CompassConfigurationError>);
+pub struct PluginRegistration(
+    pub fn(&mut CompassAppBuilder) -> Result<(), CompassConfigurationError>,
+);
 inventory::collect!(PluginRegistration);
-
 
 // this macro will register the default set of builders with inventory. these are iterated through in the CompassAppBuilder::new method
 // along with any plugins registered by downstream libraries.
@@ -99,7 +100,6 @@ inventory::submit! {
     })
 }
 
-
 /// Upstream component factory of [`crate::app::compass::compass_app::CompassApp`]
 /// that builds components when constructing a CompassApp instance.
 ///
@@ -124,12 +124,10 @@ pub struct CompassAppBuilder {
     output_plugin_builders: HashMap<String, Rc<dyn OutputPluginBuilder>>,
 }
 
-
-
 impl CompassAppBuilder {
     /// Build an empty [`CompassAppBuilder`] instance. does not inject any builders
     /// submitted by this or downstream libraries using [`inventory::submit!`].
-    /// 
+    ///
     /// If no additional builders are added, this will be unable to create
     /// components for a [`crate::app::compass::compass_app::CompassApp`],
     /// so this method is only useful is seeking a blank slate for customizing.
@@ -349,4 +347,3 @@ impl CompassAppBuilder {
         Ok(plugins)
     }
 }
-

--- a/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
+++ b/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
@@ -73,7 +73,7 @@ inventory::collect!(BuilderRegistration);
 // along with any plugins registered by downstream libraries.
 inventory::submit! {
     BuilderRegistration(|builder| {
-        builder.add_traversal_model(String::from("distance"),  Rc::new(DistanceTraversalBuilder {}));
+        builder.add_traversal_model("distance".to_string(),  Rc::new(DistanceTraversalBuilder {}));
         builder.add_traversal_model("speed".to_string(), Rc::new(SpeedTraversalBuilder {}));
         builder.add_traversal_model("time".to_string(), Rc::new(TimeTraversalBuilder {}));
         builder.add_traversal_model("grade".to_string(), Rc::new(GradeTraversalBuilder {}));

--- a/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
+++ b/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
@@ -88,8 +88,8 @@ inventory::submit! {
         builder.add_frontier_model("turn_restriction".to_string(), Rc::new(TurnRestrictionBuilder {}));
         builder.add_frontier_model("battery_frontier".to_string(), Rc::new(BatteryFrontierBuilder::default()));
         builder.add_frontier_model("vehicle_restriction".to_string(), Rc::new(VehicleRestrictionBuilder {}));
-        builder.add_label_model("vertex_label".to_string(), Rc::new(VertexLabelModelBuilder));
-        builder.add_label_model("soc_label".to_string(), Rc::new(SOCLabelModelBuilder));
+        builder.add_label_model("vertex".to_string(), Rc::new(VertexLabelModelBuilder));
+        builder.add_label_model("soc".to_string(), Rc::new(SOCLabelModelBuilder));
         builder.add_input_plugin("grid_search".to_string(), Rc::new(GridSearchBuilder {}));
         builder.add_input_plugin("load_balancer".to_string(), Rc::new(LoadBalancerBuilder {}));
         builder.add_input_plugin("inject".to_string(), Rc::new(InjectPluginBuilder {}));

--- a/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
+++ b/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
@@ -62,7 +62,7 @@ use routee_compass_powertrain::model::{
 use std::{collections::HashMap, rc::Rc, sync::Arc};
 
 /// provides a plugin API for downstream libraries to inject values into the CompassAppBuilder.
-/// for details, see the [`inventory`] crate. must be a "type" defined in this crate in order to 
+/// for details, see the [`inventory`] crate. must be a "type" defined in this crate in order to
 /// get used at compile time, hence it's a struct.
 pub struct BuilderRegistration(
     pub fn(&mut CompassBuilderInventory) -> Result<(), CompassConfigurationError>,

--- a/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
+++ b/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
@@ -61,7 +61,7 @@ use routee_compass_powertrain::model::{
 };
 use std::{collections::HashMap, rc::Rc, sync::Arc};
 
-/// provides a plugin API for downstream libraries to inject values into the CompassAppBuilder.
+/// provides a plugin API for downstream libraries to inject values into the CompassBuilderInventory.
 /// for details, see the [`inventory`] crate. must be a "type" defined in this crate in order to
 /// get used at compile time, hence it's a struct.
 pub struct BuilderRegistration(
@@ -69,7 +69,7 @@ pub struct BuilderRegistration(
 );
 inventory::collect!(BuilderRegistration);
 
-// this macro will register the default set of builders with inventory. these are iterated through in the CompassAppBuilder::new method
+// this macro will register the default set of builders with inventory. these are iterated through in the CompassBuilderInventory::new method
 // along with any plugins registered by downstream libraries.
 inventory::submit! {
     BuilderRegistration(|builder| {
@@ -81,8 +81,8 @@ inventory::submit! {
         builder.add_traversal_model("energy".to_string(), Rc::new(EnergyModelBuilder {}));
         builder.add_traversal_model("simple_charging".to_string(), Rc::new(SimpleChargingBuilder::default()));
         builder.add_traversal_model("custom".to_string(), Rc::new(CustomTraversalBuilder {}));
-        builder.add_access_model("no_access_model".to_string(),Rc::new(NoAccessModel {}));
-        builder.add_access_model("turn_delay".to_string(),Rc::new(TurnDelayAccessModelBuilder {}));
+        builder.add_access_model("no_access_model".to_string(), Rc::new(NoAccessModel {}));
+        builder.add_access_model("turn_delay".to_string(), Rc::new(TurnDelayAccessModelBuilder {}));
         builder.add_frontier_model("no_restriction".to_string(), Rc::new(NoRestrictionBuilder {}));
         builder.add_frontier_model("road_class".to_string(), Rc::new(RoadClassBuilder {}));
         builder.add_frontier_model("turn_restriction".to_string(), Rc::new(TurnRestrictionBuilder {}));
@@ -104,10 +104,10 @@ inventory::submit! {
 /// Upstream component factory of [`crate::app::compass::compass_app::CompassApp`]
 /// that builds components when constructing a CompassApp instance.
 ///
-/// A [`CompassAppBuilder`] instance is typically created via the [`CompassAppBuilder::default']
+/// A [`CompassBuilderInventory`] instance is typically created via the [`CompassBuilderInventory::new']
 /// method, which provides builders for commonly-used components.
-/// Alternatively, there is a [`CompassAppBuilder::new'] method to build an empty instance
-/// Custom builder types can be added to an instance of CompassAppBuilder and
+/// Alternatively, there is a [`CompassBuilderInventory::new'] method to build an empty instance
+/// Custom builder types can be added to an instance of CompassBuilderInventory and
 /// then loaded into a CompassApp when the configuration TOML input provides a `type` argument
 /// signaling the key associated with the builder below.
 ///
@@ -126,18 +126,18 @@ pub struct CompassBuilderInventory {
 }
 
 impl CompassBuilderInventory {
-    /// Build an empty [`CompassAppBuilder`] instance. does not inject any builders
+    /// Build an empty [`CompassBuilderInventory`] instance. does not inject any builders
     /// submitted by this or downstream libraries using [`inventory::submit!`].
     ///
     /// If no additional builders are added, this will be unable to create
     /// components for a [`crate::app::compass::compass_app::CompassApp`],
     /// so this method is only useful is seeking a blank slate for customizing.
-    /// the [`CompassAppBuilder::default`] method provides the default builder set and is
+    /// the [`CompassBuilderInventory::new`] method provides the default builder set and is
     /// the preferred method.
     ///
     /// # Returns
     ///
-    /// * an instance of a CompassAppBuilder that can be used to build a CompassApp
+    /// * an instance of a CompassBuilderInventory that can be used to build a CompassApp
     pub fn empty() -> CompassBuilderInventory {
         CompassBuilderInventory {
             traversal_model_builders: HashMap::new(),
@@ -149,11 +149,11 @@ impl CompassBuilderInventory {
         }
     }
 
-    /// creates a new [`CompassAppBuilder`] with all registered builder objects injected from any [`inventory`] submissions.
+    /// creates a new [`CompassBuilderInventory`] with all registered builder objects injected from any [`inventory`] submissions.
     ///
     /// # Returns
     ///
-    /// * an instance of a [`CompassAppBuilder`] with all injected builders
+    /// * an instance of a [`CompassBuilderInventory`] with all injected builders
     pub fn new() -> Result<CompassBuilderInventory, CompassConfigurationError> {
         let mut builder = Self::empty();
 

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -1,14 +1,14 @@
 pub mod compass_app;
-mod compass_builder_inventory;
 pub mod compass_app_configuration;
 mod compass_app_error;
 pub mod compass_app_ops;
+mod compass_builder_inventory;
 pub mod compass_component_error;
 pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod response;
 
+pub use compass_app_error::CompassAppError;
 pub use compass_builder_inventory::BuilderRegistration;
 pub use compass_builder_inventory::CompassBuilderInventory;
-pub use compass_app_error::CompassAppError;
 pub use compass_component_error::CompassComponentError;

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -1,5 +1,5 @@
 pub mod compass_app;
-mod compass_app_builder;
+mod compass_builder_inventory;
 pub mod compass_app_configuration;
 mod compass_app_error;
 pub mod compass_app_ops;
@@ -8,7 +8,7 @@ pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod response;
 
-pub use compass_app_builder::PluginRegistration;
-pub use compass_app_builder::CompassAppBuilder;
+pub use compass_builder_inventory::BuilderRegistration;
+pub use compass_builder_inventory::CompassBuilderInventory;
 pub use compass_app_error::CompassAppError;
 pub use compass_component_error::CompassComponentError;

--- a/rust/routee-compass/src/app/compass/mod.rs
+++ b/rust/routee-compass/src/app/compass/mod.rs
@@ -8,6 +8,7 @@ pub mod compass_input_field;
 pub mod compass_json_extensions;
 pub mod response;
 
+pub use compass_app_builder::PluginRegistration;
 pub use compass_app_builder::CompassAppBuilder;
 pub use compass_app_error::CompassAppError;
 pub use compass_component_error::CompassComponentError;

--- a/rust/routee-compass/src/doc.md
+++ b/rust/routee-compass/src/doc.md
@@ -53,10 +53,10 @@ For more information, see[`crate::plugin::output`].
 
 A RouteE Compass app exists as a value of type [CompassApp] on a given system.
 An instance can be built using one of two `try_from` methods:
-  1. from a path, which assumes the default [CompassAppBuilder]
-  2. from an instance of [Config](https://docs.rs/config/latest/config/) along with a (possibly customized) [CompassAppBuilder]
+  1. from a path, which assumes the default [CompassBuilderInventory]
+  2. from an instance of [Config](https://docs.rs/config/latest/config/) along with a (possibly customized) [CompassBuilderInventory]
 
-Customizing a [CompassAppBuilder] is the extension point for adding 3rd party extensions to [CompassApp].
+Customizing a [CompassBuilderInventory] is the extension point for adding 3rd party extensions to [CompassApp].
 If this is not needed, then sticking to the default is sufficient, via the `CompassApp::try_from(path)` builder method.
 
 #### Running queries on CompassApp
@@ -99,8 +99,8 @@ Memory requirements for the CompassApp at this time are not reported.
 In order to add capabilities to Compass, you can choose from a number of trait objects to implement your solution.
 The way this is typically done is as follows:
   1. write custom models or input plugins
-  2. create a [CompassAppBuilder] object and inject your custom modules into it
-  3. create your own run application (such as a `fn main`) which uses your [CompassAppBuilder] to create a [CompassApp]
+  2. create a [CompassBuilderInventory] object and inject your custom modules into it
+  3. create your own run application (such as a `fn main`) which uses your [CompassBuilderInventory] to create a [CompassApp]
 
 #### Custom Models
 
@@ -128,7 +128,7 @@ For examples, review the implementation of the built-in plugins:
 [CompassApp]: crate::app::compass::CompassApp
 [SearchApp]: crate::app::search::SearchApp
 [SearchInstance]: routee_compass_core::algorithm::search::SearchInstance
-[CompassAppBuilder]: crate::app::compass::CompassAppBuilder
+[CompassBuilderInventory]: crate::app::compass::CompassBuilderInventory
 
 [traversal]: routee_compass_core::model::traversal
 [access]: routee_compass_core::model::access

--- a/rust/routee-compass/src/main.rs
+++ b/rust/routee-compass/src/main.rs
@@ -2,13 +2,13 @@ use clap::Parser;
 use log::error;
 use routee_compass::app::cli::cli_args::CliArgs;
 use routee_compass::app::cli::run;
-use routee_compass::app::compass::CompassAppBuilder;
+use routee_compass::app::compass::CompassBuilderInventory;
 
 fn main() {
     env_logger::init();
 
     let args = CliArgs::parse();
-    let builder = CompassAppBuilder::new().expect("failed to load compass app builder");
+    let builder = CompassBuilderInventory::new().expect("failed to load compass app builder");
     match run::command_line_runner(&args, Some(builder), None) {
         Ok(_) => {}
         Err(e) => {

--- a/rust/routee-compass/src/main.rs
+++ b/rust/routee-compass/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     env_logger::init();
 
     let args = CliArgs::parse();
-    let builder = CompassAppBuilder::default();
+    let builder = CompassAppBuilder::new().expect("failed to load compass app builder");
     match run::command_line_runner(&args, Some(builder), None) {
         Ok(_) => {}
         Err(e) => {


### PR DESCRIPTION
this PR integrates the [inventory](https://crates.io/crates/inventory) crate, which allows downstream libraries to inject builders at compile time. in order to leverage this, a downstream library will want to register builders in it's lib.rs file:

```rust
use routee_compass::app::compass::BuilderRegistration;
use inventory;
use std::rc::Rc;

inventory::submit! {
  BuilderRegistration(|builders| {
    builders.add_traversal_model("my_model".to_string(), Rc::new(MyModelTraversalBuilder {});
    // ... more here, call any add* methods on the builders object
    Ok(())
  })
}
```

use of this is demonstrated in the routee_compass::app::compass::compass_builder_inventory file.

along the way, a few breaking changes:
  - CompassAppBuilder renamed to `CompassBuilderInventory` to disambiguate from the builders that it contains and to clarify it doesn't follow the Builder design pattern 
  - CompassAppBuilder::default() method was removed in order to make a clearer distinction on how to create a `new` builder (with all injected values) or an `empty` one, if needed
    - it is still possible to build a CompassBuilderInventory entirely from it's add methods, for example for testing
  - CompassApp::try_from((&Config, &CompassAppBuilder)) replaced with CompassApp::new(&Config, &CompassAppBuilder)

