### PR TITLE
Rjf/test traversal model fix

### DIFF
--- a/rust/routee-compass-core/src/testing/mock/traversal_model.rs
+++ b/rust/routee-compass-core/src/testing/mock/traversal_model.rs
@@ -90,16 +90,25 @@ impl MockUpstreamModel {
                         output_unit: None,
                     },
                 ),
-                InputFeature::Custom { name, unit: _ } => (
-                    name.clone(),
-                    StateVariableConfig::Custom {
-                        custom_type: name.clone(),
-                        accumulator: false,
-                        value: CustomVariableConfig::FloatingPoint {
-                            initial: ordered_float::OrderedFloat(0.0),
+                InputFeature::Custom { name, unit } => {
+                    // only current way to hook in custom unit type
+                    use CustomVariableConfig as C;
+                    let var_config = match unit.as_str() {
+                        "FloatingPoint" => C::FloatingPoint { initial: ordered_float::OrderedFloat(0.0) },
+                        "SignedInteger" => C::SignedInteger { initial: 0 },
+                        "UnsignedInteger" => C::UnsignedInteger { initial: 0 },
+                        "Boolean" => C::Boolean { initial: false },
+                        _ => C::FloatingPoint { initial: ordered_float::OrderedFloat(0.0) },
+                    };
+                    (
+                        name.clone(),
+                        StateVariableConfig::Custom {
+                            custom_type: name.clone(),
+                            accumulator: false,
+                            value: var_config,
                         },
-                    },
-                ),
+                    )
+                },
             })
             .collect();
         Self {

--- a/rust/routee-compass-core/src/testing/mock/traversal_model.rs
+++ b/rust/routee-compass-core/src/testing/mock/traversal_model.rs
@@ -94,12 +94,12 @@ impl MockUpstreamModel {
                     // only current way to hook in custom unit type
                     use CustomVariableConfig as C;
                     let var_config = match unit.as_str() {
-                        "FloatingPoint" => C::FloatingPoint {
+                        "floating_point" => C::FloatingPoint {
                             initial: ordered_float::OrderedFloat(0.0),
                         },
-                        "SignedInteger" => C::SignedInteger { initial: 0 },
-                        "UnsignedInteger" => C::UnsignedInteger { initial: 0 },
-                        "Boolean" => C::Boolean { initial: false },
+                        "signed_integer" => C::SignedInteger { initial: 0 },
+                        "unsigned_integer" => C::UnsignedInteger { initial: 0 },
+                        "boolean" => C::Boolean { initial: false },
                         _ => C::FloatingPoint {
                             initial: ordered_float::OrderedFloat(0.0),
                         },

--- a/rust/routee-compass-core/src/testing/mock/traversal_model.rs
+++ b/rust/routee-compass-core/src/testing/mock/traversal_model.rs
@@ -94,11 +94,15 @@ impl MockUpstreamModel {
                     // only current way to hook in custom unit type
                     use CustomVariableConfig as C;
                     let var_config = match unit.as_str() {
-                        "FloatingPoint" => C::FloatingPoint { initial: ordered_float::OrderedFloat(0.0) },
+                        "FloatingPoint" => C::FloatingPoint {
+                            initial: ordered_float::OrderedFloat(0.0),
+                        },
                         "SignedInteger" => C::SignedInteger { initial: 0 },
                         "UnsignedInteger" => C::UnsignedInteger { initial: 0 },
                         "Boolean" => C::Boolean { initial: false },
-                        _ => C::FloatingPoint { initial: ordered_float::OrderedFloat(0.0) },
+                        _ => C::FloatingPoint {
+                            initial: ordered_float::OrderedFloat(0.0),
+                        },
                     };
                     (
                         name.clone(),
@@ -108,7 +112,7 @@ impl MockUpstreamModel {
                             value: var_config,
                         },
                     )
-                },
+                }
             })
             .collect();
         Self {


### PR DESCRIPTION
this quick fix PR assists users of the TestTraversalModel, which is designed to inject mock upstream dependencies on TraversalModels based on the InputFeatures. during this, in the case of custom features, there is no mechanism to select the _type_ of custom features to inject, so FloatingPoint is selected. this breaks tests for any models under test that depend on non-FP custom values. 

as a work-around, we can read the `unit` string of the custom input feature and match it against the snake_case name of the `CustomVariableConfig` variant.