### PR TITLE
normalize python project name for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "nrel.routee.compass"
+name = "nrel_routee_compass"
 version = "0.15.0"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"


### PR DESCRIPTION
updates project name in pyproject.toml to match pypi requirements (deprecated dot-delimited naming patterns) in response to [failed CD operation](https://github.com/NREL/routee-compass/actions/runs/18890786034/job/53918698740) publishing version 0.15.0 to pypi.