### PR TITLE
allow newline json without chunksize

### DIFF
--- a/rust/routee-compass/src/app/cli/run.rs
+++ b/rust/routee-compass/src/app/cli/run.rs
@@ -50,17 +50,14 @@ pub fn command_line_runner(
 
     // execute queries on app
     match (args.chunksize, args.newline_delimited) {
-        (None, true) => Err(CompassAppError::InternalError(String::from(
-            "invalid argument combination should have been caught during CLI validation",
-        ))),
         (None, false) => run_json(&query_file, &compass_app, run_config),
-        (Some(_), true) => {
-            let chunksize = args.get_chunksize_option()?;
-            run_newline_json(&query_file, chunksize, &compass_app, run_config)
-        }
         (Some(_), false) => Err(CompassAppError::InternalError(String::from(
             "not yet implemented",
         ))),
+        (_, true) => {
+            let chunksize = args.get_chunksize_option()?;
+            run_newline_json(&query_file, chunksize, &compass_app, run_config)
+        }
     }
 }
 


### PR DESCRIPTION
Closes #412 by allowing the `--newline-delimited` flag without specifying a `--chunksize` argument. if no chunksize is specified, chunsize is set to MAX (one big chunk).