### PR TITLE
Allow parallelism and output file to be set at CLI

### DIFF
--- a/rust/routee-compass/src/app/cli/cli_args.rs
+++ b/rust/routee-compass/src/app/cli/cli_args.rs
@@ -24,9 +24,10 @@ pub struct CliArgs {
     #[arg(short, long)]
     pub parallelism: Option<usize>,
 
-    /// Override output filename from config file
-    #[arg(short, long, value_name = "FILE")]
-    pub output_file: Option<String>,
+    /// Override output directory for all output files. output filenames in config will be
+    /// treated as filenames only and written to this directory.
+    #[arg(short, long, value_name = "DIR")]
+    pub output_directory: Option<String>,
 }
 
 impl CliArgs {


### PR DESCRIPTION
A small change to enable a CLI override of the `parallelism` and `output_file` parameters that are typically set in the config. This allows for ease of changing runtime parameters without changing the config. 