### PR TITLE
address error cases where transparent error propagation creates ambiguity

### DIFF
--- a/rust/routee-compass-core/src/config/compass_configuration_error.rs
+++ b/rust/routee-compass-core/src/config/compass_configuration_error.rs
@@ -52,11 +52,11 @@ pub enum CompassConfigurationError {
     InsertError(String),
     #[error(transparent)]
     GraphError(#[from] NetworkError),
-    #[error(transparent)]
+    #[error("IO error while loading configuration: {0}")]
     IoError(#[from] std::io::Error),
-    #[error(transparent)]
+    #[error("failed to deserialize configuration JSON: {0}")]
     SerdeDeserializationError(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("unit/value conversion error during configuration: {0}")]
     ConversionError(#[from] ConversionError),
     #[error(transparent)]
     TraversalModelError(#[from] TraversalModelError),

--- a/rust/routee-compass-core/src/util/conversion/conversion_error.rs
+++ b/rust/routee-compass-core/src/util/conversion/conversion_error.rs
@@ -4,13 +4,13 @@ use std::num::ParseIntError;
 pub enum ConversionError {
     #[error("could not decode {0} as {1}")]
     DecoderError(String, String),
-    #[error(transparent)]
+    #[error("JSON serialization/deserialization error during value conversion: {source}")]
     SerdeJsonError {
         #[from]
         source: serde_json::Error,
     },
-    #[error(transparent)]
+    #[error("regex compilation error during conversion: {0}")]
     RegexError(#[from] regex::Error),
-    #[error(transparent)]
+    #[error("failed to parse integer during conversion: {0}")]
     ParseIntError(#[from] ParseIntError),
 }

--- a/rust/routee-compass/src/app/mapping/mapping_app_error.rs
+++ b/rust/routee-compass/src/app/mapping/mapping_app_error.rs
@@ -2,7 +2,7 @@ use routee_compass_core::model::{map::MapError, network::EdgeId};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MappingAppError {
-    #[error(transparent)]
+    #[error("map error during route geometry mapping: {0}")]
     MapError(#[from] MapError),
     #[error("expecting edge id {0} not found")]
     InvalidEdgeId(EdgeId),


### PR DESCRIPTION
this tiny PR adds error message prefixes to some errors which previously used transparent propagation, in an effort to provide additional context on these errors. the transparent keyword is still used when no additional context is required.