### PR TITLE
Rjf/state model contains key

### DIFF
--- a/rust/routee-compass-core/src/model/state/state_model.rs
+++ b/rust/routee-compass-core/src/model/state/state_model.rs
@@ -110,7 +110,7 @@ impl StateModel {
         self.0.is_empty()
     }
 
-    pub fn contains_key(&self, k: &String) -> bool {
+    pub fn contains_key(&self, k: &str) -> bool {
         self.0.contains_key(k)
     }
 

--- a/rust/routee-compass-powertrain/src/model/charging/battery/model.rs
+++ b/rust/routee-compass-powertrain/src/model/charging/battery/model.rs
@@ -20,7 +20,7 @@ impl ConstraintModel for BatteryFilter {
         state: &[StateVariable],
         state_model: &StateModel,
     ) -> Result<bool, ConstraintModelError> {
-        if !state_model.contains_key(&fieldname::TRIP_SOC.to_string()) {
+        if !state_model.contains_key(fieldname::TRIP_SOC) {
             // if we don't have the trip_soc, then this frontier is valid
             return Ok(true);
         }

--- a/rust/routee-compass/src/app/cli/run.rs
+++ b/rust/routee-compass/src/app/cli/run.rs
@@ -111,13 +111,13 @@ pub fn command_line_runner(
 
     // execute queries on app
     let result = match (args.chunksize, args.newline_delimited) {
-        (None, false) => run_json(&query_file_path, &compass_app, run_config),
+        (None, false) => run_json(query_file_path, &compass_app, run_config),
         (Some(_), false) => Err(CompassAppError::InternalError(String::from(
             "not yet implemented",
         ))),
         (_, true) => {
             let chunksize = args.get_chunksize_option()?;
-            run_newline_json(&query_file_path, chunksize, &compass_app, run_config)
+            run_newline_json(query_file_path, chunksize, &compass_app, run_config)
         }
     };
 


### PR DESCRIPTION
super little PR here to adjust the signature of `state_model.contains_key` so that it takes a &str instead of a &String. to get around allocating the string "route_id" at every search iteration in bambam, i need to use a [static allocation of a String via OnceLock](https://github.com/NatLabRockies/bambam/pull/126/changes#diff-38b7248da455d2f233f5ef79a66403e803646dd6eaa6afa982e3b268ac9347afR2), which is silly.