### PR TITLE
Rjf/fail fast map matching

### DIFF
--- a/rust/routee-compass-core/src/algorithm/map_matching/model/lcss/lcss_ops.rs
+++ b/rust/routee-compass-core/src/algorithm/map_matching/model/lcss/lcss_ops.rs
@@ -147,7 +147,7 @@ pub(crate) fn find_candidates(
 
     let mut candidates = Vec::new();
     for result in nearest_iter {
-        match result {
+        match result? {
             NearestSearchResult::NearestEdge(list_id, eid) => {
                 let distance = compute_distance_to_edge(point, &list_id, &eid, si);
                 candidates.push((list_id, eid, distance));

--- a/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
+++ b/rust/routee-compass-core/src/algorithm/search/a_star/a_star_algorithm.rs
@@ -349,7 +349,7 @@ mod tests {
     }
 
     fn build_search_instance(graph: Arc<Graph>) -> SearchInstance {
-        let map_model = Arc::new(MapModel::new(graph.clone(), &MapModelConfig::default()).unwrap());
+        let map_model = Arc::new(MapModel::new(graph.clone(), MapModelConfig::default()).unwrap());
         let traversal_model = Arc::new(DistanceTraversalModel::new(DistanceUnit::default(), true));
 
         // setup the graph, traversal model, and a* heuristic to be shared across the queries in parallel

--- a/rust/routee-compass-core/src/model/map/map_model.rs
+++ b/rust/routee-compass-core/src/model/map/map_model.rs
@@ -19,10 +19,12 @@ pub struct MapModel {
     /// allow for queries without a destination location, such as when generating
     /// shortest path trees or isochrones.
     pub queries_without_destinations: bool,
+    /// the configuration used to create this map model
+    pub config: MapModelConfig,
 }
 
 impl MapModel {
-    pub fn new(graph: Arc<Graph>, config: &MapModelConfig) -> Result<MapModel, MapError> {
+    pub fn new(graph: Arc<Graph>, config: MapModelConfig) -> Result<MapModel, MapError> {
         let geometry = config
             .geometry
             .iter()
@@ -56,6 +58,7 @@ impl MapModel {
             spatial_index,
             geometry,
             queries_without_destinations,
+            config,
         })
     }
 

--- a/rust/routee-compass-core/src/model/map/map_model_config.rs
+++ b/rust/routee-compass-core/src/model/map/map_model_config.rs
@@ -71,6 +71,7 @@ impl TryFrom<Option<&Value>> for MapModelConfig {
     }
 }
 
+/// distance tolerance to apply while map matching, specified as a magnitude and unit pair.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DistanceTolerance {
     pub distance: f64,
@@ -80,5 +81,11 @@ pub struct DistanceTolerance {
 impl DistanceTolerance {
     pub fn to_uom(&self) -> Length {
         self.unit.to_uom(self.distance)
+    }
+}
+
+impl std::fmt::Display for DistanceTolerance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.distance, self.unit)
     }
 }

--- a/rust/routee-compass-core/src/model/map/matching_type.rs
+++ b/rust/routee-compass-core/src/model/map/matching_type.rs
@@ -322,7 +322,7 @@ fn test_edge(edge: &Edge, cm: Arc<dyn ConstraintModel>) -> Result<bool, MapError
 }
 
 /// helper function wrapping the [ConstraintModel::valid_edge] method that fails when the
-/// constraint model return 'false' with a [MapMatchError] error type.
+/// constraint model returns 'false' with a [MapMatchError] error type.
 fn validate_edge(edge: &Edge, cm: Arc<dyn ConstraintModel>) -> Result<(), MapError> {
     let is_valid = test_edge(edge, cm)?;
     if !is_valid {

--- a/rust/routee-compass-core/src/model/map/matching_type.rs
+++ b/rust/routee-compass-core/src/model/map/matching_type.rs
@@ -161,7 +161,7 @@ impl MatchingType {
                 // are within our matching tolerance and validate them with the constraint model
                 let src_point = geo::Point(query.get_origin_coordinate()?);
                 for nearest in si.map_model.spatial_index.nearest_graph_id_iter(&src_point) {
-                    match nearest {
+                    match nearest? {
                         NearestSearchResult::NearestVertex(vertex_id) => {
                             // if any of the out-edges of this vertex are valid, we can finish
                             let edges = si.graph.out_edges(&vertex_id).iter().map(|(edge_list_id, edge_id)| si.graph.get_edge(edge_list_id, edge_id)).collect::<Result<Vec<_>, _>>().map_err(|e| MapError::MapMatchError(format!("while attempting to validate vertex id {vertex_id} for map matching, the underlying Graph model caused an error: {e}")))?;
@@ -271,13 +271,13 @@ impl MatchingType {
                 };
 
                 for nearest in si.map_model.spatial_index.nearest_graph_id_iter(&dst_point) {
-                    match nearest {
+                    match nearest? {
                         NearestSearchResult::NearestVertex(vertex_id) => {
                             // if any of the out-edges of this vertex are valid, we can finish
                             let edges = si.graph.out_edges(&vertex_id).iter().map(|(edge_list_id, edge_id)| si.graph.get_edge(edge_list_id, edge_id)).collect::<Result<Vec<_>, _>>().map_err(|e| MapError::MapMatchError(format!("while attempting to validate vertex id {vertex_id} for map matching, the underlying Graph model caused an error: {e}")))?;
                             for edge in edges.into_iter() {
-                                let fm =  si.get_constraint_model(&edge.edge_list_id).map_err(|e| MapError::InternalError(format!("while map matching point '{}', failed to retrieve constraint model for out edge list '{}', edge '{}': {e}", dst_point.to_wkt(), edge.edge_list_id, edge.edge_id)))?;
-                                let is_valid = test_edge(edge, fm)?;
+                                let cm =  si.get_constraint_model(&edge.edge_list_id).map_err(|e| MapError::InternalError(format!("while map matching point '{}', failed to retrieve constraint model for out edge list '{}', edge '{}': {e}", dst_point.to_wkt(), edge.edge_list_id, edge.edge_id)))?;
+                                let is_valid = test_edge(edge, cm)?;
                                 if is_valid {
                                     query.add_destination_vertex(vertex_id)?;
                                     return Ok(MapInputResult::Found);
@@ -287,8 +287,8 @@ impl MatchingType {
                         }
                         NearestSearchResult::NearestEdge(edge_list_id, edge_id) => {
                             let edge = si.graph.get_edge(&edge_list_id, &edge_id).map_err(|e| MapError::MapMatchError(format!("while attempting to validate edge id {edge_id} from nearest neighbor search for map matching, the underlying Graph model caused an error: {e}")))?;
-                            let fm =  si.get_constraint_model(&edge_list_id).map_err(|e| MapError::InternalError(format!("while map matching edge_list_id '{edge_list_id}', edge_id '{edge_id}', failed to retrieve constraint model for out edge list '{edge_list_id}', edge '{edge_id}': {e}")))?;
-                            let is_valid = test_edge(edge, fm)?;
+                            let cm =  si.get_constraint_model(&edge_list_id).map_err(|e| MapError::InternalError(format!("while map matching edge_list_id '{edge_list_id}', edge_id '{edge_id}', failed to retrieve constraint model for out edge list '{edge_list_id}', edge '{edge_id}': {e}")))?;
+                            let is_valid = test_edge(edge, cm)?;
                             if is_valid {
                                 query.add_destination_edge(edge_list_id, edge_id)?;
                                 return Ok(MapInputResult::Found);
@@ -306,16 +306,18 @@ impl MatchingType {
     }
 }
 
-fn test_edge(edge: &Edge, fm: Arc<dyn ConstraintModel>) -> Result<bool, MapError> {
-    let is_valid = fm.valid_edge(edge).map_err(|e| MapError::MapMatchError(format!("while attempting to validate edge id {} for map matching, the underlying ConstraintModel caused an error: {}", edge.edge_id, e)))?;
-    Ok(is_valid)
+/// helper function wrapping the [ConstraintModel::valid_edge] method with a [MapMatchError] error type.
+fn test_edge(edge: &Edge, cm: Arc<dyn ConstraintModel>) -> Result<bool, MapError> {
+    cm.valid_edge(edge).map_err(|e| MapError::MapMatchError(format!("while attempting to validate edge id {} for map matching, the underlying ConstraintModel caused an error: {}", edge.edge_id, e)))
 }
 
-fn validate_edge(edge: &Edge, fm: Arc<dyn ConstraintModel>) -> Result<(), MapError> {
-    let is_valid = test_edge(edge, fm)?;
+/// helper function wrapping the [ConstraintModel::valid_edge] method that fails when the
+/// constraint model return 'false' with a [MapMatchError] error type.
+fn validate_edge(edge: &Edge, cm: Arc<dyn ConstraintModel>) -> Result<(), MapError> {
+    let is_valid = test_edge(edge, cm)?;
     if !is_valid {
         Err(MapError::MapMatchError(format!(
-            "query assigned origin of edge {} is not valid according to the ConstraintModel",
+            "query assigned edge {} is not valid according to the ConstraintModel",
             edge.edge_id
         )))
     } else {

--- a/rust/routee-compass-core/src/model/map/matching_type.rs
+++ b/rust/routee-compass-core/src/model/map/matching_type.rs
@@ -186,10 +186,15 @@ impl MatchingType {
                         }
                     }
                 }
+                let tolerance_string = match &si.map_model.config.tolerance {
+                    Some(t) => format!(" within tolerance of {t}"),
+                    None => "".to_string(),
+                };
                 Err(MapError::MapMatchError(format!(
-                    "attempted to match query origin coordinate ({}, {}) to map but exausted all possibilities",
+                    "attempted to match query origin coordinate ({}, {}) to map but no valid connections were found{}",
                     src_point.x(),
                     src_point.y(),
+                    tolerance_string
                 )))
             }
         }
@@ -296,10 +301,15 @@ impl MatchingType {
                         }
                     }
                 }
+                let tolerance_string = match &si.map_model.config.tolerance {
+                    Some(t) => format!(" within tolerance of {t}"),
+                    None => "".to_string(),
+                };
                 Err(MapError::MapMatchError(format!(
-                    "attempted to match query destination coordinate ({}, {}) to map but exausted all possibilities",
+                    "attempted to match query destination coordinate ({}, {}) to map but no valid connections were found{}",
                     dst_point.x(),
                     dst_point.y(),
+                    tolerance_string
                 )))
             }
         }

--- a/rust/routee-compass-core/src/model/map/spatial_index.rs
+++ b/rust/routee-compass-core/src/model/map/spatial_index.rs
@@ -96,21 +96,40 @@ impl SpatialIndex {
     pub fn nearest_graph_id_iter<'a>(
         &'a self,
         point: &'a Point<f32>,
-    ) -> Box<dyn Iterator<Item = NearestSearchResult> + 'a> {
+    ) -> Box<dyn Iterator<Item = Result<NearestSearchResult, MapError>> + 'a> {
         match self {
             SpatialIndex::VertexOrientedIndex { rtree, tolerance } => {
                 let iter = rtree
                     .nearest_neighbor_iter_with_distance_2(point)
-                    .filter(|(obj, _)| obj.test_threshold(point, tolerance).unwrap_or(false))
-                    .map(|(next, _)| NearestSearchResult::NearestVertex(next.vertex_id));
+                    .map_while(|(obj, _)| {
+                        let valid = match obj.test_threshold(point, tolerance) {
+                            Ok(v) => v,
+                            Err(e) => return Some(Err(e)),
+                        };
+                        if valid {
+                            Some(Ok(NearestSearchResult::NearestVertex(obj.vertex_id)))
+                        } else {
+                            None
+                        }
+                    });
                 Box::new(iter)
             }
             SpatialIndex::EdgeOrientedIndex { rtree, tolerance } => {
                 let iter = rtree
                     .nearest_neighbor_iter_with_distance_2(point)
-                    .filter(|(obj, _)| obj.test_threshold(point, tolerance).unwrap_or(false))
-                    .map(|(next, _)| {
-                        NearestSearchResult::NearestEdge(next.edge_list_id, next.edge_id)
+                    .map_while(|(obj, _)| {
+                        let valid = match obj.test_threshold(point, tolerance) {
+                            Ok(v) => v,
+                            Err(e) => return Some(Err(e)),
+                        };
+                        if valid {
+                            Some(Ok(NearestSearchResult::NearestEdge(
+                                obj.edge_list_id,
+                                obj.edge_id,
+                            )))
+                        } else {
+                            None
+                        }
                     });
                 Box::new(iter)
             }

--- a/rust/routee-compass/src/app/cli/run.rs
+++ b/rust/routee-compass/src/app/cli/run.rs
@@ -111,13 +111,13 @@ pub fn command_line_runner(
 
     // execute queries on app
     let result = match (args.chunksize, args.newline_delimited) {
-        (None, false) => run_json(&query_file_path, &compass_app, run_config),
+        (None, false) => run_json(query_file_path, &compass_app, run_config),
         (Some(_), false) => Err(CompassAppError::InternalError(String::from(
             "not yet implemented",
         ))),
         (_, true) => {
             let chunksize = args.get_chunksize_option()?;
-            run_newline_json(&query_file_path, chunksize, &compass_app, run_config)
+            run_newline_json(query_file_path, chunksize, &compass_app, run_config)
         }
     };
 

--- a/rust/routee-compass/src/app/compass/compass_app.rs
+++ b/rust/routee-compass/src/app/compass/compass_app.rs
@@ -106,7 +106,7 @@ impl CompassApp {
         let graph = ops::with_timing("graph", || Ok(Arc::new(Graph::try_from(&config.graph)?)))?;
 
         let map_model = ops::with_timing("map model", || {
-            let mm = MapModel::new(graph.clone(), &config.mapping).map_err(|e| {
+            let mm = MapModel::new(graph.clone(), config.mapping.clone()).map_err(|e| {
                 CompassAppError::BuildFailure(format!("unable to load MapModel from config: {e}"))
             })?;
             Ok(Arc::new(mm))


### PR DESCRIPTION
this PR modifies map matching code that applies a distance threshold. the current implementation removes potential mapped locations via a `filter` combinator. in the case where no items are found that are within the threshold, this implementation will _still visit all items_ in the index/graph. this is very inefficient when graphs are very large.

via this PR the behavior is to fail fast when the first object is rejected. additionally, a previously-silenced error is propagated.