### PR TITLE
make powertrain dependency optional in routee-compass

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,7 +38,7 @@ ndarray = "=0.17.2" # forces correct transitive dependency on ndarray by ninterp
 ninterp = "0.8.0"
 ordered-float = { version = "5.1.0", features = ["serde"] }
 ordered_hash_map = { version = "0.5.0", features = ["serde"] }
-ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "copy-dylibs"]}
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "copy-dylibs"] }
 parquet = "58.0.0"
 priority-queue = "2.7.0"
 proc-macro-error = "1.0"
@@ -60,7 +60,6 @@ topological-sort = "0.2.2"
 uom = { version = "=0.38.0", features = ["serde"] }
 wkb = "0.9.1"
 wkt = { version = "0.14.0", features = ["serde"] }
-
 
 [profile.profiling]
 inherits = "release"

--- a/rust/routee-compass-py/Cargo.toml
+++ b/rust/routee-compass-py/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/NREL/routee-compass"
 documentation = "https://docs.rs/routee-compass"
 exclude = ["test", "**/.DS_Store", "target/"]
 
-[features]
-default = ["routee-compass/default"]
-ort-static = ["routee-compass/ort-static"]
-
 [lib]
 name = "routee_compass_py"
 crate-type = ["cdylib"]
+
+[features]
+default = ["routee-compass/default"]
+ort-static = ["routee-compass/ort-static"]
 
 [dependencies]
 config = { workspace = true }

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -9,18 +9,8 @@ description = "The RouteE-Compass energy-aware routing engine"
 homepage = "https://nrel.github.io/routee-compass"
 repository = "https://github.com/NREL/routee-compass"
 documentation = "https://docs.rs/routee-compass"
-keywords = [
-    "eco-routing",
-    "route-planning",
-    "routing",
-    "networks",
-    "road-networks",
-]
+keywords = ["eco-routing", "route-planning", "routing", "networks", "road-networks"]
 categories = ["science", "science::geo"]
-
-[features]
-default = ["routee-compass-powertrain/default"]
-ort-static = ["routee-compass-powertrain/ort-static"]
 
 [lib]
 bench = false
@@ -34,6 +24,10 @@ bench = false
 name = "geom-app"
 path = "src/bin/geom-app.rs"
 bench = false
+
+[features]
+default = ["routee-compass-powertrain/default"]
+ort-static = ["routee-compass-powertrain/ort-static"]
 
 [dependencies]
 allocative = { workspace = true }

--- a/rust/routee-compass/Cargo.toml
+++ b/rust/routee-compass/Cargo.toml
@@ -57,7 +57,7 @@ ordered_hash_map = { workspace = true }
 parquet = { workspace = true }
 rayon = { workspace = true }
 routee-compass-core = { path = "../routee-compass-core", version = "0.19.2" }
-routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.19.2", default-features = false }
+routee-compass-powertrain = { path = "../routee-compass-powertrain", version = "0.19.2", default-features = false, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_json_path = { workspace = true }

--- a/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
+++ b/rust/routee-compass/src/app/compass/compass_builder_inventory.rs
@@ -50,6 +50,7 @@ use routee_compass_core::{
         },
     },
 };
+#[cfg(feature = "routee-compass-powertrain")]
 use routee_compass_powertrain::model::{
     charging::{
         battery::BatteryFilterBuilder, simple_charging_builder::SimpleChargingBuilder,
@@ -76,18 +77,14 @@ inventory::submit! {
         builder.add_traversal_model("time".to_string(), Rc::new(TimeTraversalBuilder {}));
         builder.add_traversal_model("grade".to_string(), Rc::new(GradeTraversalBuilder {}));
         builder.add_traversal_model("elevation".to_string(), Rc::new(ElevationTraversalBuilder {}));
-        builder.add_traversal_model("energy".to_string(), Rc::new(EnergyModelBuilder {}));
-        builder.add_traversal_model("simple_charging".to_string(), Rc::new(SimpleChargingBuilder::default()));
         builder.add_traversal_model("temperature".to_string(), Rc::new(TemperatureTraversalBuilder {}));
         builder.add_traversal_model("turn_delay".to_string(), Rc::new(TurnDelayTraversalModelBuilder {}));
         builder.add_traversal_model("custom".to_string(), Rc::new(CustomTraversalBuilder {}));
         builder.add_constraint_model("no_restriction".to_string(), Rc::new(NoRestrictionBuilder {}));
         builder.add_constraint_model("road_class".to_string(), Rc::new(RoadClassBuilder {}));
         builder.add_constraint_model("turn_restriction".to_string(), Rc::new(TurnRestrictionBuilder {}));
-        builder.add_constraint_model("battery".to_string(), Rc::new(BatteryFilterBuilder::default()));
         builder.add_constraint_model("vehicle_restriction".to_string(), Rc::new(VehicleRestrictionBuilder {}));
         builder.add_label_model("vertex".to_string(), Rc::new(VertexLabelModelBuilder));
-        builder.add_label_model("soc".to_string(), Rc::new(SOCLabelModelBuilder));
         builder.add_input_plugin("grid_search".to_string(), Rc::new(GridSearchBuilder {}));
         builder.add_input_plugin("load_balancer".to_string(), Rc::new(LoadBalancerBuilder {}));
         builder.add_input_plugin("inject".to_string(), Rc::new(InjectPluginBuilder {}));
@@ -97,6 +94,14 @@ inventory::submit! {
         builder.add_output_plugin("uuid".to_string(), Rc::new(UUIDOutputPluginBuilder {}));
         builder.add_output_plugin("eval".to_string(), Rc::new(EvalOutputPluginBuilder {}));
         builder.add_map_matching_model("lcss".to_string(), Rc::new(LcssMapMatchingBuilder {}));
+
+        #[cfg(feature = "routee-compass-powertrain")]
+        {
+            builder.add_label_model("soc".to_string(), Rc::new(SOCLabelModelBuilder));
+            builder.add_traversal_model("energy".to_string(), Rc::new(EnergyModelBuilder {}));
+            builder.add_traversal_model("simple_charging".to_string(), Rc::new(SimpleChargingBuilder::default()));
+            builder.add_constraint_model("battery".to_string(), Rc::new(BatteryFilterBuilder::default()));
+        }
         Ok(())
     })
 }


### PR DESCRIPTION
this PR makes it possible for downstream users like bambam to import routee-compass without powertrain/onnx compilation via `default-features = false`. in the builder inventory file, this skips importing routee-compass-powertrain and skips injecting the builders related to powertrain modeling.