### PR TITLE
no fail fast in output plugin processing

### DIFF
--- a/rust/routee-compass/src/app/compass/compass_app_ops.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_ops.rs
@@ -316,7 +316,7 @@ pub fn apply_output_processing(
 ) -> serde_json::Value {
     let mut initial = json!({ "request": request_json });
 
-    // set up "info" section with existing runtime metrics
+    // set up "runtimes" section with existing metrics
     let mut runtimes = Runtimes::new(TimeUnit::Seconds);
     if let Ok((sr, _)) = &result {
         runtimes.add_search_runtime(sr.search_runtime);
@@ -325,6 +325,7 @@ pub fn apply_output_processing(
         runtimes.add_input_plugin_runtimes(ipr);
     }
 
+    // process all output plugins. collect runtimes along the way.
     for output_plugin in output_plugins.iter() {
         let plugin_start_time = chrono::Local::now();
         match output_plugin.process(&mut initial, &result) {
@@ -334,12 +335,14 @@ pub fn apply_output_processing(
         runtimes.add_output_plugin_runtime(output_plugin.name(), plugin_start_time);
     }
 
-    if let Ok((sr, _)) = &result {
-        let info = Info::new(sr, runtimes, search_app.estimate_ram);
-        initial[INFO_KEY] = json!(info);
+    // write the "info" section with the runtimes along with search results, if present
+    let info = if let Ok((sr, _)) = &result {
+        Info::new_from_success(sr, runtimes, search_app.estimate_ram)
     } else {
-        initial[INFO_KEY] = json!({});
-    }
+        Info::new_from_failure(runtimes)
+    };
+    initial[INFO_KEY] = json!(info);
+
     initial
 }
 

--- a/rust/routee-compass/src/app/compass/compass_app_ops.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_ops.rs
@@ -316,6 +316,11 @@ pub fn apply_output_processing(
 ) -> serde_json::Value {
     let mut initial = json!({ "request": request_json });
 
+    // append error if exists
+    if let Err(e) = &result {
+        initial["error"] = json!(e.to_string());
+    }
+
     // set up "runtimes" section with existing metrics
     let mut runtimes = Runtimes::new(TimeUnit::Seconds);
     if let Ok((sr, _)) = &result {

--- a/rust/routee-compass/src/app/compass/compass_app_ops.rs
+++ b/rust/routee-compass/src/app/compass/compass_app_ops.rs
@@ -314,16 +314,13 @@ pub fn apply_output_processing(
     search_app: &SearchApp,
     output_plugins: &[Arc<dyn OutputPlugin>],
 ) -> serde_json::Value {
-    let (sr, _si) = match &result {
-        Ok(pair) => pair,
-        Err(e) => return package_error(request_json, e),
-    };
-
     let mut initial = json!({ "request": request_json });
 
     // set up "info" section with existing runtime metrics
     let mut runtimes = Runtimes::new(TimeUnit::Seconds);
-    runtimes.add_search_runtime(sr.search_runtime);
+    if let Ok((sr, _)) = &result {
+        runtimes.add_search_runtime(sr.search_runtime);
+    }
     if let Some(ipr) = input_plugin_runtimes {
         runtimes.add_input_plugin_runtimes(ipr);
     }
@@ -337,8 +334,12 @@ pub fn apply_output_processing(
         runtimes.add_output_plugin_runtime(output_plugin.name(), plugin_start_time);
     }
 
-    let info = Info::new(sr, runtimes, search_app.estimate_ram);
-    initial[INFO_KEY] = json!(info);
+    if let Ok((sr, _)) = &result {
+        let info = Info::new(sr, runtimes, search_app.estimate_ram);
+        initial[INFO_KEY] = json!(info);
+    } else {
+        initial[INFO_KEY] = json!({});
+    }
     initial
 }
 

--- a/rust/routee-compass/src/app/compass/info.rs
+++ b/rust/routee-compass/src/app/compass/info.rs
@@ -53,7 +53,7 @@ impl Info {
             tree_edges: 0,
             route_edges: None,
             ram_mib: None,
-            terminated: "".to_string(),
+            terminated: "false".to_string(),
             runtime,
         }
     }

--- a/rust/routee-compass/src/app/compass/info.rs
+++ b/rust/routee-compass/src/app/compass/info.rs
@@ -17,7 +17,7 @@ pub struct Info {
 
 impl Info {
     /// creates a new record of the "info" section of a result. written to the output JSON at [INFO_KEY].
-    pub fn new(result: &SearchAppResult, runtime: Runtimes, record_ram: bool) -> Self {
+    pub fn new_from_success(result: &SearchAppResult, runtime: Runtimes, record_ram: bool) -> Self {
         let route_edges = match result.routes.as_slice() {
             [] => None,
             rs => {
@@ -42,6 +42,18 @@ impl Info {
             route_edges,
             terminated,
             ram_mib,
+            runtime,
+        }
+    }
+
+    /// helper constructor for when we are creating an info section on a failed run.
+    pub fn new_from_failure(runtime: Runtimes) -> Self {
+        Self {
+            iterations: 0,
+            tree_edges: 0,
+            route_edges: None,
+            ram_mib: None,
+            terminated: "".to_string(),
             runtime,
         }
     }


### PR DESCRIPTION
this PR is a quick bug fix. the way we designed output plugins, they accept a `&Result<(SearchAppResult, SearchInstance), CompassAppError>` and _do something with it_. that means they can still run when the search result is an Err. 

_however_, a certain someone (myself) came through and messed this up in the output plugin processing by returning early if an Err was encountered before calling the output plugin process methods.

this fix reverses that without throwing out any of the new runtime logging behaviors. now, if an output plugin fails, that will still break from running all remaining output plugins. i believe that's the behavior we want, since often output plugins are sequential + codependent.