### PR TITLE
Rjf/nrel name change charging import

### DIFF
--- a/python/nrel/routee/compass/io/charging_station_ops.py
+++ b/python/nrel/routee/compass/io/charging_station_ops.py
@@ -35,7 +35,7 @@ def download_ev_charging_stations(state: str, api_key: str = "DEMO_KEY") -> "Dat
     except ImportError as _:
         raise ImportError("Required libraries not installed. Please install pandas.")
     # Build query URL
-    query = f"https://developer.nrel.gov/api/alt-fuel-stations/v1.json?api_key={api_key}&status=E&access=public&fuel_type=ELEC&state={state}"
+    query = f"https://developer.nlr.gov/api/alt-fuel-stations/v1.json?api_key={api_key}&status=E&access=public&fuel_type=ELEC&state={state}"
 
     # Download data
     try:

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -151,13 +151,12 @@ def generate_compass_dataset(
         import osmnx as ox
     except ImportError:
         raise ImportError("requires osmnx to be installed. Try 'pip install osmnx'")
-    
+
     import numpy as np
     import pandas as pd
     import geopandas as gpd
     from shapely.geometry import box
     import requests
-
 
     log.info(f"running pipeline import with phases: [{[p.name for p in phases]}]")
     output_directory = Path(output_directory)

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -149,13 +149,15 @@ def generate_compass_dataset(
     """
     try:
         import osmnx as ox
-        import numpy as np
-        import pandas as pd
-        import geopandas as gpd
-        from shapely.geometry import box
-        import requests
     except ImportError:
         raise ImportError("requires osmnx to be installed. Try 'pip install osmnx'")
+    
+    import numpy as np
+    import pandas as pd
+    import geopandas as gpd
+    from shapely.geometry import box
+    import requests
+
 
     log.info(f"running pipeline import with phases: [{[p.name for p in phases]}]")
     output_directory = Path(output_directory)
@@ -375,11 +377,11 @@ def generate_compass_dataset(
         )
 
         if charging_gdf.empty:
-            log.warning(
+            msg = (
                 "No charging stations found in the bounding box for the road network. "
-                "Skipping charging station processing."
+                "please re-run without the CHARGING_STATIONS pipeline phase."
             )
-            return
+            raise Exception(msg)
 
         out_df = charging_gdf[
             [

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -159,8 +159,8 @@ def generate_compass_dataset(
         import geopandas as gpd
         from shapely.geometry import box
         import requests
-    except ImportError as e:
-        raise ImportError(f"please install compass with the 'osm' feature enabled. {e}")
+    except ImportError as err:
+        raise ImportError(f"please install compass with the 'osm' feature enabled. {err}")
 
     log.info(f"running pipeline import with phases: [{[p.name for p in phases]}]")
     output_directory = Path(output_directory)

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -160,7 +160,9 @@ def generate_compass_dataset(
         from shapely.geometry import box
         import requests
     except ImportError as err:
-        raise ImportError(f"please install compass with the 'osm' feature enabled. {err}")
+        raise ImportError(
+            f"please install compass with the 'osm' feature enabled. {err}"
+        )
 
     log.info(f"running pipeline import with phases: [{[p.name for p in phases]}]")
     output_directory = Path(output_directory)

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -382,9 +382,10 @@ def generate_compass_dataset(
         if charging_gdf.empty and require_charging_stations:
             msg = (
                 "No charging stations found in the bounding box for the road network. "
-                "please re-run without the CHARGING_STATIONS pipeline phase."
+                "please re-run without the CHARGING_STATIONS pipeline phase, or if "
+                "no chargers is acceptable, call this function with `require_charging_stations=False`."
             )
-            raise Exception(msg)
+            raise RuntimeError(msg)
         elif charging_gdf.empty:
             msg = "No charging stations found in the bounding box for the road network."
             log.warning(msg)

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -106,6 +106,7 @@ def generate_compass_dataset(
     default_config: bool = True,
     requests_kwds: Optional[Dict[Any, Any]] = None,
     afdc_api_key: str = "DEMO_KEY",
+    require_charging_stations: bool = True,
     vehicle_models: Optional[List[str]] = None,
     hooks: Optional[List[DatasetHook]] = None,
 ) -> None:
@@ -134,6 +135,7 @@ def generate_compass_dataset(
         default_config (bool, optional): If true, copy default configuration files into the output directory. Defaults to True.
         requests_kwds (Optional[Dict], optional): Keyword arguments to pass to the `requests` Python library for HTTP configuration. Defaults to None.
         afdc_api_key (str, optional): API key for the AFDC API to download EV charging stations. Defaults to "DEMO_KEY". See https://developer.nrel.gov/docs/transportation/alt-fuel-stations-v1/all/ for more information.
+        require_charging_stations: if the CHARGING_STATIONS phase is active, fail when no chargers are found.
         vehicle_models (Optional[List[str]]): If provided, only download and
             configure the listed vehicle models (by name, e.g.
             ``["2017_CHEVROLET_Bolt", "2016_TOYOTA_Camry_4cyl_2WD"]``).
@@ -375,28 +377,31 @@ def generate_compass_dataset(
             vertex_bbox, api_key=afdc_api_key
         )
 
-        if charging_gdf.empty:
+        if charging_gdf.empty and require_charging_stations:
             msg = (
                 "No charging stations found in the bounding box for the road network. "
                 "please re-run without the CHARGING_STATIONS pipeline phase."
             )
             raise Exception(msg)
-
-        out_df = charging_gdf[
-            [
-                "power_type",
-                "power_kw",
-                "cost_per_kwh",
-                "x",
-                "y",
+        elif charging_gdf.empty:
+            msg = "No charging stations found in the bounding box for the road network."
+            log.warning(msg)
+        else:
+            out_df = charging_gdf[
+                [
+                    "power_type",
+                    "power_kw",
+                    "cost_per_kwh",
+                    "x",
+                    "y",
+                ]
             ]
-        ]
 
-        out_df.to_csv(
-            output_directory / "charging-stations.csv.gz",
-            index=False,
-            compression="gzip",
-        )
+            out_df.to_csv(
+                output_directory / "charging-stations.csv.gz",
+                index=False,
+                compression="gzip",
+            )
 
     # RUN HOOKS
     if hooks is not None:

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -134,7 +134,7 @@ def generate_compass_dataset(
         raster_resolution_arc_seconds (str, optional): If grade is added, the resolution (in arc-seconds) of the tiles to download (either 1 or 1/3). Defaults to 1.
         default_config (bool, optional): If true, copy default configuration files into the output directory. Defaults to True.
         requests_kwds (Optional[Dict], optional): Keyword arguments to pass to the `requests` Python library for HTTP configuration. Defaults to None.
-        afdc_api_key (str, optional): API key for the AFDC API to download EV charging stations. Defaults to "DEMO_KEY". See https://developer.nrel.gov/docs/transportation/alt-fuel-stations-v1/all/ for more information.
+        afdc_api_key (str, optional): API key for the AFDC API to download EV charging stations. Defaults to "DEMO_KEY". See https://developer.nlr.gov/docs/transportation/alt-fuel-stations-v1/all/ for more information.
         require_charging_stations: if the CHARGING_STATIONS phase is active, fail when no chargers are found.
         vehicle_models (Optional[List[str]]): If provided, only download and
             configure the listed vehicle models (by name, e.g.

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -153,12 +153,14 @@ def generate_compass_dataset(
         import osmnx as ox
     except ImportError:
         raise ImportError("requires osmnx to be installed. Try 'pip install osmnx'")
-
-    import numpy as np
-    import pandas as pd
-    import geopandas as gpd
-    from shapely.geometry import box
-    import requests
+    try:
+        import numpy as np
+        import pandas as pd
+        import geopandas as gpd
+        from shapely.geometry import box
+        import requests
+    except ImportError as e:
+        raise ImportError(f"please install compass with the 'osm' feature enabled. {e}")
 
     log.info(f"running pipeline import with phases: [{[p.name for p in phases]}]")
     output_directory = Path(output_directory)


### PR DESCRIPTION
This PR fixes two issues with the python CI tests that is currently blocking all PRs from passing CI. Due to the recent name change from NREL to NLR, the API for downloading charging stations has changed. this URL is hard-coded into the python script for running downloads. 

additionally, when the CHARGING_STATIONS pipeline phase is selected but no charging stations are found, the program currently only logs a warning. this seems like it should be an error case for the happy path, given that the user has specified they want to download charging stations. however, there are cases where this breaks down, such as when a reasonable map region is selected that does not intersect with any charging stations. for this, a new argument `require_charging_stations: bool` was added with the default of failure when no chargers are found, but logging a warning if `require_charging_stations` is `False`.

Closes #523.