### PR TITLE
Introduce ModelIdentifier for ID options during energy model handling

### DIFF
--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -29,5 +29,5 @@ routee-compass-core = { path = "../routee-compass-core", version = "0.19.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smartcore = { workspace = true }
+thiserror = { workspace = true }
 uom = { workspace = true }
-thiserror = {workspace = true}

--- a/rust/routee-compass-powertrain/Cargo.toml
+++ b/rust/routee-compass-powertrain/Cargo.toml
@@ -30,3 +30,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 smartcore = { workspace = true }
 uom = { workspace = true }
+thiserror = {workspace = true}

--- a/rust/routee-compass-powertrain/src/model/energy_model_builder.rs
+++ b/rust/routee-compass-powertrain/src/model/energy_model_builder.rs
@@ -1,4 +1,5 @@
 use crate::model::energy_model_service::EnergyModelService;
+use crate::model::model_identifier::ModelIdentifier;
 use crate::model::BevEnergyModel;
 use crate::model::IceEnergyModel;
 use crate::model::PhevEnergyModel;
@@ -68,16 +69,24 @@ impl TraversalModelBuilder for EnergyModelBuilder {
                 vehicle_json["include_trip_energy"] = serde_json::Value::Bool(include_trip_energy);
             }
 
-            let model_name = vehicle_json
-                .get("name")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    TraversalModelError::BuildError(format!(
-                        "vehicle model missing 'name' field in '{}'",
-                        vehicle_file
-                    ))
-                })?
-                .to_string();
+            // grabs the "name" field from the json and attempts to deserialize it into a ModelIdentifier
+            let model_identifier: ModelIdentifier = serde_json::from_value(
+                vehicle_json
+                    .get("name")
+                    .ok_or_else(|| {
+                        TraversalModelError::BuildError(format!(
+                            "vehicle model missing 'name' field in '{}'",
+                            vehicle_file
+                        ))
+                    })?
+                    .clone(),
+            )
+            .map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Could not build ModelIdentifier from vehicle config file '{}': {}",
+                    vehicle_file, e
+                ))
+            })?;
 
             let (vehicle_json_stripped, vehicle_type) = strip_type_from_config(&vehicle_json)
                 .map_err(|e| TraversalModelError::BuildError(e.to_string()))?;
@@ -94,7 +103,7 @@ impl TraversalModelBuilder for EnergyModelBuilder {
                 }
             };
 
-            vehicle_library.insert(model_name, service);
+            vehicle_library.insert(model_identifier, service);
         }
 
         let service = EnergyModelService::new(vehicle_library)?;

--- a/rust/routee-compass-powertrain/src/model/energy_model_service.rs
+++ b/rust/routee-compass-powertrain/src/model/energy_model_service.rs
@@ -38,15 +38,11 @@ impl TraversalModelService for EnergyModelService {
 
         let service = self.vehicle_library.get(&model_identifier).ok_or_else(|| {
             TraversalModelError::BuildError(format!(
-                "unknown vehicle model {:?}, must be one of [{}]",
-                model_identifier,
-                self.vehicle_library
-                    .keys()
-                    .map(|m| format!("{m:?}"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                "unknown vehicle model {} from `model_name` field in query",
+                model_identifier
             ))
         })?;
+
         let model = service.build(parameters)?;
         Ok(model)
     }

--- a/rust/routee-compass-powertrain/src/model/energy_model_service.rs
+++ b/rust/routee-compass-powertrain/src/model/energy_model_service.rs
@@ -1,3 +1,4 @@
+use crate::model::model_identifier::ModelIdentifier;
 use routee_compass_core::model::traversal::{
     TraversalModel, TraversalModelError, TraversalModelService,
 };
@@ -8,12 +9,12 @@ use std::sync::Arc;
 /// based on the model_name field of the incoming query.
 #[derive(Clone)]
 pub struct EnergyModelService {
-    pub vehicle_library: HashMap<String, Arc<dyn TraversalModelService>>,
+    pub vehicle_library: HashMap<ModelIdentifier, Arc<dyn TraversalModelService>>,
 }
 
 impl EnergyModelService {
     pub fn new(
-        vehicle_library: HashMap<String, Arc<dyn TraversalModelService>>,
+        vehicle_library: HashMap<ModelIdentifier, Arc<dyn TraversalModelService>>,
     ) -> Result<Self, TraversalModelError> {
         Ok(EnergyModelService { vehicle_library })
     }
@@ -24,25 +25,22 @@ impl TraversalModelService for EnergyModelService {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Arc<dyn TraversalModel>, TraversalModelError> {
-        let model_name = parameters
-            .get("model_name")
-            .ok_or_else(|| {
-                TraversalModelError::BuildError("query missing 'model_name' field".to_string())
-            })?
-            .as_str()
-            .ok_or_else(|| {
-                TraversalModelError::BuildError("query 'model_name' is not a string".to_string())
+        let model_identifier: ModelIdentifier = serde_json::from_value(parameters.clone())
+            .map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Query missing 'model_identifier' field\nFrom serde_json::{e}"
+                ))
             })?;
 
-        let service = self.vehicle_library.get(model_name).ok_or_else(|| {
+        let service = self.vehicle_library.get(&model_identifier).ok_or_else(|| {
             TraversalModelError::BuildError(format!(
-                "unknown vehicle model {}, must be one of [{}]",
-                model_name,
+                "unknown vehicle model {:?}, must be one of [{}]",
+                model_identifier,
                 self.vehicle_library
                     .keys()
-                    .cloned()
+                    .map(|m| format!("{m:?}"))
                     .collect::<Vec<_>>()
-                    .join(",")
+                    .join(", ")
             ))
         })?;
         let model = service.build(parameters)?;

--- a/rust/routee-compass-powertrain/src/model/energy_model_service.rs
+++ b/rust/routee-compass-powertrain/src/model/energy_model_service.rs
@@ -25,14 +25,14 @@ impl TraversalModelService for EnergyModelService {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Arc<dyn TraversalModel>, TraversalModelError> {
-        let model_identifier_value = parameters.get("model_name").ok_or_else(|| {
-            TraversalModelError::BuildError("query missing 'model_identifier' field".to_string())
+        let model_name: &serde_json::Value = parameters.get("model_name").ok_or_else(|| {
+            TraversalModelError::BuildError("query missing 'model_name' field".to_string())
         })?;
 
-        let model_identifier: ModelIdentifier =
-            serde_json::from_value(model_identifier_value.clone()).map_err(|e| {
+        let model_identifier: ModelIdentifier = serde_json::from_value(model_name.clone())
+            .map_err(|e| {
                 TraversalModelError::BuildError(format!(
-                    "Could not deserialize 'model_identifier' field into ModelIdentifier: {e}"
+                    "Could not deserialize 'model_name' field from query into ModelIdentifier: {e}"
                 ))
             })?;
 

--- a/rust/routee-compass-powertrain/src/model/energy_model_service.rs
+++ b/rust/routee-compass-powertrain/src/model/energy_model_service.rs
@@ -25,10 +25,14 @@ impl TraversalModelService for EnergyModelService {
         &self,
         parameters: &serde_json::Value,
     ) -> Result<Arc<dyn TraversalModel>, TraversalModelError> {
-        let model_identifier: ModelIdentifier = serde_json::from_value(parameters.clone())
-            .map_err(|e| {
+        let model_identifier_value = parameters.get("model_name").ok_or_else(|| {
+            TraversalModelError::BuildError("query missing 'model_identifier' field".to_string())
+        })?;
+
+        let model_identifier: ModelIdentifier =
+            serde_json::from_value(model_identifier_value.clone()).map_err(|e| {
                 TraversalModelError::BuildError(format!(
-                    "Query missing 'model_identifier' field\nFrom serde_json::{e}"
+                    "Could not deserialize 'model_identifier' field into ModelIdentifier: {e}"
                 ))
             })?;
 

--- a/rust/routee-compass-powertrain/src/model/mod.rs
+++ b/rust/routee-compass-powertrain/src/model/mod.rs
@@ -5,6 +5,7 @@ pub mod energy_model_ops;
 pub mod energy_model_service;
 pub mod fieldname;
 mod ice_energy_model;
+mod model_identifier;
 mod phev_energy_model;
 pub mod prediction;
 

--- a/rust/routee-compass-powertrain/src/model/model_identifier.rs
+++ b/rust/routee-compass-powertrain/src/model/model_identifier.rs
@@ -3,18 +3,19 @@ use serde_json;
 use std::fmt;
 use std::fmt::Display;
 use std::num::NonZeroU64;
+use std::str::FromStr;
 
-/// The ModelIdentifier is a type deserialized from a RouteE Powertrain .json file's "name" field,
+/// The `ModelIdentifier` is an `enum` deserialized from a RouteE Powertrain .json file's "name" field,
 /// and details the vehicle energy model.
 ///
-/// The variants are either a fully qualified string ID:
+/// The variants are either a `String` detailing the `FullyQualifiedID`:
 /// ```json
 /// {
-///     "name": "2016_BMW_328d_4cyl_2WD",
+///     "name": "BMW/328d_4cyl_2WD/2016",
 /// }
 /// ```
 ///
-/// or a structured ID:
+/// or a structured json object detailing the `StructuredID`:
 /// ```json
 /// {
 ///     "name": {
@@ -25,9 +26,8 @@ use std::num::NonZeroU64;
 /// }
 /// ```
 ///
-/// Note: variant and version fields are both of type Option<String>, so they
+/// Note: variant and version fields are both of type `Option<String>`, so they
 /// are not required.
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(untagged)] // serde tries each variant
 pub enum ModelIdentifier {
@@ -36,25 +36,64 @@ pub enum ModelIdentifier {
         make: String,
         model: String,
         year: NonZeroU64,
-        #[serde(skip_serializing_if = "Option::is_none")]
         variant: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         version: Option<String>,
     },
 }
 
-// standard display of a ModelIdentifier converts the object to its minified json,
-// but a fully qualified id is represented as a raw string rather than a JSON string.
-impl Display for ModelIdentifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ModelIdentifier::FullyQualifiedId(id) => write!(f, "{id}"),
-            ModelIdentifier::StructuredId { .. } => write!(
-                f,
-                "{}",
-                serde_json::to_string(self).map_err(|_| fmt::Error)?
-            ),
+/// `ModelIdentifierError` (for `TryFrom<&ModelIdentifier> for ModelIdentifier` trait implementation)
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ModelIdentifierError {
+    #[error("fully qualified id '{0}' must have at least make/model/year fields")]
+    MissingFields(String),
+    #[error("invalid year '{0}' in fully qualified id")]
+    InvalidYear(String),
+}
+
+impl TryFrom<&ModelIdentifier> for ModelIdentifier {
+    type Error = ModelIdentifierError;
+
+    /// `TryFrom` implementation for `ModelIdentifier` which will create a copy of
+    /// `ModelIdentifier::FullyQualifiedID` as a `ModelIdentifier::StructuredID`
+    /// or will create a copy of the `ModelIdentifier::StructuredID`.
+    fn try_from(value: &ModelIdentifier) -> Result<Self, Self::Error> {
+        match value {
+            ModelIdentifier::StructuredId { .. } => Ok(value.clone()),
+            ModelIdentifier::FullyQualifiedId(id) => {
+                let mut attributes = id.split('/').map(|s| s.to_string());
+
+                let (make, model, year) =
+                    match (attributes.next(), attributes.next(), attributes.next()) {
+                        (Some(a), Some(b), Some(c)) => (a, b, c),
+                        _ => return Err(ModelIdentifierError::MissingFields(id.clone())),
+                    };
+
+                let year = NonZeroU64::from_str(&year)
+                    .map_err(|_| ModelIdentifierError::InvalidYear(year))?;
+
+                Ok(ModelIdentifier::StructuredId {
+                    make,
+                    model,
+                    year,
+                    variant: attributes.next(),
+                    version: attributes.next(),
+                })
+            }
         }
+    }
+}
+
+impl Display for ModelIdentifier {
+    /// `Display` trait `fmt()` implementation for `ModelIdentifier`.
+    /// If self is `FullyQualifiedID`, prints as `StructuredID`.
+    /// If self is `StructuredID`, prints as `StructuredID`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let structured = ModelIdentifier::try_from(self).map_err(|_| fmt::Error)?; // Tries to convert FullyQualifiedID to StructuredID.
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&structured).map_err(|_| fmt::Error)?
+        )
     }
 }
 
@@ -165,13 +204,14 @@ mod tests {
         Ok(())
     }
 
-    // ensure that if one non-optional field is redacted, we receive an error when attempting to deserialize
+    // Ensure that if one non-optional field is redacted, we receive an error when attempting to deserialize a ModelIdentifier.
     #[test]
     fn test_model_identifier_rejects_invalid() {
         let bad = serde_json::json!({ "make": "Ford" }); // no model, no year
         assert!(ModelIdentifier::deserialize(&bad).is_err());
     }
 
+    // Ensures that structuredID is printed as structuredID.
     #[test]
     fn test_display_structured() -> Result<(), TraversalModelError> {
         let vehicle_json_as_str = r#"{
@@ -214,17 +254,18 @@ mod tests {
             })?;
 
         assert_eq!(
-            r#"{"make":"Ford","model":"Quadricycle","year":1896}"#,
+            r#"{"make":"Ford","model":"Quadricycle","year":1896,"variant":null,"version":null}"#,
             format!("{}", model_identifier)
         );
 
         Ok(())
     }
 
+    // Ensures that FullyQualifiedID converts to StructuredID when printing.
     #[test]
     fn test_display_fully_qualified() -> Result<(), TraversalModelError> {
         let vehicle_json_as_str = r#"{
-            "name": "1896_Ford_Quadricycle",
+            "name": "Ford/Quadricycle/1896",
             "type": "ice",
             "mass_estimate_lbs": 500,
             "model_input_file": "ford_quad_1896.bin",
@@ -258,7 +299,10 @@ mod tests {
                 ))
             })?;
 
-        assert_eq!("1896_Ford_Quadricycle", format!("{}", model_identifier));
+        assert_eq!(
+            r#"{"make":"Ford","model":"Quadricycle","year":1896,"variant":null,"version":null}"#,
+            format!("{}", model_identifier)
+        );
 
         Ok(())
     }

--- a/rust/routee-compass-powertrain/src/model/model_identifier.rs
+++ b/rust/routee-compass-powertrain/src/model/model_identifier.rs
@@ -50,8 +50,8 @@ pub enum ModelIdentifierError {
     MissingFields(String),
     #[error("invalid year '{0}' in fully qualified id")]
     InvalidYear(String),
-    #[error("version and variant must appear together, found only '{0}'")]
-    OneOfVariantOrVersion(String),
+    #[error("version and variant must appear together, found only '{0}' = '{1}'")]
+    OneOfVariantOrVersion(String, String),
 }
 
 impl ModelIdentifier {
@@ -75,10 +75,16 @@ impl ModelIdentifier {
                 let (variant, version) = match (attributes.next(), attributes.next()) {
                     (Some(var), Some(ver)) => (Some(var), Some(ver)),
                     (Some(var), None) => {
-                        return Err(ModelIdentifierError::OneOfVariantOrVersion(var))
+                        return Err(ModelIdentifierError::OneOfVariantOrVersion(
+                            "variant".to_string(),
+                            var.to_string(),
+                        ))
                     }
                     (None, Some(ver)) => {
-                        return Err(ModelIdentifierError::OneOfVariantOrVersion(ver))
+                        return Err(ModelIdentifierError::OneOfVariantOrVersion(
+                            "version".to_string(),
+                            ver.to_string(),
+                        ))
                     }
                     (None, None) => (None, None),
                 };
@@ -109,12 +115,14 @@ impl ModelIdentifier {
                     "{}/{}/{}/{}/{}",
                     make, model, year, var, ver
                 ))),
-                (Some(var), None) => {
-                    Err(ModelIdentifierError::OneOfVariantOrVersion(var.to_string()))
-                }
-                (None, Some(ver)) => {
-                    Err(ModelIdentifierError::OneOfVariantOrVersion(ver.to_string()))
-                }
+                (Some(var), None) => Err(ModelIdentifierError::OneOfVariantOrVersion(
+                    "variant".to_string(),
+                    var.to_string(),
+                )),
+                (None, Some(ver)) => Err(ModelIdentifierError::OneOfVariantOrVersion(
+                    "version".to_string(),
+                    ver.to_string(),
+                )),
                 (None, None) => Ok(FullyQualifiedId(format!("{}/{}/{}", make, model, year))),
             },
             Self::FullyQualifiedId(_) => Ok(self.clone()),

--- a/rust/routee-compass-powertrain/src/model/model_identifier.rs
+++ b/rust/routee-compass-powertrain/src/model/model_identifier.rs
@@ -1,4 +1,7 @@
 use serde::{Deserialize, Serialize};
+use serde_json;
+use std::fmt;
+use std::fmt::Display;
 use std::num::NonZeroU64;
 
 /// The ModelIdentifier is a type deserialized from a RouteE Powertrain .json file's "name" field,
@@ -16,7 +19,7 @@ use std::num::NonZeroU64;
 /// {
 ///     "name": {
 ///         "make": "BMW",
-///         "model": "328d",
+///         "model": "328d_4cyl_2WD",
 ///         "year": 2016,
 ///     },
 /// }
@@ -33,9 +36,26 @@ pub enum ModelIdentifier {
         make: String,
         model: String,
         year: NonZeroU64,
+        #[serde(skip_serializing_if = "Option::is_none")]
         variant: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         version: Option<String>,
     },
+}
+
+// standard display of a ModelIdentifier converts the object to its minified json,
+// but a fully qualified id is represented as a raw string rather than a JSON string.
+impl Display for ModelIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ModelIdentifier::FullyQualifiedId(id) => write!(f, "{id}"),
+            ModelIdentifier::StructuredId { .. } => write!(
+                f,
+                "{}",
+                serde_json::to_string(self).map_err(|_| fmt::Error)?
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -150,5 +170,96 @@ mod tests {
     fn test_model_identifier_rejects_invalid() {
         let bad = serde_json::json!({ "make": "Ford" }); // no model, no year
         assert!(ModelIdentifier::deserialize(&bad).is_err());
+    }
+
+    #[test]
+    fn test_display_structured() -> Result<(), TraversalModelError> {
+        let vehicle_json_as_str = r#"{
+            "name": {
+                "make": "Ford",
+                "model": "Quadricycle",
+                "year": 1896
+            },
+            "type": "ice",
+            "mass_estimate_lbs": 500,
+            "model_input_file": "ford_quad_1896.bin",
+            "energy_rate_unit": "gallons gasoline/mile",
+            "real_world_energy_adjustment": 100.0,
+            "a_star_heuristic_energy_rate": 0.001,
+            "input_features": [
+                {
+                    "type": "speed",
+                    "name": "edge_speed",
+                    "unit": "mph"
+                }
+            ],
+            "model_type": "onnx"
+            }"#;
+        let vehicle_json: serde_json::Value =
+            serde_json::from_str(vehicle_json_as_str).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Couldn't load vehicle json because of {e}"
+                ))
+            })?;
+        let name_field = vehicle_json
+            .get("name")
+            .ok_or(TraversalModelError::BuildError(
+                "vehicle_json does not have field `name`".to_string(),
+            ))?;
+        let model_identifier: ModelIdentifier =
+            ModelIdentifier::deserialize(name_field).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Could not deserialize `name` field into ModelIdentifier because of {e}"
+                ))
+            })?;
+
+        assert_eq!(
+            r#"{"make":"Ford","model":"Quadricycle","year":1896}"#,
+            format!("{}", model_identifier)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_display_fully_qualified() -> Result<(), TraversalModelError> {
+        let vehicle_json_as_str = r#"{
+            "name": "1896_Ford_Quadricycle",
+            "type": "ice",
+            "mass_estimate_lbs": 500,
+            "model_input_file": "ford_quad_1896.bin",
+            "energy_rate_unit": "gallons gasoline/mile",
+            "real_world_energy_adjustment": 100.0,
+            "a_star_heuristic_energy_rate": 0.001,
+            "input_features": [
+                {
+                    "type": "speed",
+                    "name": "edge_speed",
+                    "unit": "mph"
+                }
+            ],
+            "model_type": "onnx"
+            }"#;
+        let vehicle_json: serde_json::Value =
+            serde_json::from_str(vehicle_json_as_str).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Couldn't load vehicle json because of {e}"
+                ))
+            })?;
+        let name_field = vehicle_json
+            .get("name")
+            .ok_or(TraversalModelError::BuildError(
+                "vehicle_json does not have field `name`".to_string(),
+            ))?;
+        let model_identifier: ModelIdentifier =
+            ModelIdentifier::deserialize(name_field).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Could not deserialize `name` field into ModelIdentifier because of {e}"
+                ))
+            })?;
+
+        assert_eq!("1896_Ford_Quadricycle", format!("{}", model_identifier));
+
+        Ok(())
     }
 }

--- a/rust/routee-compass-powertrain/src/model/model_identifier.rs
+++ b/rust/routee-compass-powertrain/src/model/model_identifier.rs
@@ -1,9 +1,11 @@
 use serde::{Deserialize, Serialize};
-use serde_json;
+use serde_json::{json, Value};
 use std::fmt;
 use std::fmt::Display;
 use std::num::NonZeroU64;
 use std::str::FromStr;
+
+use crate::model::model_identifier::ModelIdentifier::FullyQualifiedId;
 
 /// The `ModelIdentifier` is an `enum` deserialized from a RouteE Powertrain .json file's "name" field,
 /// and details the vehicle energy model.
@@ -41,25 +43,24 @@ pub enum ModelIdentifier {
     },
 }
 
-/// `ModelIdentifierError` (for `TryFrom<&ModelIdentifier> for ModelIdentifier` trait implementation)
+/// `ModelIdentifierError` variants
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ModelIdentifierError {
     #[error("fully qualified id '{0}' must have at least make/model/year fields")]
     MissingFields(String),
     #[error("invalid year '{0}' in fully qualified id")]
     InvalidYear(String),
+    #[error("version and variant must appear together, found only '{0}'")]
+    OneOfVariantOrVersion(String),
 }
 
-impl TryFrom<&ModelIdentifier> for ModelIdentifier {
-    type Error = ModelIdentifierError;
-
-    /// `TryFrom` implementation for `ModelIdentifier` which will create a copy of
-    /// `ModelIdentifier::FullyQualifiedID` as a `ModelIdentifier::StructuredID`
-    /// or will create a copy of the `ModelIdentifier::StructuredID`.
-    fn try_from(value: &ModelIdentifier) -> Result<Self, Self::Error> {
-        match value {
-            ModelIdentifier::StructuredId { .. } => Ok(value.clone()),
-            ModelIdentifier::FullyQualifiedId(id) => {
+impl ModelIdentifier {
+    /// Creates a copy of the `ModelIdentifier` from it's current variant (either `FullyQualifiedId` or `StructuredId`)
+    /// to `StructuredId`
+    pub fn to_structured(&self) -> Result<Self, ModelIdentifierError> {
+        match self {
+            Self::StructuredId { .. } => Ok(self.clone()),
+            Self::FullyQualifiedId(id) => {
                 let mut attributes = id.split('/').map(|s| s.to_string());
 
                 let (make, model, year) =
@@ -71,29 +72,85 @@ impl TryFrom<&ModelIdentifier> for ModelIdentifier {
                 let year = NonZeroU64::from_str(&year)
                     .map_err(|_| ModelIdentifierError::InvalidYear(year))?;
 
+                let (variant, version) = match (attributes.next(), attributes.next()) {
+                    (Some(var), Some(ver)) => (Some(var), Some(ver)),
+                    (Some(var), None) => {
+                        return Err(ModelIdentifierError::OneOfVariantOrVersion(var))
+                    }
+                    (None, Some(ver)) => {
+                        return Err(ModelIdentifierError::OneOfVariantOrVersion(ver))
+                    }
+                    (None, None) => (None, None),
+                };
+
                 Ok(ModelIdentifier::StructuredId {
                     make,
                     model,
                     year,
-                    variant: attributes.next(),
-                    version: attributes.next(),
+                    variant,
+                    version,
                 })
             }
+        }
+    }
+
+    /// Converts the `ModelIdentifier` from it's current variant (either `FullyQualifiedId` or `StructuredId`)
+    /// to `FullyQualifiedId`
+    pub fn to_fully_qualified(&self) -> Result<Self, ModelIdentifierError> {
+        match self {
+            Self::StructuredId {
+                make,
+                model,
+                year,
+                variant,
+                version,
+            } => match (variant, version) {
+                (Some(var), Some(ver)) => Ok(FullyQualifiedId(format!(
+                    "{}/{}/{}/{}/{}",
+                    make, model, year, var, ver
+                ))),
+                (Some(var), None) => {
+                    Err(ModelIdentifierError::OneOfVariantOrVersion(var.to_string()))
+                }
+                (None, Some(ver)) => {
+                    Err(ModelIdentifierError::OneOfVariantOrVersion(ver.to_string()))
+                }
+                (None, None) => Ok(FullyQualifiedId(format!("{}/{}/{}", make, model, year))),
+            },
+            Self::FullyQualifiedId(_) => Ok(self.clone()),
         }
     }
 }
 
 impl Display for ModelIdentifier {
-    /// `Display` trait `fmt()` implementation for `ModelIdentifier`.
-    /// If self is `FullyQualifiedID`, prints as `StructuredID`.
-    /// If self is `StructuredID`, prints as `StructuredID`.
+    /// Default `Display` implementation of `fmt()` for `ModelIdentifier`
+    /// prints the `ModelIdentifier` as the original variant.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let structured = ModelIdentifier::try_from(self).map_err(|_| fmt::Error)?; // Tries to convert FullyQualifiedID to StructuredID.
-        write!(
-            f,
-            "{}",
-            serde_json::to_string(&structured).map_err(|_| fmt::Error)?
-        )
+        match self {
+            ModelIdentifier::FullyQualifiedId(id) => write!(f, "{id}"),
+            ModelIdentifier::StructuredId {
+                make,
+                model,
+                year,
+                variant,
+                version,
+            } => {
+                // if the variant or version are None type, prints "none"
+                let opt_to_val = |o: &Option<String>| {
+                    Value::String(o.clone().unwrap_or_else(|| "none".to_string()))
+                };
+
+                let obj = json!({
+                    "make": make,
+                    "model": model,
+                    "year": year,
+                    "variant": opt_to_val(variant),
+                    "version": opt_to_val(version),
+                });
+
+                write!(f, "{obj}")
+            }
+        }
     }
 }
 
@@ -254,7 +311,7 @@ mod tests {
             })?;
 
         assert_eq!(
-            r#"{"make":"Ford","model":"Quadricycle","year":1896,"variant":null,"version":null}"#,
+            r#"{"make":"Ford","model":"Quadricycle","year":1896,"variant":"none","version":"none"}"#,
             format!("{}", model_identifier)
         );
 
@@ -299,10 +356,7 @@ mod tests {
                 ))
             })?;
 
-        assert_eq!(
-            r#"{"make":"Ford","model":"Quadricycle","year":1896,"variant":null,"version":null}"#,
-            format!("{}", model_identifier)
-        );
+        assert_eq!(r#"Ford/Quadricycle/1896"#, format!("{}", model_identifier));
 
         Ok(())
     }

--- a/rust/routee-compass-powertrain/src/model/model_identifier.rs
+++ b/rust/routee-compass-powertrain/src/model/model_identifier.rs
@@ -1,0 +1,154 @@
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroU64;
+
+/// The ModelIdentifier is a type deserialized from a RouteE Powertrain .json file's "name" field,
+/// and details the vehicle energy model.
+///
+/// The variants are either a fully qualified string ID:
+/// ```json
+/// {
+///     "name": "2016_BMW_328d_4cyl_2WD",
+/// }
+/// ```
+///
+/// or a structured ID:
+/// ```json
+/// {
+///     "name": {
+///         "make": "BMW",
+///         "model": "328d",
+///         "year": 2016,
+///     },
+/// }
+/// ```
+///
+/// Note: variant and version fields are both of type Option<String>, so they
+/// are not required.
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(untagged)] // serde tries each variant
+pub enum ModelIdentifier {
+    FullyQualifiedId(String),
+    StructuredId {
+        make: String,
+        model: String,
+        year: NonZeroU64,
+        variant: Option<String>,
+        version: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use routee_compass_core::model::traversal::TraversalModelError;
+
+    // Testing deserialization of vehicle_json["name"] into ModelIdentifier::StructuredID
+    #[test]
+    fn test_model_identifier_structured() -> Result<(), TraversalModelError> {
+        let vehicle_json_as_str = r#"{
+            "name": {
+                "make": "Ford",
+                "model": "Quadricycle",
+                "year": 1896
+            },
+            "type": "ice",
+            "mass_estimate_lbs": 500,
+            "model_input_file": "ford_quad_1896.bin",
+            "energy_rate_unit": "gallons gasoline/mile",
+            "real_world_energy_adjustment": 100.0,
+            "a_star_heuristic_energy_rate": 0.001,
+            "input_features": [
+                {
+                    "type": "speed",
+                    "name": "edge_speed",
+                    "unit": "mph"
+                }
+            ],
+            "model_type": "onnx"
+            }"#;
+        let vehicle_json: serde_json::Value =
+            serde_json::from_str(vehicle_json_as_str).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Couldn't load vehicle json because of {e}"
+                ))
+            })?;
+        let name_field = vehicle_json
+            .get("name")
+            .ok_or(TraversalModelError::BuildError(
+                "vehicle_json does not have field `name`".to_string(),
+            ))?;
+        let model_identifier: ModelIdentifier =
+            ModelIdentifier::deserialize(name_field).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Could not deserialize `name` field into ModelIdentifier because of {e}"
+                ))
+            })?;
+
+        assert_eq!(
+            model_identifier,
+            ModelIdentifier::StructuredId {
+                make: "Ford".to_string(),
+                model: "Quadricycle".to_string(),
+                year: NonZeroU64::new(1896).unwrap(),
+                variant: None,
+                version: None
+            },
+        );
+
+        Ok(())
+    }
+
+    // Tests deserializing vehicle_json["name"] into ModelIdentifier::FullyQualifiedID
+    #[test]
+    fn test_model_identifier_fully_qualified() -> Result<(), TraversalModelError> {
+        let vehicle_json_as_str = r#"{
+            "name": "1896_Ford_Quadricycle",
+            "type": "ice",
+            "mass_estimate_lbs": 500,
+            "model_input_file": "ford_quad_1896.bin",
+            "energy_rate_unit": "gallons gasoline/mile",
+            "real_world_energy_adjustment": 100.0,
+            "a_star_heuristic_energy_rate": 0.001,
+            "input_features": [
+                {
+                    "type": "speed",
+                    "name": "edge_speed",
+                    "unit": "mph"
+                }
+            ],
+            "model_type": "onnx"
+            }"#;
+        let vehicle_json: serde_json::Value =
+            serde_json::from_str(vehicle_json_as_str).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Couldn't load vehicle json because of {e}"
+                ))
+            })?;
+        let name_field = vehicle_json
+            .get("name")
+            .ok_or(TraversalModelError::BuildError(
+                "vehicle_json does not have field `name`".to_string(),
+            ))?;
+        let model_identifier: ModelIdentifier =
+            ModelIdentifier::deserialize(name_field).map_err(|e| {
+                TraversalModelError::BuildError(format!(
+                    "Could not deserialize `name` field into ModelIdentifier because of {e}"
+                ))
+            })?;
+
+        assert_eq!(
+            model_identifier,
+            ModelIdentifier::FullyQualifiedId("1896_Ford_Quadricycle".to_string())
+        );
+
+        Ok(())
+    }
+
+    // ensure that if one non-optional field is redacted, we receive an error when attempting to deserialize
+    #[test]
+    fn test_model_identifier_rejects_invalid() {
+        let bad = serde_json::json!({ "make": "Ford" }); // no model, no year
+        assert!(ModelIdentifier::deserialize(&bad).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
* Closes #529 
* Added a new `ModelIdentifier` enum and updated `EnergyModelBuilder` and `EnergyModelService` to reflect the addition of structured IDs.
* `vehicle_library` is now type `HashMap<ModelIdentifier, Arc<dyn TraversalModelService>>`
* `model_name` variable in both the builder and service has changed to `model_identifier`

## Testing: 
Unit tests for the new `ModelIdentifier` class pass and workspace tests pass (not shown in image):

<img width="1162" height="223" alt="Screenshot 2026-06-22 at 11 41 55 AM" src="https://github.com/user-attachments/assets/20a934c4-70af-4bc3-9a2b-87110787921f" />

**Testing Note**: The unit tests mocked up the vehicle_json files with strings rather than through files I/O. If you would like me to incorporate tests for reading in the files let me know.