### PR TITLE
0.19.4 workspace change breaks "default-features = false" behavior

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ quote = "1.0"
 rand = "0.10.0"
 rayon = "1.11.0"
 regex = "1.12.2"
-routee-compass = { path = "routee-compass", version = "0.19.4" }
+routee-compass = { path = "routee-compass", version = "0.19.4", default-features = false }
 routee-compass-core = { path = "routee-compass-core", version = "0.19.4" }
 routee-compass-macros = { path = "routee-compass-macros", version = "0.19.4" }
 routee-compass-powertrain = { path = "routee-compass-powertrain", version = "0.19.4" }


### PR DESCRIPTION
evidently, adding routee-compass as a workspace-level defined dependency of routee-compass-py without placing "default-features = false" at that location breaks the opt-in behavior for routee-compass-powertrain and onnx that we desire. this small fix modifies the workspace Cargo.toml to reverse that.