### PR TITLE
version patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nrel_routee_compass"
-version = "0.19.4"
+version = "0.19.5"
 description = "An eco-routing tool build upon RouteE-Powertrain"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.4"
+version = "0.19.5"
 
 [workspace.dependencies]
 allocative = "0.3.4"
@@ -50,10 +50,10 @@ quote = "1.0"
 rand = "0.10.0"
 rayon = "1.11.0"
 regex = "1.12.2"
-routee-compass = { path = "routee-compass", version = "0.19.4", default-features = false }
-routee-compass-core = { path = "routee-compass-core", version = "0.19.4" }
-routee-compass-macros = { path = "routee-compass-macros", version = "0.19.4" }
-routee-compass-powertrain = { path = "routee-compass-powertrain", version = "0.19.4" }
+routee-compass = { path = "routee-compass", version = "0.19.5", default-features = false }
+routee-compass-core = { path = "routee-compass-core", version = "0.19.5" }
+routee-compass-macros = { path = "routee-compass-macros", version = "0.19.5" }
+routee-compass-powertrain = { path = "routee-compass-powertrain", version = "0.19.5" }
 rstar = "0.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }

--- a/rust/routee-compass-core/README.md
+++ b/rust/routee-compass-core/README.md
@@ -12,7 +12,7 @@ To install as a library in Rust, add routee-compass-core to your Cargo.toml file
 
 ```toml
 [dependencies]
-routee-compass-core = { version = "0.19.4" }
+routee-compass-core = { version = "0.19.5" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass-core/latest/routee_compass_core/) for usage.

--- a/rust/routee-compass-macros/README.md
+++ b/rust/routee-compass-macros/README.md
@@ -10,7 +10,7 @@ To install as a library in Rust, add routee-compass-macros to your Cargo.toml fi
 
 ```toml
 [dependencies]
-routee-compass-macros = { version = "0.19.4" }
+routee-compass-macros = { version = "0.19.5" }
 ```
 
 This crate currently just provides a single macro for wrapping a compass application with python bindings.

--- a/rust/routee-compass-powertrain/README.md
+++ b/rust/routee-compass-powertrain/README.md
@@ -12,7 +12,7 @@ To install as a library in Rust, add routee-compass-powertrain to your Cargo.tom
 
 ```toml
 [dependencies]
-routee-compass-powertrain = { version = "0.19.4" }
+routee-compass-powertrain = { version = "0.19.5" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass-powertrain/latest/routee_compass_powertrain/) for usage.

--- a/rust/routee-compass-py/README.md
+++ b/rust/routee-compass-py/README.md
@@ -16,7 +16,7 @@ To install as a library in Rust, add routee-compass-py to your Cargo.toml file:
 
 ```toml
 [dependencies]
-routee-compass-py = { version = "0.19.4" }
+routee-compass-py = { version = "0.19.5" }
 ```
 
 ## License

--- a/rust/routee-compass/README.md
+++ b/rust/routee-compass/README.md
@@ -11,7 +11,7 @@ To install as a library in Rust, add routee-compass to your Cargo.toml file:
 
 ```toml
 [dependencies]
-routee-compass = { version = "0.19.4" }
+routee-compass = { version = "0.19.5" }
 ```
 
 Please see the [documentation](https://docs.rs/routee-compass/latest/routee_compass/) for usage.


### PR DESCRIPTION
this release fixes a regression after revising workspace exports of versions and dependencies, solving a downstream import error where routee-compass-py cannot be imported with default-features = false.