### PR TITLE
Bumps ruff requirement to >= 0.16.0 to match CI tests and fixes all ruff check errors

### DIFF
--- a/docs/examples/01_open_street_maps_example.py
+++ b/docs/examples/01_open_street_maps_example.py
@@ -14,10 +14,10 @@ conda create -n routee-compass -c conda-forge python=3.11 nrel.routee.compass
 
 
 def main():
-    import osmnx as ox
-
     import json
 
+    import osmnx as ox
+    from IPython.display import display
     from nrel.routee.compass import CompassApp
     from nrel.routee.compass.io import generate_compass_dataset, results_to_geopandas
     from nrel.routee.compass.io.generate_dataset import GeneratePipelinePhase
@@ -293,7 +293,7 @@ def main():
         line_kwargs={"color": "blue", "tooltip": "Least Cost"},
         folium_map=m,
     )
-    m
+    display(m)
 
     """
     We can also use the plot_routes_folium function and pass in multiple results. The function will color the routes based on the `value_fn` which takes a single result as an argument. For example, we can tell it to color the routes based on the total energy usage.
@@ -306,7 +306,7 @@ def main():
         ],
         color_map="plasma",
     )
-    folium_map
+    display(folium_map)
 
     """
     And the `plot_routes_folium` can also accept an existing `folium_map` parameter. Let's query our application with different origin and destination places:
@@ -329,7 +329,7 @@ def main():
         color_map="plasma",
         folium_map=folium_map,
     )
-    folium_map
+    display(folium_map)
 
 
 if __name__ == "__main__":

--- a/docs/examples/02_different_powertrains_example.py
+++ b/docs/examples/02_different_powertrains_example.py
@@ -9,7 +9,6 @@ This builds off of the [Open Street Maps Example](01_open_street_maps_example) a
 
 def main():
     import seaborn as sns
-
     from nrel.routee.compass import CompassApp
     from nrel.routee.compass.io.convert_results import results_to_geopandas
 

--- a/docs/examples/03_time_energy_tradeoff_example.py
+++ b/docs/examples/03_time_energy_tradeoff_example.py
@@ -8,10 +8,9 @@ This builds off the [Open Street Maps Example](01_open_street_maps_example) and 
 
 
 def main():
-    import seaborn as sns
-    import numpy as np
     import matplotlib.pyplot as plt
-
+    import numpy as np
+    import seaborn as sns
     from nrel.routee.compass import CompassApp
     from nrel.routee.compass.io.convert_results import results_to_geopandas
 

--- a/docs/examples/04_charging_stations_example.py
+++ b/docs/examples/04_charging_stations_example.py
@@ -12,11 +12,11 @@ so be sure to check that one out first.
 
 def main():
     import folium
+    import matplotlib.pyplot as plt
+    import pandas as pd
+    from IPython.display import display
     from nrel.routee.compass import CompassApp
     from nrel.routee.compass.plot import plot_route_folium
-
-    import pandas as pd
-    import matplotlib.pyplot as plt
 
     """
     First, we'll load the application from the pre-built configuration file 
@@ -97,7 +97,7 @@ def main():
     """
 
     m = plot_route_folium(low_soc_result)
-    m
+    display(m)
 
     """
     ## Visualizing Charging Infrastructure
@@ -128,7 +128,7 @@ def main():
             )
         )
 
-    m
+    display(m)
 
     """
     ## Analyzing State of Charge Over the Route

--- a/docs/examples/05_ambient_temperature_example.py
+++ b/docs/examples/05_ambient_temperature_example.py
@@ -11,10 +11,9 @@ so be sure to check that one out first.
 
 
 def main():
-    from nrel.routee.compass import CompassApp
-
-    import pandas as pd
     import matplotlib.pyplot as plt
+    import pandas as pd
+    from nrel.routee.compass import CompassApp
 
     """
     First, we'll load the application from the pre-built configuration file 

--- a/docs/examples/_convert_examples_to_notebooks.py
+++ b/docs/examples/_convert_examples_to_notebooks.py
@@ -40,7 +40,7 @@ def script_to_notebook(script_path: Path, notebook_path: Path) -> None:
             continue
         # dedent lines inside def main()
         if in_main and not line.strip().startswith('"""'):
-            line = line[4:] if line.startswith("    ") else line
+            line = line.removeprefix("    ")
         if line.strip().startswith('"""'):
             # handle triple-quote toggle; dedent the """ line itself if inside main
             if in_main and line.startswith("    "):

--- a/docs/running.md
+++ b/docs/running.md
@@ -18,7 +18,7 @@ query = {
     "origin_x": -105.1710052,
     "origin_y": 39.7402804,
     "destination_x": -104.9009913,
-    "destination_y": 39.6757025
+    "destination_y": 39.6757025,
 }
 
 result = app.run(query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "pytest>=8.0,<9.0",
     "maturin>=1.0,<2.0",
     "jupyter-book>=1.0,<2.0",
-    "ruff==0.15.22",
+    "ruff>=0.16.0",
     "sphinx-book-theme>=1.0.0,<2.0",
     "mypy>=1.0.0,<2.0",
     "jupyterlab>=4.0.0,<5.0",

--- a/python/nrel/routee/compass/__init__.py
+++ b/python/nrel/routee/compass/__init__.py
@@ -1,10 +1,11 @@
-from nrel.routee.compass.compass_app import CompassApp
-from nrel.routee.compass.io.generate_dataset import generate_compass_dataset
-from nrel.routee.compass.io.generate_dataset import list_available_vehicle_models
-
+import logging
 from pathlib import Path
 
-import logging
+from nrel.routee.compass.compass_app import CompassApp
+from nrel.routee.compass.io.generate_dataset import (
+    generate_compass_dataset,
+    list_available_vehicle_models,
+)
 
 
 def package_root() -> Path:

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -186,9 +186,9 @@ class CompassApp:
         Returns:
             CompassApp: a CompassApp object
         """
-        if phases is None: 
+        if phases is None:
             phases = GeneratePipelinePhase.default()
-            
+
         if cache_dir is None:
             temp_dir = TemporaryDirectory()
             cache_dir = Path(temp_dir.name)
@@ -388,9 +388,7 @@ class CompassApp:
             queries = query
             single_query = False
         else:
-            raise TypeError(
-                f"Query must be a dict or list of dicts, not {type(query)}"
-            )
+            raise TypeError(f"Query must be a dict or list of dicts, not {type(query)}")
 
         queries_str = list(map(json.dumps, queries))
         config_str = json.dumps(config) if config is not None else None
@@ -496,9 +494,7 @@ class CompassApp:
             queries = query
             single_query = False
         else:
-            raise TypeError(
-                f"Query must be a dict or list of dicts, not {type(query)}"
-            )
+            raise TypeError(f"Query must be a dict or list of dicts, not {type(query)}")
 
         queries_str = list(map(json.dumps, queries))
         results_json: list[str] = self._app._map_match(queries_str)
@@ -538,9 +534,7 @@ class CompassApp:
             queries = query
             single_query = False
         else:
-            raise TypeError(
-                f"Query must be a dict or list of dicts, not {type(query)}"
-            )
+            raise TypeError(f"Query must be a dict or list of dicts, not {type(query)}")
 
         queries_str = list(map(json.dumps, queries))
         config_str = json.dumps(config) if config is not None else None

--- a/python/nrel/routee/compass/compass_app.py
+++ b/python/nrel/routee/compass/compass_app.py
@@ -1,33 +1,34 @@
 from __future__ import annotations
 
 import logging
-from tempfile import TemporaryDirectory
-
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, List, Optional, Union, Callable, TYPE_CHECKING, cast
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any, cast
+
+from nrel.routee.compass.io.generate_dataset import (
+    DatasetHook,
+    GeneratePipelinePhase,
+    generate_compass_dataset,
+)
 from nrel.routee.compass.routee_compass_py import (
     CompassAppWrapper,
 )
-from nrel.routee.compass.io.generate_dataset import (
-    GeneratePipelinePhase,
-    generate_compass_dataset,
-    DatasetHook,
-)
 
 if TYPE_CHECKING:
-    from shapely.geometry import Polygon, MultiPolygon
+    import networkx as nx
     from nrel.routee.compass.utils.type_alias import (
+        CompassQuery,
         Config,
         OSMNXQuery,
-        CompassQuery,
         Result,
         Results,
     )
-    import networkx as nx
+    from shapely.geometry import MultiPolygon, Polygon
 
-import tomlkit
 import json
 
+import tomlkit
 
 log = logging.getLogger(__name__)
 
@@ -56,8 +57,8 @@ class CompassApp:
     @classmethod
     def from_config_file(
         cls,
-        config_file: Union[str, Path],
-        parallelism: Optional[int] = None,
+        config_file: str | Path,
+        parallelism: int | None = None,
     ) -> CompassApp:
         """
         Build a CompassApp from a config file
@@ -76,14 +77,14 @@ class CompassApp:
         """
         config_path = Path(config_file)
         if not config_path.is_file():
-            raise ValueError(f"Config file {str(config_path)} does not exist")
+            raise ValueError(f"Config file {config_path!s} does not exist")
         with open(config_path) as f:
             toml_config = tomlkit.load(f)
 
         return cls.from_dict(toml_config, config_path, parallelism=parallelism)
 
     @classmethod
-    def _get_default_config_file(cls, phases: List[GeneratePipelinePhase]) -> str:
+    def _get_default_config_file(cls, phases: list[GeneratePipelinePhase]) -> str:
         """
         Internal helper to get the default config file name based on the phases.
         """
@@ -96,8 +97,8 @@ class CompassApp:
     def from_dict(
         cls,
         config: tomlkit.TOMLDocument,
-        working_dir: Optional[Path] = None,
-        parallelism: Optional[int] = None,
+        working_dir: Path | None = None,
+        parallelism: int | None = None,
     ) -> CompassApp:
         """
         Build a CompassApp from a configuration object
@@ -127,17 +128,17 @@ class CompassApp:
     def from_graph(
         cls,
         graph: nx.MultiDiGraph,
-        config_file: Optional[str] = None,
-        cache_dir: Optional[Union[str, Path]] = None,
-        hwy_speeds: Optional[dict[str, Any]] = None,
-        fallback: Optional[float] = None,
-        agg: Optional[Callable[[Any], Any]] = None,
-        phases: List[GeneratePipelinePhase] = GeneratePipelinePhase.default(),
-        raster_resolution_arc_seconds: Union[str, int] = 1,
-        vehicle_models: Optional[List[str]] = None,
-        parallelism: Optional[int] = None,
+        config_file: str | None = None,
+        cache_dir: str | Path | None = None,
+        hwy_speeds: dict[str, Any] | None = None,
+        fallback: float | None = None,
+        agg: Callable[[Any], Any] | None = None,
+        phases: list[GeneratePipelinePhase] | None = None,
+        raster_resolution_arc_seconds: str | int = 1,
+        vehicle_models: list[str] | None = None,
+        parallelism: int | None = None,
         overwrite: bool = False,
-        hooks: Optional[List[DatasetHook]] = None,
+        hooks: list[DatasetHook] | None = None,
     ) -> CompassApp:
         """
         Build a CompassApp from a networkx graph.
@@ -185,6 +186,9 @@ class CompassApp:
         Returns:
             CompassApp: a CompassApp object
         """
+        if phases is None: 
+            phases = GeneratePipelinePhase.default()
+            
         if cache_dir is None:
             temp_dir = TemporaryDirectory()
             cache_dir = Path(temp_dir.name)
@@ -225,8 +229,8 @@ class CompassApp:
         cls,
         query: OSMNXQuery,
         network_type: str = "drive",
-        parallelism: Optional[int] = None,
-        cache_dir: Optional[Union[str, Path]] = None,
+        parallelism: int | None = None,
+        cache_dir: str | Path | None = None,
         overwrite: bool = False,
         **kwargs: Any,
     ) -> CompassApp:
@@ -283,10 +287,10 @@ class CompassApp:
     @classmethod
     def from_polygon(
         cls,
-        polygon: Union["Polygon" | "MultiPolygon"],
+        polygon: Polygon | MultiPolygon,
         network_type: str = "drive",
-        parallelism: Optional[int] = None,
-        cache_dir: Optional[Union[str, Path]] = None,
+        parallelism: int | None = None,
+        cache_dir: str | Path | None = None,
         overwrite: bool = False,
         **kwargs: Any,
     ) -> CompassApp:
@@ -349,9 +353,9 @@ class CompassApp:
 
     def run(
         self,
-        query: Union[CompassQuery, List[CompassQuery]],
-        config: Optional[Config] = None,
-    ) -> Union[Result, Results]:
+        query: CompassQuery | list[CompassQuery],
+        config: Config | None = None,
+    ) -> Result | Results:
         """
         Run a query (or multiple queries) against the CompassApp
 
@@ -384,14 +388,14 @@ class CompassApp:
             queries = query
             single_query = False
         else:
-            raise ValueError(
+            raise TypeError(
                 f"Query must be a dict or list of dicts, not {type(query)}"
             )
 
         queries_str = list(map(json.dumps, queries))
         config_str = json.dumps(config) if config is not None else None
 
-        results_json: List[str] = self._app._run_queries(queries_str, config_str)
+        results_json: list[str] = self._app._run_queries(queries_str, config_str)
 
         results: Results = list(map(json.loads, results_json))
         if single_query and len(results) == 1:
@@ -423,7 +427,7 @@ class CompassApp:
         return cast(int, self._app.graph_edge_destination(edge_id))
 
     def graph_edge_distance(
-        self, edge_id: int, distance_unit: Optional[str] = None
+        self, edge_id: int, distance_unit: str | None = None
     ) -> float:
         """
         get the distance for some edge
@@ -437,7 +441,7 @@ class CompassApp:
         """
         return cast(float, self._app.graph_edge_distance(edge_id, distance_unit))
 
-    def graph_get_out_edge_ids(self, vertex_id: int) -> List[int]:
+    def graph_get_out_edge_ids(self, vertex_id: int) -> list[int]:
         """
         get the list of edge ids that depart from some vertex
 
@@ -447,9 +451,9 @@ class CompassApp:
         Returns:
             edges: the edge ids of edges departing from this vertex
         """
-        return cast(List[int], self._app.graph_get_out_edge_ids(vertex_id))
+        return cast(list[int], self._app.graph_get_out_edge_ids(vertex_id))
 
-    def graph_get_in_edge_ids(self, vertex_id: int) -> List[int]:
+    def graph_get_in_edge_ids(self, vertex_id: int) -> list[int]:
         """
         get the list of edge ids that arrive from some vertex
 
@@ -459,12 +463,12 @@ class CompassApp:
         Returns:
             edges: the edge ids of edges arriving at this vertex
         """
-        return cast(List[int], self._app.graph_get_in_edge_ids(vertex_id))
+        return cast(list[int], self._app.graph_get_in_edge_ids(vertex_id))
 
     def map_match(
         self,
-        query: Union[CompassQuery, List[CompassQuery]],
-    ) -> Union[Result, Results]:
+        query: CompassQuery | list[CompassQuery],
+    ) -> Result | Results:
         """
         Run a map matching query (or multiple queries) against the CompassApp
 
@@ -492,12 +496,12 @@ class CompassApp:
             queries = query
             single_query = False
         else:
-            raise ValueError(
+            raise TypeError(
                 f"Query must be a dict or list of dicts, not {type(query)}"
             )
 
         queries_str = list(map(json.dumps, queries))
-        results_json: List[str] = self._app._map_match(queries_str)
+        results_json: list[str] = self._app._map_match(queries_str)
 
         results: Results = list(map(json.loads, results_json))
         if single_query and len(results) == 1:
@@ -506,9 +510,9 @@ class CompassApp:
 
     def run_calculate_path(
         self,
-        query: Union[CompassQuery, List[CompassQuery]],
-        config: Optional[Config] = None,
-    ) -> Union[Result, Results]:
+        query: CompassQuery | list[CompassQuery],
+        config: Config | None = None,
+    ) -> Result | Results:
         """
         Run a path evaluation query (or multiple queries) against the CompassApp
 
@@ -534,14 +538,14 @@ class CompassApp:
             queries = query
             single_query = False
         else:
-            raise ValueError(
+            raise TypeError(
                 f"Query must be a dict or list of dicts, not {type(query)}"
             )
 
         queries_str = list(map(json.dumps, queries))
         config_str = json.dumps(config) if config is not None else None
 
-        results_json: List[str] = self._app._run_calculate_path(queries_str, config_str)
+        results_json: list[str] = self._app._run_calculate_path(queries_str, config_str)
 
         results: Results = list(map(json.loads, results_json))
         if single_query and len(results) == 1:

--- a/python/nrel/routee/compass/io/__init__.py
+++ b/python/nrel/routee/compass/io/__init__.py
@@ -1,6 +1,5 @@
-from .generate_dataset import generate_compass_dataset
-from .generate_dataset import list_available_vehicle_models
 from .convert_results import results_to_geopandas
+from .generate_dataset import generate_compass_dataset, list_available_vehicle_models
 
 __all__ = (
     "generate_compass_dataset",

--- a/python/nrel/routee/compass/io/charging_station_ops.py
+++ b/python/nrel/routee/compass/io/charging_station_ops.py
@@ -1,13 +1,13 @@
 import importlib.resources
-import requests
-import re
-from typing import List, Union, TYPE_CHECKING
-
 import logging
+import re
+from typing import TYPE_CHECKING, Union
+
+import requests
 
 if TYPE_CHECKING:
-    from pandas import DataFrame
     from geopandas import GeoDataFrame
+    from pandas import DataFrame
     from shapely.geometry import Polygon
 
 log = logging.getLogger(__name__)
@@ -43,10 +43,10 @@ def download_ev_charging_stations(state: str, api_key: str = "DEMO_KEY") -> "Dat
         response.raise_for_status()
         result = response.json()
     except requests.RequestException as e:
-        raise Exception(f"Failed to download charging station data: {e}")
+        raise RuntimeError(f"Failed to download charging station data: {e}")
 
     if "fuel_stations" not in result:
-        raise Exception("Invalid response format from NREL API")
+        raise RuntimeError("Invalid response format from NREL API")
 
     # Create dataframe
     df = pd.DataFrame(result["fuel_stations"])
@@ -199,7 +199,7 @@ def _parse_cost_per_kwh(pricing_str: str) -> float:
 
 
 def states_intersecting_with_polygon(
-    polygon: Union["Polygon", List["Polygon"]], states_gdf: "GeoDataFrame"
+    polygon: Union["Polygon", list["Polygon"]], states_gdf: "GeoDataFrame"
 ) -> "GeoDataFrame":
     """
     Find states that intersect with a given polygon.
@@ -277,8 +277,8 @@ def load_us_state_boundaries() -> "GeoDataFrame":
         GeoDataFrame containing state boundaries with STUSPS (state code) column
     """
     try:
-        import pandas as pd
         import geopandas as gpd
+        import pandas as pd
     except ImportError as _:
         raise ImportError(
             "Required libraries not installed. Please install pandas and geopandas."
@@ -317,8 +317,8 @@ def download_ev_charging_stations_for_polygon(
         Combined DataFrame with charging stations from all intersecting states
     """
     try:
-        import pandas as pd
         import geopandas as gpd
+        import pandas as pd
     except ImportError as _:
         raise ImportError(
             "Required libraries not installed. Please install pandas and geopandas."
@@ -340,7 +340,7 @@ def download_ev_charging_stations_for_polygon(
                 # Add state column for reference
                 state_stations["state"] = state
                 all_stations.append(state_stations)
-        except Exception as e:
+        except RuntimeError as e:
             log.warning(f"Warning: Failed to download stations for state {state}: {e}")
             continue
 

--- a/python/nrel/routee/compass/io/convert_results.py
+++ b/python/nrel/routee/compass/io/convert_results.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 from nrel.routee.compass.utils.geometry import geometry_from_route
 from nrel.routee.compass.utils.type_alias import Result, Results
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 def tree_result_to_geopandas(
     result: Result,
 ) -> Optional["GeoDataFrame"]:
-    """ """
+    """convert the tree result to geopandas"""
     try:
         import geopandas as gpd
     except ImportError:
@@ -34,7 +34,7 @@ def tree_result_to_geopandas(
 def route_result_to_geopandas(
     result: Result,
 ) -> Optional["GeoDataFrame"]:
-    """ """
+    """convert the route result to geopandas"""
     try:
         import geopandas as gpd
         import pandas as pd
@@ -70,9 +70,9 @@ def route_result_to_geopandas(
 
 
 def results_to_geopandas(
-    results: Union[Result, Results],
-) -> Union["GeoDataFrame", Tuple["GeoDataFrame", "GeoDataFrame"]]:
-    """ """
+    results: Result | Results,
+) -> Union["GeoDataFrame", tuple["GeoDataFrame", "GeoDataFrame"]]:
+    """convert the results to a geo dataframe"""
     try:
         import pandas as pd
     except ImportError:

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -293,9 +293,12 @@ def generate_compass_dataset(
         if GeneratePipelinePhase.CHARGING_STATIONS in phases:
             base_config_files.append("osm_default_charging.toml")
         for filename in base_config_files:
-            with importlib.resources.path(
-                "nrel.routee.compass.resources", filename
-            ) as init_toml_path, init_toml_path.open() as f:
+            with (
+                importlib.resources.path(
+                    "nrel.routee.compass.resources", filename
+                ) as init_toml_path,
+                init_toml_path.open() as f,
+            ):
                 init_toml: dict[str, Any] = tomlkit.load(f)
 
             # When a vehicle subset is requested, rewrite the

--- a/python/nrel/routee/compass/io/generate_dataset.py
+++ b/python/nrel/routee/compass/io/generate_dataset.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
-import enum
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
-from pathlib import Path
 
+import enum
 import importlib.resources
 import json
 import logging
 import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
 import tomlkit
-
-
 from nrel.routee.compass.io import utils
-from nrel.routee.compass.io.utils import CACHE_DIR, add_grade_to_graph
 from nrel.routee.compass.io.charging_station_ops import (
     download_ev_charging_stations_for_polygon,
 )
+from nrel.routee.compass.io.utils import CACHE_DIR, add_grade_to_graph
 
 if TYPE_CHECKING:
+    import geopandas
     import networkx
     import pandas as pd
-    import geopandas
 
 log = logging.getLogger(__name__)
 
@@ -68,11 +68,11 @@ class GeneratePipelinePhase(enum.Enum):
     CHARGING_STATIONS = 4
 
     @classmethod
-    def default(cls) -> List[GeneratePipelinePhase]:
+    def default(cls) -> list[GeneratePipelinePhase]:
         return [cls.GRAPH, cls.CONFIG, cls.POWERTRAIN]
 
 
-def list_available_vehicle_models() -> List[str]:
+def list_available_vehicle_models() -> list[str]:
     """
     Return the list of all available vehicle model names that can be used
     with the ``vehicle_models`` parameter of :func:`generate_compass_dataset`
@@ -97,18 +97,18 @@ def list_available_vehicle_models() -> List[str]:
 
 def generate_compass_dataset(
     g: networkx.MultiDiGraph,
-    output_directory: Union[str, Path],
-    hwy_speeds: Optional[HIGHWAY_SPEED_MAP] = None,
-    fallback: Optional[float] = None,
-    agg: Optional[AggFunc] = None,
-    phases: List[GeneratePipelinePhase] = GeneratePipelinePhase.default(),
-    raster_resolution_arc_seconds: Union[str, int] = 1,
+    output_directory: str | Path,
+    hwy_speeds: HIGHWAY_SPEED_MAP | None = None,
+    fallback: float | None = None,
+    agg: AggFunc | None = None,
+    phases: list[GeneratePipelinePhase] | None = None,
+    raster_resolution_arc_seconds: str | int = 1,
     default_config: bool = True,
-    requests_kwds: Optional[Dict[Any, Any]] = None,
+    requests_kwds: dict[Any, Any] | None = None,
     afdc_api_key: str = "DEMO_KEY",
     require_charging_stations: bool = True,
-    vehicle_models: Optional[List[str]] = None,
-    hooks: Optional[List[DatasetHook]] = None,
+    vehicle_models: list[str] | None = None,
+    hooks: list[DatasetHook] | None = None,
 ) -> None:
     """
     Processes a graph downloaded via OSMNx, generating the set of input
@@ -154,15 +154,18 @@ def generate_compass_dataset(
     except ImportError:
         raise ImportError("requires osmnx to be installed. Try 'pip install osmnx'")
     try:
+        import geopandas as gpd
         import numpy as np
         import pandas as pd
-        import geopandas as gpd
-        from shapely.geometry import box
         import requests
+        from shapely.geometry import box
     except ImportError as err:
         raise ImportError(
             f"please install compass with the 'osm' feature enabled. {err}"
         )
+
+    if phases is None:
+        phases = GeneratePipelinePhase.default()
 
     log.info(f"running pipeline import with phases: [{[p.name for p in phases]}]")
     output_directory = Path(output_directory)
@@ -292,9 +295,8 @@ def generate_compass_dataset(
         for filename in base_config_files:
             with importlib.resources.path(
                 "nrel.routee.compass.resources", filename
-            ) as init_toml_path:
-                with init_toml_path.open() as f:
-                    init_toml: dict[str, Any] = tomlkit.load(f)
+            ) as init_toml_path, init_toml_path.open() as f:
+                init_toml: dict[str, Any] = tomlkit.load(f)
 
             # When a vehicle subset is requested, rewrite the
             # vehicle_input_files list in the energy traversal model
@@ -335,7 +337,7 @@ def generate_compass_dataset(
 
                 cached_model_destination = CACHE_DIR / f"{model_name}.bin"
                 if not cached_model_destination.exists():
-                    kwds: Dict[Any, Any] = (
+                    kwds: dict[Any, Any] = (
                         requests_kwds if requests_kwds is not None else {}
                     )
                     download_response = requests.get(model_link, **kwds)
@@ -421,7 +423,7 @@ def generate_compass_dataset(
             hook(params)
 
 
-def _resolve_required_model_bins(vehicle_models: List[str]) -> set[str]:
+def _resolve_required_model_bins(vehicle_models: list[str]) -> set[str]:
     """
     Given a list of vehicle model names (JSON file stems), determine the set
     of ``.bin`` model names that need to be downloaded.
@@ -462,7 +464,7 @@ def _resolve_required_model_bins(vehicle_models: List[str]) -> set[str]:
 
 
 def _filter_vehicle_input_files(
-    toml_config: dict[str, Any], vehicle_models: List[str]
+    toml_config: dict[str, Any], vehicle_models: list[str]
 ) -> None:
     """
     Walk through a parsed TOML config and rewrite any

--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -182,9 +182,7 @@ def add_grade_to_graph(
                 "If this road network is outside of the US, consider re-running without `grade` in your ."
             )
         elif len(files) == 1:
-            filepath: Path | list[Path] = files[
-                0
-            ]  # if only one file, pass it directly
+            filepath: Path | list[Path] = files[0]  # if only one file, pass it directly
         else:
             filepath = files
 

--- a/python/nrel/routee/compass/io/utils.py
+++ b/python/nrel/routee/compass/io/utils.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import logging
+import math
 from enum import Enum
 from pathlib import Path
-
-import logging
-from typing import Union, Optional, TYPE_CHECKING
-import math
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import networkx
@@ -90,7 +89,7 @@ def _download_tile(
     filename = url.split("/")[-1]
     destination = output_dir / filename
     if destination.is_file():
-        log.info(f"{str(destination)} already exists, skipping")
+        log.info(f"{destination!s} already exists, skipping")
         return destination
 
     with requests.get(url, stream=True) as r:
@@ -117,8 +116,8 @@ def _download_tile(
 def add_grade_to_graph(
     g: networkx.MultiDiGraph,
     output_dir: Path = Path("cache"),
-    resolution_arc_seconds: Union[str, int] = 1,
-    api_key: Optional[str] = None,
+    resolution_arc_seconds: str | int = 1,
+    api_key: str | None = None,
 ) -> networkx.MultiDiGraph:
     """
     Adds grade information to the edges of a graph.
@@ -183,7 +182,7 @@ def add_grade_to_graph(
                 "If this road network is outside of the US, consider re-running without `grade` in your ."
             )
         elif len(files) == 1:
-            filepath: Union[Path, list[Path]] = files[
+            filepath: Path | list[Path] = files[
                 0
             ]  # if only one file, pass it directly
         else:

--- a/python/nrel/routee/compass/map_matching/utils.py
+++ b/python/nrel/routee/compass/map_matching/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from geopandas import GeoDataFrame
@@ -11,12 +11,12 @@ from nrel.routee.compass.utils.type_alias import CompassQuery, Result, Results
 
 
 def load_trace(
-    file: Union[str, pathlib.Path],
+    file: str | pathlib.Path,
     x_col: str = "longitude",
     y_col: str = "latitude",
-    search_parameters: Optional[Dict[str, Any]] = None,
-    output_format: Optional[str] = None,
-    summary_ops: Optional[Dict[str, Any]] = None,
+    search_parameters: dict[str, Any] | None = None,
+    output_format: str | None = None,
+    summary_ops: dict[str, Any] | None = None,
 ) -> CompassQuery:
     """
     Load a trace from a file and convert it into a map matching query.
@@ -56,12 +56,12 @@ def load_trace(
 
 
 def load_trace_csv(
-    file: Union[str, pathlib.Path],
+    file: str | pathlib.Path,
     x_col: str = "longitude",
     y_col: str = "latitude",
-    search_parameters: Optional[Dict[str, Any]] = None,
-    output_format: Optional[str] = None,
-    summary_ops: Optional[Dict[str, Any]] = None,
+    search_parameters: dict[str, Any] | None = None,
+    output_format: str | None = None,
+    summary_ops: dict[str, Any] | None = None,
 ) -> CompassQuery:
     """
     Load a trace from a CSV file and convert it into a map matching query.
@@ -87,7 +87,7 @@ def load_trace_csv(
     df = pd.read_csv(file)
     trace = []
     for _, row in df.iterrows():
-        point: Dict[str, Any] = {"x": float(row[x_col]), "y": float(row[y_col])}
+        point: dict[str, Any] = {"x": float(row[x_col]), "y": float(row[y_col])}
         trace.append(point)
 
     query: CompassQuery = {"trace": trace}
@@ -102,10 +102,10 @@ def load_trace_csv(
 
 
 def load_trace_gpx(
-    file: Union[str, pathlib.Path],
-    search_parameters: Optional[Dict[str, Any]] = None,
-    output_format: Optional[str] = None,
-    summary_ops: Optional[Dict[str, Any]] = None,
+    file: str | pathlib.Path,
+    search_parameters: dict[str, Any] | None = None,
+    output_format: str | None = None,
+    summary_ops: dict[str, Any] | None = None,
 ) -> CompassQuery:
     """
     Load a trace from a GPX file and convert it into a map matching query.
@@ -130,7 +130,7 @@ def load_trace_gpx(
     for trkpt in root.findall(".//gpx:trkpt", namespace):
         lat = float(trkpt.attrib["lat"])
         lon = float(trkpt.attrib["lon"])
-        point: Dict[str, Any] = {"x": lon, "y": lat}
+        point: dict[str, Any] = {"x": lon, "y": lat}
         trace.append(point)
 
     if not trace:
@@ -153,8 +153,8 @@ def load_trace_gpx(
 
 
 def match_result_to_geopandas(
-    results: Union[Result, Results],
-) -> "GeoDataFrame":
+    results: Result | Results,
+) -> GeoDataFrame:
     """
     Convert map matching results into a GeoPandas GeoDataFrame.
     Uses the 'matched_path' field of the result.

--- a/python/nrel/routee/compass/plot/plot_folium.py
+++ b/python/nrel/routee/compass/plot/plot_folium.py
@@ -1,9 +1,8 @@
+from collections.abc import Callable, Sequence
+from typing import Any
+
 import folium
-
-
-from typing import Any, Callable, Optional, Sequence, Tuple, Union
 from nrel.routee.compass.plot.plot_utils import ColormapCircularIterator, rgba_to_hex
-
 from nrel.routee.compass.utils.geometry import ROUTE_KEY, geometry_from_route
 
 MATCHED_PATH_KEY = "matched_path"
@@ -18,7 +17,7 @@ DEFAULT_LINE_KWARGS = {
 
 def result_dict_to_coords(
     result_dict: dict[str, Any],
-) -> Sequence[Tuple[float, float]]:
+) -> Sequence[tuple[float, float]]:
     """
     Converts the CompassApp results to coords to be sent to the folium map.
 
@@ -45,7 +44,7 @@ def result_dict_to_coords(
         )
 
     if not isinstance(result_dict, dict):
-        raise ValueError(f"Expected to get a dictionary but got a {type(result_dict)}")
+        raise TypeError(f"Expected to get a dictionary but got a {type(result_dict)}")
 
     route = result_dict.get(ROUTE_KEY)
     if route is None:
@@ -66,7 +65,7 @@ def result_dict_to_coords(
 
 
 def _calculate_folium_args(
-    fit_coords: Sequence[Tuple[float, float]],
+    fit_coords: Sequence[tuple[float, float]],
 ) -> dict[str, Any]:
     """
     Calculates where the center of the map and the bounds that the map
@@ -100,7 +99,7 @@ def _calculate_folium_args(
 
 
 def _create_empty_folium_map(
-    fit_coords: Sequence[Tuple[float, float]],
+    fit_coords: Sequence[tuple[float, float]],
 ) -> folium.Map:
     """
     Creates an empty folium.Map calculating the center and the fit_bounds
@@ -136,8 +135,8 @@ def _create_empty_folium_map(
 
 def plot_route_folium(
     result_dict: dict[str, Any],
-    line_kwargs: Optional[dict[str, Any]] = None,
-    folium_map: Optional[folium.Map] = None,
+    line_kwargs: dict[str, Any] | None = None,
+    folium_map: folium.Map | None = None,
 ) -> folium.Map:
     """
     Plots a single route from a compass query on a folium map.
@@ -165,9 +164,9 @@ def plot_route_folium(
 
 
 def plot_coords_folium(
-    coords: Sequence[Tuple[float, float]],
-    line_kwargs: Optional[dict[str, Any]] = None,
-    folium_map: Optional[folium.Map] = None,
+    coords: Sequence[tuple[float, float]],
+    line_kwargs: dict[str, Any] | None = None,
+    folium_map: folium.Map | None = None,
 ) -> folium.Map:
     """
     Plots a sequence of pairs of latitude and longitude on a folium map as a route.
@@ -225,10 +224,10 @@ def plot_coords_folium(
 
 
 def plot_routes_folium(
-    results: Union[dict[str, Any], list[dict[str, Any]]],
+    results: dict[str, Any] | list[dict[str, Any]],
     value_fn: Callable[[dict[str, Any]], Any] = lambda r: r["request"].get("name"),
     color_map: str = "viridis",
-    folium_map: Optional[folium.Map] = None,
+    folium_map: folium.Map | None = None,
 ) -> folium.Map:
     """
     Plot multiple routes from a CompassApp query on a folium map
@@ -255,8 +254,8 @@ def plot_routes_folium(
 
     """
     try:
-        import matplotlib.pyplot as plt
         import matplotlib.colors as mcolors
+        import matplotlib.pyplot as plt
     except ImportError:
         raise ImportError(
             "You need to install the matplotlib package to use this function"
@@ -272,7 +271,7 @@ def plot_routes_folium(
     values = [value_fn(result) for result in results]
 
     cmap = plt.get_cmap(color_map)
-    if all(isinstance(v, float) or isinstance(v, int) for v in values):
+    if all(isinstance(v, (float, int)) for v in values):
         norm = mcolors.Normalize(vmin=min(values), vmax=max(values))
         colors = [rgba_to_hex(cmap(norm(v))) for v in values]
     else:
@@ -294,7 +293,7 @@ def plot_routes_folium(
 
 def matched_path_to_coords(
     matched_path: dict[str, Any],
-) -> Sequence[Tuple[float, float]]:
+) -> Sequence[tuple[float, float]]:
     """
     Converts the matched path from a map matching query to coords to be sent to the folium map.
 
@@ -324,8 +323,8 @@ def matched_path_to_coords(
 
 def plot_matched_path_folium(
     result_dict: dict[str, Any],
-    line_kwargs: Optional[dict[str, Any]] = None,
-    folium_map: Optional[folium.Map] = None,
+    line_kwargs: dict[str, Any] | None = None,
+    folium_map: folium.Map | None = None,
 ) -> folium.Map:
     """
     Plots the matched path from a map matching query on a folium map.

--- a/python/nrel/routee/compass/plot/plot_utils.py
+++ b/python/nrel/routee/compass/plot/plot_utils.py
@@ -12,7 +12,7 @@ class ColormapCircularIterator:
         self.num_colors = num_colors
         self.index = 0
 
-    def __iter__(self) -> "ColormapCircularIterator":
+    def __iter__(self) -> ColormapCircularIterator:
         return self
 
     def __next__(self) -> str:
@@ -29,6 +29,4 @@ RGBA_TUPLE = tuple[float, float, float, float]
 
 
 def rgba_to_hex(rgba: RGBA_TUPLE) -> str:
-    return "#{:02x}{:02x}{:02x}".format(
-        int(rgba[0] * 255), int(rgba[1] * 255), int(rgba[2] * 255)
-    )
+    return f"#{int(rgba[0] * 255):02x}{int(rgba[1] * 255):02x}{int(rgba[2] * 255):02x}"

--- a/python/nrel/routee/compass/utils/geometry.py
+++ b/python/nrel/routee/compass/utils/geometry.py
@@ -1,6 +1,5 @@
-from typing import TYPE_CHECKING
-
 import json
+from typing import TYPE_CHECKING
 
 from nrel.routee.compass.utils.type_alias import Route
 

--- a/python/nrel/routee/compass/utils/type_alias.py
+++ b/python/nrel/routee/compass/utils/type_alias.py
@@ -1,8 +1,7 @@
-from typing import Any, Union
-
+from typing import Any
 
 Config = dict[str, Any]
-OSMNXQuery = Union[str, dict[str, str], list[Union[str, dict[str, str]]]]
+OSMNXQuery = str | dict[str, str] | list[str | dict[str, str]]
 CompassQuery = dict[str, Any]
 Result = dict[str, Any]
 Results = list[Result]

--- a/python/tests/test_charging_station_io.py
+++ b/python/tests/test_charging_station_io.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from nrel.routee.compass.io.charging_station_ops import _parse_cost_per_kwh
 
 

--- a/python/tests/test_downtown_denver_example.py
+++ b/python/tests/test_downtown_denver_example.py
@@ -1,6 +1,7 @@
 import json
-from unittest import TestCase
 from typing import Any
+from unittest import TestCase
+
 from nrel.routee.compass import package_root
 from nrel.routee.compass.compass_app import CompassApp
 
@@ -97,7 +98,7 @@ class TestDowntownDenverExample(TestCase):
 
             error = result.get("error")
             if error is not None:
-                raise Exception(
+                raise RuntimeError(
                     f"Error running query with p={p}: {error}\nresponse: {json.dumps(result, indent=2)}"
                 )
             weight_results.append(
@@ -270,7 +271,7 @@ class TestDowntownDenverExample(TestCase):
 
             error = result.get("error")
             if error is not None:
-                raise Exception(
+                raise RuntimeError(
                     f"Error running query with p={p}: {error}\nresponse: {json.dumps(result, indent=2)}"
                 )
             weight_results.append(

--- a/python/tests/test_from_graph.py
+++ b/python/tests/test_from_graph.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
-from nrel.routee.compass.compass_app import CompassApp
+
 import osmnx as ox
+from nrel.routee.compass.compass_app import CompassApp
 
 
 class TestFromGraph(TestCase):

--- a/python/tests/test_map_match.py
+++ b/python/tests/test_map_match.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from nrel.routee.compass import package_root
 from nrel.routee.compass.compass_app import CompassApp
 

--- a/python/tests/test_map_matching_utils.py
+++ b/python/tests/test_map_matching_utils.py
@@ -1,11 +1,12 @@
-from unittest import TestCase
-from typing import Any
-import tempfile
 import pathlib
+import tempfile
+from typing import Any
+from unittest import TestCase
+
 from nrel.routee.compass.map_matching.utils import (
+    load_trace,
     load_trace_csv,
     load_trace_gpx,
-    load_trace,
     match_result_to_geopandas,
 )
 

--- a/python/tests/test_plot_map_match.py
+++ b/python/tests/test_plot_map_match.py
@@ -1,8 +1,9 @@
+import unittest
+from typing import Any
+
 from nrel.routee.compass import package_root
 from nrel.routee.compass.compass_app import CompassApp
 from nrel.routee.compass.plot.plot_folium import plot_matched_path_folium
-import unittest
-from typing import Any
 
 
 class TestMapMatchPlot(unittest.TestCase):

--- a/rust/routee-compass/src/app/compass/test/map_matching_test/generate_grid.py
+++ b/rust/routee-compass/src/app/compass/test/map_matching_test/generate_grid.py
@@ -102,7 +102,6 @@ with open(edges_file, "w", newline="") as f:
 
 # Write Geometries
 with open(geoms_file, "w") as f:
-    for g in geoms:
-        f.write(g + "\n")
+    f.writelines(g + "\n" for g in geoms)
 
 print(f"Generated {len(nodes)} nodes and {len(edges)} edges.")

--- a/scripts/build_model_download_links.py
+++ b/scripts/build_model_download_links.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from boxsdk.auth.oauth2 import OAuth2
 from boxsdk.client.client import Client
 
-
 log = logging.getLogger()
 log.setLevel(logging.INFO)
 


### PR DESCRIPTION
Fixes #559.

@robfitzgerald @nreinicke I wanted to mention that there were some generic `Exception` types that ruff was mad about in some of the examples and in the pipeline, so I changed them to `RuntimeError`, but might be worth a sanity check. I marked all the ones I thought you may want to take a look at in the conversation below.